### PR TITLE
fix(discovery/aws): guard nil Placement and ImageId in EC2 discovery

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -400,15 +400,19 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 							ec2LabelSeparator)
 				}
 
-				labels[ec2LabelAMI] = model.LabelValue(*inst.ImageId)
-				labels[ec2LabelAZ] = model.LabelValue(*inst.Placement.AvailabilityZone)
-				azID, ok := d.azToAZID[*inst.Placement.AvailabilityZone]
-				if !ok && d.azToAZID != nil {
-					d.logger.Debug(
-						"Availability zone ID not found",
-						"az", *inst.Placement.AvailabilityZone)
+				if inst.ImageId != nil {
+					labels[ec2LabelAMI] = model.LabelValue(*inst.ImageId)
 				}
-				labels[ec2LabelAZID] = model.LabelValue(azID)
+				if inst.Placement != nil && inst.Placement.AvailabilityZone != nil {
+					labels[ec2LabelAZ] = model.LabelValue(*inst.Placement.AvailabilityZone)
+					azID, ok := d.azToAZID[*inst.Placement.AvailabilityZone]
+					if !ok && d.azToAZID != nil {
+						d.logger.Debug(
+							"Availability zone ID not found",
+							"az", *inst.Placement.AvailabilityZone)
+					}
+					labels[ec2LabelAZID] = model.LabelValue(azID)
+				}
 				labels[ec2LabelInstanceState] = model.LabelValue(inst.State.Name)
 				labels[ec2LabelInstanceType] = model.LabelValue(inst.InstanceType)
 
@@ -492,3 +496,4 @@ func getInstanceIPv6Addresses(i *ec2Types.Instance) (*string, []string, []string
 
 	return nil, primaryIPv6Addrs, ipv6Addrs
 }
+


### PR DESCRIPTION
## Summary

Fixes #19374 — EC2 service discovery panics when `DescribeInstances` returns instances with a nil `Placement` field (or nil `ImageId`).

`discovery/aws/ec2.go` refresh() dereferences `inst.Placement.AvailabilityZone` and `inst.ImageId` with no nil guard. When either is nil, this panics and crashes the entire Prometheus process (there is no `recover()` in `discovery/`).

## Changes

- Guard `ec2LabelAMI` behind `inst.ImageId != nil`
- Guard `ec2LabelAZ` / `ec2LabelAZID` behind `inst.Placement != nil && inst.Placement.AvailabilityZone != nil`

This mirrors the guard pattern already used for every other optional field in this file (e.g. `if inst.PublicIpAddress != nil`), and the recently-fixed MSK case (#19184).

## Testing

- `go build ./discovery/aws/...` passes
- Existing tests in `discovery/aws/` pass