### PR TITLE
tsdb: fix default block reload interval for custom options

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -792,9 +792,11 @@ func main() {
 		}
 		cfg.tsdb.MaxExemplars = cfgFile.StorageConfig.ExemplarsConfig.MaxExemplars
 	}
-	if cfg.tsdb.BlockReloadInterval < model.Duration(1*time.Second) {
-		logger.Warn("The option --storage.tsdb.block-reload-interval is set to a value less than 1s. Setting it to 1s to avoid overload.")
-		cfg.tsdb.BlockReloadInterval = model.Duration(1 * time.Second)
+	minBlockReloadInterval := model.Duration(tsdb.MinBlockReloadInterval)
+	if cfg.tsdb.BlockReloadInterval < minBlockReloadInterval {
+		minBlockReloadIntervalString := minBlockReloadInterval.String()
+		logger.Warn("The option --storage.tsdb.block-reload-interval is set to a value less than " + minBlockReloadIntervalString + ". Setting it to " + minBlockReloadIntervalString + " to avoid overload.")
+		cfg.tsdb.BlockReloadInterval = minBlockReloadInterval
 	}
 	// The configuration file takes precedence over the flag-derived default. An
 	// absent field keeps that default; other values are rejected when the

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -58,8 +58,10 @@ const (
 	// DefaultCompactionDelayMaxPercent in percentage.
 	DefaultCompactionDelayMaxPercent = 10
 
+	// MinBlockReloadInterval is the minimum supported non-zero block reload interval.
+	MinBlockReloadInterval = time.Second
+
 	defaultBlockReloadInterval = time.Minute
-	minBlockReloadInterval     = time.Second
 
 	// Block dir suffixes to make deletion and creation operations atomic.
 	// We decided to do suffixes instead of creating meta.json as last (or delete as first) one,
@@ -265,7 +267,8 @@ type Options struct {
 	BlockCompactionExcludeFunc BlockExcludeFilterFunc
 
 	// BlockReloadInterval is the interval at which blocks are reloaded.
-	// A zero value uses the default of one minute. Non-zero values below one second are clamped to one second.
+	// A zero value uses the default of one minute. Non-zero values below
+	// MinBlockReloadInterval are clamped to it.
 	BlockReloadInterval time.Duration
 
 	// FloatChunkEncoding is the encoding used for new float chunks. It is the
@@ -971,8 +974,8 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64, error) {
 	}
 	if opts.BlockReloadInterval == 0 {
 		opts.BlockReloadInterval = defaultBlockReloadInterval
-	} else if opts.BlockReloadInterval < minBlockReloadInterval {
-		opts.BlockReloadInterval = minBlockReloadInterval
+	} else if opts.BlockReloadInterval < MinBlockReloadInterval {
+		opts.BlockReloadInterval = MinBlockReloadInterval
 	}
 
 	if len(rngs) == 0 {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -58,6 +58,9 @@ const (
 	// DefaultCompactionDelayMaxPercent in percentage.
 	DefaultCompactionDelayMaxPercent = 10
 
+	defaultBlockReloadInterval = time.Minute
+	minBlockReloadInterval     = time.Second
+
 	// Block dir suffixes to make deletion and creation operations atomic.
 	// We decided to do suffixes instead of creating meta.json as last (or delete as first) one,
 	// because in error case you still can recover meta.json from the block content within local TSDB dir.
@@ -96,7 +99,7 @@ func DefaultOptions() *Options {
 		CompactionDelayMaxPercent:   DefaultCompactionDelayMaxPercent,
 		CompactionDelay:             time.Duration(0),
 		PostingsDecoderFactory:      DefaultPostingsDecoderFactory,
-		BlockReloadInterval:         1 * time.Minute,
+		BlockReloadInterval:         defaultBlockReloadInterval,
 	}
 }
 
@@ -262,6 +265,7 @@ type Options struct {
 	BlockCompactionExcludeFunc BlockExcludeFilterFunc
 
 	// BlockReloadInterval is the interval at which blocks are reloaded.
+	// A zero value uses the default of one minute. Non-zero values below one second are clamped to one second.
 	BlockReloadInterval time.Duration
 
 	// FloatChunkEncoding is the encoding used for new float chunks. It is the
@@ -965,8 +969,10 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64, error) {
 	if opts.OutOfOrderTimeWindow < 0 {
 		opts.OutOfOrderTimeWindow = 0
 	}
-	if opts.BlockReloadInterval < 1*time.Second {
-		opts.BlockReloadInterval = 1 * time.Second
+	if opts.BlockReloadInterval == 0 {
+		opts.BlockReloadInterval = defaultBlockReloadInterval
+	} else if opts.BlockReloadInterval < minBlockReloadInterval {
+		opts.BlockReloadInterval = minBlockReloadInterval
 	}
 
 	if len(rngs) == 0 {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9707,29 +9707,45 @@ func TestBlockReloadInterval(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name            string
-		reloadInterval  time.Duration
-		expectedReloads float64
+		name             string
+		opts             *Options
+		expectedInterval time.Duration
+		verifyReloads    bool
+		expectedReloads  float64
 	}{
 		{
-			name:            "extremely small interval",
-			reloadInterval:  1 * time.Millisecond,
-			expectedReloads: 5,
+			name: "zero interval with custom options",
+			opts: &Options{
+				RetentionDuration: int64(time.Hour / time.Millisecond),
+			},
+			expectedInterval: time.Minute,
 		},
 		{
-			name:            "one second interval",
-			reloadInterval:  1 * time.Second,
-			expectedReloads: 5,
+			name: "extremely small interval",
+			opts: &Options{
+				BlockReloadInterval: time.Millisecond,
+			},
+			expectedInterval: time.Second,
+			verifyReloads:    true,
+			expectedReloads:  5,
+		},
+		{
+			name: "one second interval",
+			opts: &Options{
+				BlockReloadInterval: time.Second,
+			},
+			expectedInterval: time.Second,
+			verifyReloads:    true,
+			expectedReloads:  5,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			db := newTestDB(t, withOpts(&Options{
-				BlockReloadInterval: c.reloadInterval,
-			}))
-			if c.reloadInterval < 1*time.Second {
-				require.Equal(t, 1*time.Second, db.opts.BlockReloadInterval, "interval should be clamped to minimum of 1 second")
+			db := newTestDB(t, withOpts(c.opts))
+			require.Equal(t, c.expectedInterval, db.opts.BlockReloadInterval)
+			if !c.verifyReloads {
+				return
 			}
 			require.Equal(t, float64(1), prom_testutil.ToFloat64(db.metrics.reloads), "there should be one initial reload")
 			require.Eventually(t, func() bool {


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
`BlockReloadInterval` defaults to one minute when callers use `DefaultOptions`. Callers that provide custom options leave the field at zero, which validation previously clamped to one second. This caused block reloads and head chunk mmap scans to run roughly 60 times more frequently than intended.

Treat zero as unspecified and apply the one-minute default before clamping explicitly configured sub-second intervals to one second. Add regression coverage for custom options with an unset reload interval.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #19365.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] tsdb: fix default block reload interval for custom options
```
