### PR TITLE
promql: safely derive info series evaluation time

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -4624,12 +4624,22 @@ func preprocessExprHelper(expr parser.Expr, start, end time.Time) (isStepInvaria
 			unwrapParenExpr(&n.Args[i])
 			var argIsStepInvariant bool
 			argIsStepInvariant, shouldWrap[i] = preprocessExprHelper(n.Args[i], start, end)
+			if n.Func.Name == "info" && i == 1 {
+				// The second argument is selector syntax and is not evaluated.
+				shouldWrap[i] = false
+				continue
+			}
 			isStepInvariant = isStepInvariant && argIsStepInvariant
 
 			_, argIsVectorSelector := n.Args[i].(*parser.VectorSelector)
 			if !argIsStepInvariant || !argIsVectorSelector {
 				isTimestampWithAllArgsStepInvariantSafe = false
 			}
+		}
+		if n.Func.Name == "info" {
+			// Different vector input reference times make info() depend on the evaluation step.
+			_, _, uniformReference := infoSelectTimestampAndOffset(n.Args[0])
+			isStepInvariant = isStepInvariant && uniformReference
 		}
 
 		if isStepInvariant || isTimestampWithAllArgsStepInvariantSafe {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -960,6 +960,23 @@ func FindMinMaxTime(s *parser.EvalStmt) (int64, int64) {
 	var evalRange time.Duration
 	parser.Inspect(s.Expr, func(node parser.Node, path []parser.Node) error {
 		switch n := node.(type) {
+		case *parser.Call:
+			if n.Func.Name != "info" {
+				break
+			}
+			nodeTimestamp, offset := infoSeriesSelectTimestampAndOffset(n.Args[0])
+			// Include info()'s implicit metadata selection in the query-wide bounds
+			// because SelectHints cannot expand the scoped Querier's time range.
+			start, end := getTimeRangesForSelector(s, &parser.VectorSelector{
+				Timestamp:      nodeTimestamp,
+				OriginalOffset: offset,
+			}, path, 0)
+			if start < minTimestamp {
+				minTimestamp = start
+			}
+			if end > maxTimestamp {
+				maxTimestamp = end
+			}
 		case *parser.VectorSelector:
 			start, end := getTimeRangesForSelector(s, n, path, evalRange)
 			if start < minTimestamp {

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3053,89 +3053,32 @@ func TestQueryLogger_error(t *testing.T) {
 	require.Contains(t, logLines[0], "params", map[string]any{"query": "test statement"})
 }
 
-func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
-	startTime := time.Unix(1000, 0)
-	endTime := time.Unix(9999, 0)
-	testCases := []struct {
-		input      string      // The input to be parsed.
-		expected   parser.Expr // The expected expression AST.
-		outputTest bool
-	}{
-		{
-			input: "123.4567",
-			expected: &parser.NumberLiteral{
-				Val:      123.4567,
-				PosRange: posrange.PositionRange{Start: 0, End: 8},
-			},
-		},
-		{
-			input: `"foo"`,
-			expected: &parser.StringLiteral{
-				Val:      "foo",
-				PosRange: posrange.PositionRange{Start: 0, End: 5},
-			},
-		},
-		{
-			input: "foo * bar",
-			expected: &parser.BinaryExpr{
-				Op: parser.MUL,
-				LHS: &parser.VectorSelector{
-					Name: "foo",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   3,
-					},
+func TestPreprocessExpr(t *testing.T) {
+	t.Run("wrap step-invariant expressions", func(t *testing.T) {
+		startTime := time.Unix(1000, 0)
+		endTime := time.Unix(9999, 0)
+		testCases := []struct {
+			input      string      // The input to be parsed.
+			expected   parser.Expr // The expected expression AST.
+			outputTest bool
+		}{
+			{
+				input: "123.4567",
+				expected: &parser.NumberLiteral{
+					Val:      123.4567,
+					PosRange: posrange.PositionRange{Start: 0, End: 8},
 				},
-				RHS: &parser.VectorSelector{
-					Name: "bar",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "bar"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 6,
-						End:   9,
-					},
-				},
-				VectorMatching: &parser.VectorMatching{Card: parser.CardOneToOne},
 			},
-		},
-		{
-			input: "foo * bar @ 10",
-			expected: &parser.BinaryExpr{
-				Op: parser.MUL,
-				LHS: &parser.VectorSelector{
-					Name: "foo",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   3,
-					},
+			{
+				input: `"foo"`,
+				expected: &parser.StringLiteral{
+					Val:      "foo",
+					PosRange: posrange.PositionRange{Start: 0, End: 5},
 				},
-				RHS: &parser.StepInvariantExpr{
-					Expr: &parser.VectorSelector{
-						Name: "bar",
-						LabelMatchers: []*labels.Matcher{
-							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "bar"),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 6,
-							End:   14,
-						},
-						Timestamp: makeInt64Pointer(10000),
-					},
-				},
-				VectorMatching: &parser.VectorMatching{Card: parser.CardOneToOne},
 			},
-		},
-		{
-			input: "foo @ 20 * bar @ 10",
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.BinaryExpr{
+			{
+				input: "foo * bar",
+				expected: &parser.BinaryExpr{
 					Op: parser.MUL,
 					LHS: &parser.VectorSelector{
 						Name: "foo",
@@ -3144,9 +3087,8 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 						},
 						PosRange: posrange.PositionRange{
 							Start: 0,
-							End:   8,
+							End:   3,
 						},
-						Timestamp: makeInt64Pointer(20000),
 					},
 					RHS: &parser.VectorSelector{
 						Name: "bar",
@@ -3154,76 +3096,113 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "bar"),
 						},
 						PosRange: posrange.PositionRange{
-							Start: 11,
-							End:   19,
+							Start: 6,
+							End:   9,
 						},
-						Timestamp: makeInt64Pointer(10000),
 					},
 					VectorMatching: &parser.VectorMatching{Card: parser.CardOneToOne},
 				},
 			},
-		},
-		{
-			input: "test[5s]",
-			expected: &parser.MatrixSelector{
-				VectorSelector: &parser.VectorSelector{
-					Name: "test",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
+			{
+				input: "foo * bar @ 10",
+				expected: &parser.BinaryExpr{
+					Op: parser.MUL,
+					LHS: &parser.VectorSelector{
+						Name: "foo",
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   3,
+						},
 					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   4,
+					RHS: &parser.StepInvariantExpr{
+						Expr: &parser.VectorSelector{
+							Name: "bar",
+							LabelMatchers: []*labels.Matcher{
+								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "bar"),
+							},
+							PosRange: posrange.PositionRange{
+								Start: 6,
+								End:   14,
+							},
+							Timestamp: makeInt64Pointer(10000),
+						},
 					},
-				},
-				Range:  5 * time.Second,
-				EndPos: 8,
-			},
-		},
-		{
-			input: `test{a="b"}[5y] @ 1603774699`,
-			expected: &parser.MatrixSelector{
-				VectorSelector: &parser.VectorSelector{
-					Name:      "test",
-					Timestamp: makeInt64Pointer(1603774699000),
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "a", "b"),
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   11,
-					},
-				},
-				Range:  5 * 365 * 24 * time.Hour,
-				EndPos: 28,
-			},
-		},
-		{
-			input: "sum by (foo)(some_metric)",
-			expected: &parser.AggregateExpr{
-				Op: parser.SUM,
-				Expr: &parser.VectorSelector{
-					Name: "some_metric",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 13,
-						End:   24,
-					},
-				},
-				Grouping: []string{"foo"},
-				PosRange: posrange.PositionRange{
-					Start: 0,
-					End:   25,
+					VectorMatching: &parser.VectorMatching{Card: parser.CardOneToOne},
 				},
 			},
-		},
-		{
-			input: "sum by (foo)(some_metric @ 10)",
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.AggregateExpr{
+			{
+				input: "foo @ 20 * bar @ 10",
+				expected: &parser.StepInvariantExpr{
+					Expr: &parser.BinaryExpr{
+						Op: parser.MUL,
+						LHS: &parser.VectorSelector{
+							Name: "foo",
+							LabelMatchers: []*labels.Matcher{
+								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
+							},
+							PosRange: posrange.PositionRange{
+								Start: 0,
+								End:   8,
+							},
+							Timestamp: makeInt64Pointer(20000),
+						},
+						RHS: &parser.VectorSelector{
+							Name: "bar",
+							LabelMatchers: []*labels.Matcher{
+								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "bar"),
+							},
+							PosRange: posrange.PositionRange{
+								Start: 11,
+								End:   19,
+							},
+							Timestamp: makeInt64Pointer(10000),
+						},
+						VectorMatching: &parser.VectorMatching{Card: parser.CardOneToOne},
+					},
+				},
+			},
+			{
+				input: "test[5s]",
+				expected: &parser.MatrixSelector{
+					VectorSelector: &parser.VectorSelector{
+						Name: "test",
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   4,
+						},
+					},
+					Range:  5 * time.Second,
+					EndPos: 8,
+				},
+			},
+			{
+				input: `test{a="b"}[5y] @ 1603774699`,
+				expected: &parser.MatrixSelector{
+					VectorSelector: &parser.VectorSelector{
+						Name:      "test",
+						Timestamp: makeInt64Pointer(1603774699000),
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "a", "b"),
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   11,
+						},
+					},
+					Range:  5 * 365 * 24 * time.Hour,
+					EndPos: 28,
+				},
+			},
+			{
+				input: "sum by (foo)(some_metric)",
+				expected: &parser.AggregateExpr{
 					Op: parser.SUM,
 					Expr: &parser.VectorSelector{
 						Name: "some_metric",
@@ -3232,379 +3211,43 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 						},
 						PosRange: posrange.PositionRange{
 							Start: 13,
-							End:   29,
+							End:   24,
 						},
-						Timestamp: makeInt64Pointer(10000),
 					},
 					Grouping: []string{"foo"},
 					PosRange: posrange.PositionRange{
 						Start: 0,
-						End:   30,
+						End:   25,
 					},
 				},
 			},
-		},
-		{
-			input: "sum(some_metric1 @ 10) + sum(some_metric2 @ 20)",
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.BinaryExpr{
-					Op:             parser.ADD,
-					VectorMatching: &parser.VectorMatching{},
-					LHS: &parser.AggregateExpr{
-						Op: parser.SUM,
-						Expr: &parser.VectorSelector{
-							Name: "some_metric1",
-							LabelMatchers: []*labels.Matcher{
-								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric1"),
-							},
-							PosRange: posrange.PositionRange{
-								Start: 4,
-								End:   21,
-							},
-							Timestamp: makeInt64Pointer(10000),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   22,
-						},
-					},
-					RHS: &parser.AggregateExpr{
-						Op: parser.SUM,
-						Expr: &parser.VectorSelector{
-							Name: "some_metric2",
-							LabelMatchers: []*labels.Matcher{
-								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric2"),
-							},
-							PosRange: posrange.PositionRange{
-								Start: 29,
-								End:   46,
-							},
-							Timestamp: makeInt64Pointer(20000),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 25,
-							End:   47,
-						},
-					},
-				},
-			},
-		},
-		{
-			input: "some_metric and topk(5, rate(some_metric[1m] @ 20))",
-			expected: &parser.BinaryExpr{
-				Op: parser.LAND,
-				VectorMatching: &parser.VectorMatching{
-					Card: parser.CardManyToMany,
-				},
-				LHS: &parser.VectorSelector{
-					Name: "some_metric",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   11,
-					},
-				},
-				RHS: &parser.StepInvariantExpr{
-					Expr: &parser.AggregateExpr{
-						Op: parser.TOPK,
-						Expr: &parser.Call{
-							Func: parser.MustGetFunction("rate"),
-							Args: parser.Expressions{
-								&parser.MatrixSelector{
-									VectorSelector: &parser.VectorSelector{
-										Name: "some_metric",
-										LabelMatchers: []*labels.Matcher{
-											parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
-										},
-										PosRange: posrange.PositionRange{
-											Start: 29,
-											End:   40,
-										},
-										Timestamp: makeInt64Pointer(20000),
-									},
-									Range:  1 * time.Minute,
-									EndPos: 49,
-								},
-							},
-							PosRange: posrange.PositionRange{
-								Start: 24,
-								End:   50,
-							},
-						},
-						Param: &parser.NumberLiteral{
-							Val: 5,
-							PosRange: posrange.PositionRange{
-								Start: 21,
-								End:   22,
-							},
-						},
-						PosRange: posrange.PositionRange{
-							Start: 16,
-							End:   51,
-						},
-					},
-				},
-			},
-		},
-		{
-			input: "time()",
-			expected: &parser.Call{
-				Func: parser.MustGetFunction("time"),
-				Args: parser.Expressions{},
-				PosRange: posrange.PositionRange{
-					Start: 0,
-					End:   6,
-				},
-			},
-		},
-		{
-			input: `foo{bar="baz"}[10m:6s]`,
-			expected: &parser.SubqueryExpr{
-				Expr: &parser.VectorSelector{
-					Name: "foo",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   14,
-					},
-				},
-				Range:  10 * time.Minute,
-				Step:   6 * time.Second,
-				EndPos: 22,
-			},
-		},
-		{
-			input: `foo{bar="baz"}[10m:6s] @ 10`,
-			expected: &parser.SubqueryExpr{
-				Expr: &parser.VectorSelector{
-					Name: "foo",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   14,
-					},
-				},
-				Range:     10 * time.Minute,
-				Step:      6 * time.Second,
-				Timestamp: makeInt64Pointer(10000),
-				EndPos:    27,
-			},
-		},
-		{ // Even though the subquery is step invariant, the inside is also wrapped separately.
-			input: `sum(foo{bar="baz"} @ 20)[10m:6s] @ 10`,
-			expected: &parser.SubqueryExpr{
-				Expr: &parser.StepInvariantExpr{
+			{
+				input: "sum by (foo)(some_metric @ 10)",
+				expected: &parser.StepInvariantExpr{
 					Expr: &parser.AggregateExpr{
 						Op: parser.SUM,
 						Expr: &parser.VectorSelector{
-							Name: "foo",
+							Name: "some_metric",
 							LabelMatchers: []*labels.Matcher{
-								parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
-								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
+								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
 							},
 							PosRange: posrange.PositionRange{
-								Start: 4,
-								End:   23,
-							},
-							Timestamp: makeInt64Pointer(20000),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   24,
-						},
-					},
-				},
-				Range:     10 * time.Minute,
-				Step:      6 * time.Second,
-				Timestamp: makeInt64Pointer(10000),
-				EndPos:    37,
-			},
-		},
-		{
-			input: `min_over_time(rate(foo{bar="baz"}[2s])[5m:] @ 1603775091)[4m:3s]`,
-			expected: &parser.SubqueryExpr{
-				Expr: &parser.StepInvariantExpr{
-					Expr: &parser.Call{
-						Func: parser.MustGetFunction("min_over_time"),
-						Args: parser.Expressions{
-							&parser.SubqueryExpr{
-								Expr: &parser.Call{
-									Func: parser.MustGetFunction("rate"),
-									Args: parser.Expressions{
-										&parser.MatrixSelector{
-											VectorSelector: &parser.VectorSelector{
-												Name: "foo",
-												LabelMatchers: []*labels.Matcher{
-													parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
-													parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-												},
-												PosRange: posrange.PositionRange{
-													Start: 19,
-													End:   33,
-												},
-											},
-											Range:  2 * time.Second,
-											EndPos: 37,
-										},
-									},
-									PosRange: posrange.PositionRange{
-										Start: 14,
-										End:   38,
-									},
-								},
-								Range:     5 * time.Minute,
-								Timestamp: makeInt64Pointer(1603775091000),
-								EndPos:    56,
-							},
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   57,
-						},
-					},
-				},
-				Range:  4 * time.Minute,
-				Step:   3 * time.Second,
-				EndPos: 64,
-			},
-		},
-		{
-			input: `some_metric @ 123 offset 1m [10m:5s]`,
-			expected: &parser.SubqueryExpr{
-				Expr: &parser.StepInvariantExpr{
-					Expr: &parser.VectorSelector{
-						Name: "some_metric",
-						LabelMatchers: []*labels.Matcher{
-							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   27,
-						},
-						Timestamp:      makeInt64Pointer(123000),
-						OriginalOffset: 1 * time.Minute,
-					},
-				},
-				Range:  10 * time.Minute,
-				Step:   5 * time.Second,
-				EndPos: 36,
-			},
-		},
-		{
-			input: `some_metric[10m:5s] offset 1m @ 123`,
-			expected: &parser.SubqueryExpr{
-				Expr: &parser.VectorSelector{
-					Name: "some_metric",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   11,
-					},
-				},
-				Timestamp:      makeInt64Pointer(123000),
-				OriginalOffset: 1 * time.Minute,
-				Range:          10 * time.Minute,
-				Step:           5 * time.Second,
-				EndPos:         35,
-			},
-		},
-		{
-			input: `(foo + bar{nm="val"} @ 1234)[5m:] @ 1603775019`,
-			expected: &parser.SubqueryExpr{
-				Expr: &parser.ParenExpr{
-					Expr: &parser.BinaryExpr{
-						Op: parser.ADD,
-						VectorMatching: &parser.VectorMatching{
-							Card: parser.CardOneToOne,
-						},
-						LHS: &parser.VectorSelector{
-							Name: "foo",
-							LabelMatchers: []*labels.Matcher{
-								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-							},
-							PosRange: posrange.PositionRange{
-								Start: 1,
-								End:   4,
-							},
-						},
-						RHS: &parser.StepInvariantExpr{
-							Expr: &parser.VectorSelector{
-								Name: "bar",
-								LabelMatchers: []*labels.Matcher{
-									parser.MustLabelMatcher(labels.MatchEqual, "nm", "val"),
-									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "bar"),
-								},
-								Timestamp: makeInt64Pointer(1234000),
-								PosRange: posrange.PositionRange{
-									Start: 7,
-									End:   27,
-								},
-							},
-						},
-					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   28,
-					},
-				},
-				Range:     5 * time.Minute,
-				Timestamp: makeInt64Pointer(1603775019000),
-				EndPos:    46,
-			},
-		},
-		{
-			input: "abs(abs(metric @ 10))",
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.Call{
-					Func: &parser.Function{
-						Name:       "abs",
-						ArgTypes:   []parser.ValueType{parser.ValueTypeVector},
-						ReturnType: parser.ValueTypeVector,
-					},
-					Args: parser.Expressions{&parser.Call{
-						Func: &parser.Function{
-							Name:       "abs",
-							ArgTypes:   []parser.ValueType{parser.ValueTypeVector},
-							ReturnType: parser.ValueTypeVector,
-						},
-						Args: parser.Expressions{&parser.VectorSelector{
-							Name: "metric",
-							LabelMatchers: []*labels.Matcher{
-								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "metric"),
-							},
-							PosRange: posrange.PositionRange{
-								Start: 8,
-								End:   19,
+								Start: 13,
+								End:   29,
 							},
 							Timestamp: makeInt64Pointer(10000),
-						}},
-						PosRange: posrange.PositionRange{
-							Start: 4,
-							End:   20,
 						},
-					}},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   21,
+						Grouping: []string{"foo"},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   30,
+						},
 					},
 				},
 			},
-		},
-		{
-			input: "sum(sum(some_metric1 @ 10) + sum(some_metric2 @ 20))",
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.AggregateExpr{
-					Op: parser.SUM,
+			{
+				input: "sum(some_metric1 @ 10) + sum(some_metric2 @ 20)",
+				expected: &parser.StepInvariantExpr{
 					Expr: &parser.BinaryExpr{
 						Op:             parser.ADD,
 						VectorMatching: &parser.VectorMatching{},
@@ -3616,14 +3259,14 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric1"),
 								},
 								PosRange: posrange.PositionRange{
-									Start: 8,
-									End:   25,
+									Start: 4,
+									End:   21,
 								},
 								Timestamp: makeInt64Pointer(10000),
 							},
 							PosRange: posrange.PositionRange{
-								Start: 4,
-								End:   26,
+								Start: 0,
+								End:   22,
 							},
 						},
 						RHS: &parser.AggregateExpr{
@@ -3634,270 +3277,703 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric2"),
 								},
 								PosRange: posrange.PositionRange{
-									Start: 33,
-									End:   50,
+									Start: 29,
+									End:   46,
 								},
 								Timestamp: makeInt64Pointer(20000),
 							},
 							PosRange: posrange.PositionRange{
-								Start: 29,
+								Start: 25,
+								End:   47,
+							},
+						},
+					},
+				},
+			},
+			{
+				input: "some_metric and topk(5, rate(some_metric[1m] @ 20))",
+				expected: &parser.BinaryExpr{
+					Op: parser.LAND,
+					VectorMatching: &parser.VectorMatching{
+						Card: parser.CardManyToMany,
+					},
+					LHS: &parser.VectorSelector{
+						Name: "some_metric",
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   11,
+						},
+					},
+					RHS: &parser.StepInvariantExpr{
+						Expr: &parser.AggregateExpr{
+							Op: parser.TOPK,
+							Expr: &parser.Call{
+								Func: parser.MustGetFunction("rate"),
+								Args: parser.Expressions{
+									&parser.MatrixSelector{
+										VectorSelector: &parser.VectorSelector{
+											Name: "some_metric",
+											LabelMatchers: []*labels.Matcher{
+												parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
+											},
+											PosRange: posrange.PositionRange{
+												Start: 29,
+												End:   40,
+											},
+											Timestamp: makeInt64Pointer(20000),
+										},
+										Range:  1 * time.Minute,
+										EndPos: 49,
+									},
+								},
+								PosRange: posrange.PositionRange{
+									Start: 24,
+									End:   50,
+								},
+							},
+							Param: &parser.NumberLiteral{
+								Val: 5,
+								PosRange: posrange.PositionRange{
+									Start: 21,
+									End:   22,
+								},
+							},
+							PosRange: posrange.PositionRange{
+								Start: 16,
 								End:   51,
 							},
 						},
 					},
+				},
+			},
+			{
+				input: "time()",
+				expected: &parser.Call{
+					Func: parser.MustGetFunction("time"),
+					Args: parser.Expressions{},
 					PosRange: posrange.PositionRange{
 						Start: 0,
-						End:   52,
+						End:   6,
 					},
 				},
 			},
-		},
-		{
-			input: `foo @ start()`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.VectorSelector{
-					Name: "foo",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   13,
-					},
-					Timestamp:  makeInt64Pointer(timestamp.FromTime(startTime)),
-					StartOrEnd: parser.START,
-				},
-			},
-		},
-		{
-			input: `foo @ end()`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.VectorSelector{
-					Name: "foo",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   11,
-					},
-					Timestamp:  makeInt64Pointer(timestamp.FromTime(endTime)),
-					StartOrEnd: parser.END,
-				},
-			},
-		},
-		{
-			input: `sum_over_time(test[5y] @ start())`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.Call{
-					Func: &parser.Function{
-						Name:       "sum_over_time",
-						ArgTypes:   []parser.ValueType{parser.ValueTypeMatrix},
-						ReturnType: parser.ValueTypeVector,
-					},
-					Args: parser.Expressions{
-						&parser.MatrixSelector{
-							VectorSelector: &parser.VectorSelector{
-								Name:       "test",
-								Timestamp:  makeInt64Pointer(timestamp.FromTime(startTime)),
-								StartOrEnd: parser.START,
-								LabelMatchers: []*labels.Matcher{
-									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
-								},
-								PosRange: posrange.PositionRange{
-									Start: 14,
-									End:   18,
-								},
-							},
-							Range:  5 * 365 * 24 * time.Hour,
-							EndPos: 32,
+			{
+				input: `foo{bar="baz"}[10m:6s]`,
+				expected: &parser.SubqueryExpr{
+					Expr: &parser.VectorSelector{
+						Name: "foo",
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   14,
 						},
 					},
-					PosRange: posrange.PositionRange{Start: 0, End: 33},
+					Range:  10 * time.Minute,
+					Step:   6 * time.Second,
+					EndPos: 22,
 				},
 			},
-		},
-		{
-			input: `test[5y] @ end()`,
-			expected: &parser.MatrixSelector{
-				VectorSelector: &parser.VectorSelector{
-					Name:       "test",
-					Timestamp:  makeInt64Pointer(timestamp.FromTime(endTime)),
-					StartOrEnd: parser.END,
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
+			{
+				input: `foo{bar="baz"}[10m:6s] @ 10`,
+				expected: &parser.SubqueryExpr{
+					Expr: &parser.VectorSelector{
+						Name: "foo",
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   14,
+						},
 					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   4,
-					},
+					Range:     10 * time.Minute,
+					Step:      6 * time.Second,
+					Timestamp: makeInt64Pointer(10000),
+					EndPos:    27,
 				},
-				Range:  5 * 365 * 24 * time.Hour,
-				EndPos: 16,
 			},
-		},
-		{
-			input: `some_metric[10m:5s] @ start()`,
-			expected: &parser.SubqueryExpr{
-				Expr: &parser.VectorSelector{
-					Name: "some_metric",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
+			{ // Even though the subquery is step invariant, the inside is also wrapped separately.
+				input: `sum(foo{bar="baz"} @ 20)[10m:6s] @ 10`,
+				expected: &parser.SubqueryExpr{
+					Expr: &parser.StepInvariantExpr{
+						Expr: &parser.AggregateExpr{
+							Op: parser.SUM,
+							Expr: &parser.VectorSelector{
+								Name: "foo",
+								LabelMatchers: []*labels.Matcher{
+									parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
+									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
+								},
+								PosRange: posrange.PositionRange{
+									Start: 4,
+									End:   23,
+								},
+								Timestamp: makeInt64Pointer(20000),
+							},
+							PosRange: posrange.PositionRange{
+								Start: 0,
+								End:   24,
+							},
+						},
 					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   11,
-					},
+					Range:     10 * time.Minute,
+					Step:      6 * time.Second,
+					Timestamp: makeInt64Pointer(10000),
+					EndPos:    37,
 				},
-				Timestamp:  makeInt64Pointer(timestamp.FromTime(startTime)),
-				StartOrEnd: parser.START,
-				Range:      10 * time.Minute,
-				Step:       5 * time.Second,
-				EndPos:     29,
 			},
-		},
-		{
-			input: `some_metric[10m:5s] @ end()`,
-			expected: &parser.SubqueryExpr{
-				Expr: &parser.VectorSelector{
-					Name: "some_metric",
-					LabelMatchers: []*labels.Matcher{
-						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
+			{
+				input: `min_over_time(rate(foo{bar="baz"}[2s])[5m:] @ 1603775091)[4m:3s]`,
+				expected: &parser.SubqueryExpr{
+					Expr: &parser.StepInvariantExpr{
+						Expr: &parser.Call{
+							Func: parser.MustGetFunction("min_over_time"),
+							Args: parser.Expressions{
+								&parser.SubqueryExpr{
+									Expr: &parser.Call{
+										Func: parser.MustGetFunction("rate"),
+										Args: parser.Expressions{
+											&parser.MatrixSelector{
+												VectorSelector: &parser.VectorSelector{
+													Name: "foo",
+													LabelMatchers: []*labels.Matcher{
+														parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
+														parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
+													},
+													PosRange: posrange.PositionRange{
+														Start: 19,
+														End:   33,
+													},
+												},
+												Range:  2 * time.Second,
+												EndPos: 37,
+											},
+										},
+										PosRange: posrange.PositionRange{
+											Start: 14,
+											End:   38,
+										},
+									},
+									Range:     5 * time.Minute,
+									Timestamp: makeInt64Pointer(1603775091000),
+									EndPos:    56,
+								},
+							},
+							PosRange: posrange.PositionRange{
+								Start: 0,
+								End:   57,
+							},
+						},
 					},
-					PosRange: posrange.PositionRange{
-						Start: 0,
-						End:   11,
-					},
+					Range:  4 * time.Minute,
+					Step:   3 * time.Second,
+					EndPos: 64,
 				},
-				Timestamp:  makeInt64Pointer(timestamp.FromTime(endTime)),
-				StartOrEnd: parser.END,
-				Range:      10 * time.Minute,
-				Step:       5 * time.Second,
-				EndPos:     27,
 			},
-		},
-		{
-			input:      `floor(some_metric / (3 * 1024))`,
-			outputTest: true,
-			expected: &parser.Call{
-				Func: &parser.Function{
-					Name:       "floor",
-					ArgTypes:   []parser.ValueType{parser.ValueTypeVector},
-					ReturnType: parser.ValueTypeVector,
-				},
-				Args: parser.Expressions{
-					&parser.BinaryExpr{
-						Op: parser.DIV,
-						LHS: &parser.VectorSelector{
+			{
+				input: `some_metric @ 123 offset 1m [10m:5s]`,
+				expected: &parser.SubqueryExpr{
+					Expr: &parser.StepInvariantExpr{
+						Expr: &parser.VectorSelector{
 							Name: "some_metric",
 							LabelMatchers: []*labels.Matcher{
 								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
 							},
 							PosRange: posrange.PositionRange{
-								Start: 6,
-								End:   17,
+								Start: 0,
+								End:   27,
+							},
+							Timestamp:      makeInt64Pointer(123000),
+							OriginalOffset: 1 * time.Minute,
+						},
+					},
+					Range:  10 * time.Minute,
+					Step:   5 * time.Second,
+					EndPos: 36,
+				},
+			},
+			{
+				input: `some_metric[10m:5s] offset 1m @ 123`,
+				expected: &parser.SubqueryExpr{
+					Expr: &parser.VectorSelector{
+						Name: "some_metric",
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   11,
+						},
+					},
+					Timestamp:      makeInt64Pointer(123000),
+					OriginalOffset: 1 * time.Minute,
+					Range:          10 * time.Minute,
+					Step:           5 * time.Second,
+					EndPos:         35,
+				},
+			},
+			{
+				input: `(foo + bar{nm="val"} @ 1234)[5m:] @ 1603775019`,
+				expected: &parser.SubqueryExpr{
+					Expr: &parser.ParenExpr{
+						Expr: &parser.BinaryExpr{
+							Op: parser.ADD,
+							VectorMatching: &parser.VectorMatching{
+								Card: parser.CardOneToOne,
+							},
+							LHS: &parser.VectorSelector{
+								Name: "foo",
+								LabelMatchers: []*labels.Matcher{
+									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
+								},
+								PosRange: posrange.PositionRange{
+									Start: 1,
+									End:   4,
+								},
+							},
+							RHS: &parser.StepInvariantExpr{
+								Expr: &parser.VectorSelector{
+									Name: "bar",
+									LabelMatchers: []*labels.Matcher{
+										parser.MustLabelMatcher(labels.MatchEqual, "nm", "val"),
+										parser.MustLabelMatcher(labels.MatchEqual, "__name__", "bar"),
+									},
+									Timestamp: makeInt64Pointer(1234000),
+									PosRange: posrange.PositionRange{
+										Start: 7,
+										End:   27,
+									},
+								},
 							},
 						},
-						RHS: &parser.StepInvariantExpr{
-							Expr: &parser.ParenExpr{
-								Expr: &parser.BinaryExpr{
-									Op: parser.MUL,
-									LHS: &parser.NumberLiteral{
-										Val: 3,
-										PosRange: posrange.PositionRange{
-											Start: 21,
-											End:   22,
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   28,
+						},
+					},
+					Range:     5 * time.Minute,
+					Timestamp: makeInt64Pointer(1603775019000),
+					EndPos:    46,
+				},
+			},
+			{
+				input: "abs(abs(metric @ 10))",
+				expected: &parser.StepInvariantExpr{
+					Expr: &parser.Call{
+						Func: &parser.Function{
+							Name:       "abs",
+							ArgTypes:   []parser.ValueType{parser.ValueTypeVector},
+							ReturnType: parser.ValueTypeVector,
+						},
+						Args: parser.Expressions{&parser.Call{
+							Func: &parser.Function{
+								Name:       "abs",
+								ArgTypes:   []parser.ValueType{parser.ValueTypeVector},
+								ReturnType: parser.ValueTypeVector,
+							},
+							Args: parser.Expressions{&parser.VectorSelector{
+								Name: "metric",
+								LabelMatchers: []*labels.Matcher{
+									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "metric"),
+								},
+								PosRange: posrange.PositionRange{
+									Start: 8,
+									End:   19,
+								},
+								Timestamp: makeInt64Pointer(10000),
+							}},
+							PosRange: posrange.PositionRange{
+								Start: 4,
+								End:   20,
+							},
+						}},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   21,
+						},
+					},
+				},
+			},
+			{
+				input: "sum(sum(some_metric1 @ 10) + sum(some_metric2 @ 20))",
+				expected: &parser.StepInvariantExpr{
+					Expr: &parser.AggregateExpr{
+						Op: parser.SUM,
+						Expr: &parser.BinaryExpr{
+							Op:             parser.ADD,
+							VectorMatching: &parser.VectorMatching{},
+							LHS: &parser.AggregateExpr{
+								Op: parser.SUM,
+								Expr: &parser.VectorSelector{
+									Name: "some_metric1",
+									LabelMatchers: []*labels.Matcher{
+										parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric1"),
+									},
+									PosRange: posrange.PositionRange{
+										Start: 8,
+										End:   25,
+									},
+									Timestamp: makeInt64Pointer(10000),
+								},
+								PosRange: posrange.PositionRange{
+									Start: 4,
+									End:   26,
+								},
+							},
+							RHS: &parser.AggregateExpr{
+								Op: parser.SUM,
+								Expr: &parser.VectorSelector{
+									Name: "some_metric2",
+									LabelMatchers: []*labels.Matcher{
+										parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric2"),
+									},
+									PosRange: posrange.PositionRange{
+										Start: 33,
+										End:   50,
+									},
+									Timestamp: makeInt64Pointer(20000),
+								},
+								PosRange: posrange.PositionRange{
+									Start: 29,
+									End:   51,
+								},
+							},
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   52,
+						},
+					},
+				},
+			},
+			{
+				input: `foo @ start()`,
+				expected: &parser.StepInvariantExpr{
+					Expr: &parser.VectorSelector{
+						Name: "foo",
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   13,
+						},
+						Timestamp:  makeInt64Pointer(timestamp.FromTime(startTime)),
+						StartOrEnd: parser.START,
+					},
+				},
+			},
+			{
+				input: `foo @ end()`,
+				expected: &parser.StepInvariantExpr{
+					Expr: &parser.VectorSelector{
+						Name: "foo",
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   11,
+						},
+						Timestamp:  makeInt64Pointer(timestamp.FromTime(endTime)),
+						StartOrEnd: parser.END,
+					},
+				},
+			},
+			{
+				input: `sum_over_time(test[5y] @ start())`,
+				expected: &parser.StepInvariantExpr{
+					Expr: &parser.Call{
+						Func: &parser.Function{
+							Name:       "sum_over_time",
+							ArgTypes:   []parser.ValueType{parser.ValueTypeMatrix},
+							ReturnType: parser.ValueTypeVector,
+						},
+						Args: parser.Expressions{
+							&parser.MatrixSelector{
+								VectorSelector: &parser.VectorSelector{
+									Name:       "test",
+									Timestamp:  makeInt64Pointer(timestamp.FromTime(startTime)),
+									StartOrEnd: parser.START,
+									LabelMatchers: []*labels.Matcher{
+										parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
+									},
+									PosRange: posrange.PositionRange{
+										Start: 14,
+										End:   18,
+									},
+								},
+								Range:  5 * 365 * 24 * time.Hour,
+								EndPos: 32,
+							},
+						},
+						PosRange: posrange.PositionRange{Start: 0, End: 33},
+					},
+				},
+			},
+			{
+				input: `test[5y] @ end()`,
+				expected: &parser.MatrixSelector{
+					VectorSelector: &parser.VectorSelector{
+						Name:       "test",
+						Timestamp:  makeInt64Pointer(timestamp.FromTime(endTime)),
+						StartOrEnd: parser.END,
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   4,
+						},
+					},
+					Range:  5 * 365 * 24 * time.Hour,
+					EndPos: 16,
+				},
+			},
+			{
+				input: `some_metric[10m:5s] @ start()`,
+				expected: &parser.SubqueryExpr{
+					Expr: &parser.VectorSelector{
+						Name: "some_metric",
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   11,
+						},
+					},
+					Timestamp:  makeInt64Pointer(timestamp.FromTime(startTime)),
+					StartOrEnd: parser.START,
+					Range:      10 * time.Minute,
+					Step:       5 * time.Second,
+					EndPos:     29,
+				},
+			},
+			{
+				input: `some_metric[10m:5s] @ end()`,
+				expected: &parser.SubqueryExpr{
+					Expr: &parser.VectorSelector{
+						Name: "some_metric",
+						LabelMatchers: []*labels.Matcher{
+							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   11,
+						},
+					},
+					Timestamp:  makeInt64Pointer(timestamp.FromTime(endTime)),
+					StartOrEnd: parser.END,
+					Range:      10 * time.Minute,
+					Step:       5 * time.Second,
+					EndPos:     27,
+				},
+			},
+			{
+				input:      `floor(some_metric / (3 * 1024))`,
+				outputTest: true,
+				expected: &parser.Call{
+					Func: &parser.Function{
+						Name:       "floor",
+						ArgTypes:   []parser.ValueType{parser.ValueTypeVector},
+						ReturnType: parser.ValueTypeVector,
+					},
+					Args: parser.Expressions{
+						&parser.BinaryExpr{
+							Op: parser.DIV,
+							LHS: &parser.VectorSelector{
+								Name: "some_metric",
+								LabelMatchers: []*labels.Matcher{
+									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
+								},
+								PosRange: posrange.PositionRange{
+									Start: 6,
+									End:   17,
+								},
+							},
+							RHS: &parser.StepInvariantExpr{
+								Expr: &parser.ParenExpr{
+									Expr: &parser.BinaryExpr{
+										Op: parser.MUL,
+										LHS: &parser.NumberLiteral{
+											Val: 3,
+											PosRange: posrange.PositionRange{
+												Start: 21,
+												End:   22,
+											},
+										},
+										RHS: &parser.NumberLiteral{
+											Val: 1024,
+											PosRange: posrange.PositionRange{
+												Start: 25,
+												End:   29,
+											},
 										},
 									},
-									RHS: &parser.NumberLiteral{
-										Val: 1024,
+									PosRange: posrange.PositionRange{
+										Start: 20,
+										End:   30,
+									},
+								},
+							},
+						},
+					},
+					PosRange: posrange.PositionRange{
+						Start: 0,
+						End:   31,
+					},
+				},
+			},
+			{
+				input: "timestamp(metric @ 10)",
+				expected: &parser.StepInvariantExpr{
+					Expr: &parser.Call{
+						Func: parser.MustGetFunction("timestamp"),
+						Args: parser.Expressions{
+							&parser.VectorSelector{
+								Name:      "metric",
+								Timestamp: makeInt64Pointer(10000),
+								LabelMatchers: []*labels.Matcher{
+									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "metric"),
+								},
+								PosRange: posrange.PositionRange{
+									Start: 10,
+									End:   21,
+								},
+							},
+						},
+						PosRange: posrange.PositionRange{Start: 0, End: 22},
+					},
+				},
+			},
+			{
+				input: "timestamp(abs(metric @ 10))",
+				expected: &parser.Call{
+					Func: parser.MustGetFunction("timestamp"),
+					Args: parser.Expressions{
+						&parser.StepInvariantExpr{
+							Expr: &parser.Call{
+								Func: parser.MustGetFunction("abs"),
+								Args: parser.Expressions{
+									&parser.VectorSelector{
+										Name:      "metric",
+										Timestamp: makeInt64Pointer(10000),
+										LabelMatchers: []*labels.Matcher{
+											parser.MustLabelMatcher(labels.MatchEqual, "__name__", "metric"),
+										},
 										PosRange: posrange.PositionRange{
-											Start: 25,
-											End:   29,
+											Start: 14,
+											End:   25,
 										},
 									},
 								},
 								PosRange: posrange.PositionRange{
-									Start: 20,
-									End:   30,
+									Start: 10,
+									End:   26,
 								},
 							},
 						},
 					},
-				},
-				PosRange: posrange.PositionRange{
-					Start: 0,
-					End:   31,
+					PosRange: posrange.PositionRange{Start: 0, End: 27},
 				},
 			},
-		},
-		{
-			input: "timestamp(metric @ 10)",
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.Call{
-					Func: parser.MustGetFunction("timestamp"),
-					Args: parser.Expressions{
-						&parser.VectorSelector{
-							Name:      "metric",
-							Timestamp: makeInt64Pointer(10000),
-							LabelMatchers: []*labels.Matcher{
-								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "metric"),
-							},
-							PosRange: posrange.PositionRange{
-								Start: 10,
-								End:   21,
-							},
-						},
-					},
-					PosRange: posrange.PositionRange{Start: 0, End: 22},
-				},
-			},
-		},
-		{
-			input: "timestamp(abs(metric @ 10))",
-			expected: &parser.Call{
-				Func: parser.MustGetFunction("timestamp"),
-				Args: parser.Expressions{
-					&parser.StepInvariantExpr{
-						Expr: &parser.Call{
-							Func: parser.MustGetFunction("abs"),
-							Args: parser.Expressions{
-								&parser.VectorSelector{
-									Name:      "metric",
-									Timestamp: makeInt64Pointer(10000),
-									LabelMatchers: []*labels.Matcher{
-										parser.MustLabelMatcher(labels.MatchEqual, "__name__", "metric"),
-									},
-									PosRange: posrange.PositionRange{
-										Start: 14,
-										End:   25,
-									},
-								},
-							},
-							PosRange: posrange.PositionRange{
-								Start: 10,
-								End:   26,
-							},
-						},
-					},
-				},
-				PosRange: posrange.PositionRange{Start: 0, End: 27},
-			},
-		},
-	}
+		}
+		for _, test := range testCases {
+			t.Run(test.input, func(t *testing.T) {
+				expr, err := testParser.ParseExpr(test.input)
+				require.NoError(t, err)
+				expr, err = promql.PreprocessExpr(expr, startTime, endTime, 0)
+				require.NoError(t, err)
+				if test.outputTest {
+					require.Equal(t, test.input, expr.String(), "error on input '%s'", test.input)
+				}
+				require.Equal(t, test.expected, expr, "error on input '%s'", test.input)
+			})
+		}
+	})
 
-	for _, test := range testCases {
-		t.Run(test.input, func(t *testing.T) {
-			expr, err := testParser.ParseExpr(test.input)
-			require.NoError(t, err)
-			expr, err = promql.PreprocessExpr(expr, startTime, endTime, 0)
-			require.NoError(t, err)
-			if test.outputTest {
-				require.Equal(t, test.input, expr.String(), "error on input '%s'", test.input)
-			}
-			require.Equal(t, test.expected, expr, "error on input '%s'", test.input)
-		})
-	}
+	t.Run("info step invariance", func(t *testing.T) {
+		startTime := time.Unix(1000, 0)
+		endTime := time.Unix(9999, 0)
+		testParser := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+		testCases := []struct {
+			name                   string
+			input                  string
+			wantCallStepInvariant  bool
+			wantInputStepInvariant bool
+		}{
+			{
+				name:                   "different fixed references",
+				input:                  "info(metric @ 120 or other_metric @ 480)",
+				wantInputStepInvariant: true,
+			},
+			{
+				name:                   "different fixed references with data label selector",
+				input:                  `info(metric @ 120 or other_metric @ 480, {foo="bar"} @ 120)`,
+				wantInputStepInvariant: true,
+			},
+			{
+				name:                  "same fixed reference",
+				input:                 "info(metric @ 120 or other_metric @ 120)",
+				wantCallStepInvariant: true,
+			},
+			{
+				name:                  "same fixed reference with data label selector",
+				input:                 `info(metric @ 120 or other_metric @ 120, {foo="bar"})`,
+				wantCallStepInvariant: true,
+			},
+			{
+				name:                  "equivalent fixed references",
+				input:                 "info(metric @ 180 offset 1m or other_metric @ 120)",
+				wantCallStepInvariant: true,
+			},
+			{
+				name:                   "reference-free input with data label selector",
+				input:                  `info(label_replace(label_replace(vector(1), "instance", "a", "__name__", ".*"), "job", "1", "__name__", ".*"), {version=~".*"})`,
+				wantInputStepInvariant: true,
+			},
+			{
+				name:                   "reference-free left input with fixed sibling",
+				input:                  `info(label_replace(label_replace(vector(1), "instance", "a", "__name__", ".*"), "job", "1", "__name__", ".*") or other_metric @ 120, {version=~".*"})`,
+				wantInputStepInvariant: true,
+			},
+			{
+				name:                   "reference-free right input with fixed sibling",
+				input:                  `info(other_metric @ 120 or label_replace(label_replace(vector(1), "instance", "a", "__name__", ".*"), "job", "1", "__name__", ".*"), {version=~".*"})`,
+				wantInputStepInvariant: true,
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				expr, err := testParser.ParseExpr(tc.input)
+				require.NoError(t, err)
+				expr, err = promql.PreprocessExpr(expr, startTime, endTime, 0)
+				require.NoError(t, err)
+
+				stepInvariant, gotCallStepInvariant := expr.(*parser.StepInvariantExpr)
+				require.Equal(t, tc.wantCallStepInvariant, gotCallStepInvariant)
+				if gotCallStepInvariant {
+					expr = stepInvariant.Expr
+				}
+				call, ok := expr.(*parser.Call)
+				require.True(t, ok)
+				_, gotInputStepInvariant := call.Args[0].(*parser.StepInvariantExpr)
+				require.Equal(t, tc.wantInputStepInvariant, gotInputStepInvariant)
+				if len(call.Args) > 1 {
+					_, ok := call.Args[1].(*parser.VectorSelector)
+					require.True(t, ok)
+				}
+			})
+		}
+	})
 }
 
 func TestEngineOptsValidation(t *testing.T) {

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -296,6 +296,41 @@ func (h *hintRecordingQuerier) Select(ctx context.Context, sortSeries bool, hint
 	return h.Querier.Select(ctx, sortSeries, hints, matchers...)
 }
 
+type hintsClampingQueryable struct {
+	storage.Queryable
+}
+
+func (q hintsClampingQueryable) Querier(mint, maxt int64) (storage.Querier, error) {
+	querier, err := q.Queryable.Querier(mint, maxt)
+	if err != nil {
+		return nil, err
+	}
+	return &hintsClampingQuerier{Querier: querier, mint: mint, maxt: maxt}, nil
+}
+
+type hintsClampingQuerier struct {
+	storage.Querier
+	mint, maxt int64
+}
+
+func (q *hintsClampingQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	if hints == nil {
+		return q.Querier.Select(ctx, sortSeries, nil, matchers...)
+	}
+
+	clampedHints := *hints
+	if clampedHints.Start < q.mint {
+		clampedHints.Start = q.mint
+	}
+	if clampedHints.End > q.maxt {
+		clampedHints.End = q.maxt
+	}
+	if clampedHints.Start > clampedHints.End {
+		return storage.EmptySeriesSet()
+	}
+	return q.Querier.Select(ctx, sortSeries, &clampedHints, matchers...)
+}
+
 func TestSelectHintsSetCorrectly(t *testing.T) {
 	opts := promql.EngineOpts{
 		Logger:           nil,
@@ -610,6 +645,132 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 			require.Equal(t, tc.expected, hintsRecorder.hints)
 		})
 	}
+}
+
+func TestFindMinMaxTimeForInfo(t *testing.T) {
+	const lookbackDelta = 5 * time.Second
+	testParser := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	testCases := []struct {
+		name       string
+		query      string
+		start, end time.Time
+		wantMin    int64
+		wantMax    int64
+	}{
+		{
+			name:    "mixed fixed references",
+			query:   "info(metric @ 120 or other_metric @ 480)",
+			start:   time.Unix(480, 0),
+			end:     time.Unix(540, 0),
+			wantMin: 115001,
+			wantMax: 540000,
+		},
+		{
+			name:    "mixed offsets",
+			query:   "info(metric offset 2m or other_metric offset 6m)",
+			start:   time.Unix(480, 0),
+			end:     time.Unix(540, 0),
+			wantMin: 115001,
+			wantMax: 540000,
+		},
+		{
+			name:    "selector-free input",
+			query:   `info(label_replace(label_replace(vector(1), "instance", "a", "__name__", ".*"), "job", "1", "__name__", ".*"))`,
+			start:   time.Unix(480, 0),
+			end:     time.Unix(540, 0),
+			wantMin: 475001,
+			wantMax: 540000,
+		},
+		{
+			name:    "offset subquery",
+			query:   "last_over_time((info(metric @ 120 or other_metric @ 480))[5m:1m] offset 6m)",
+			start:   time.Unix(1200, 0),
+			end:     time.Unix(1260, 0),
+			wantMin: 115001,
+			wantMax: 900000,
+		},
+		{
+			name:    "anchored offset subquery",
+			query:   "last_over_time((info(metric @ 120 or other_metric @ 480))[5m:1m] @ 1200 offset 6m)",
+			start:   time.Unix(1200, 0),
+			end:     time.Unix(1260, 0),
+			wantMin: 115001,
+			wantMax: 840000,
+		},
+		{
+			name:    "uniform fixed reference remains narrow",
+			query:   "info(metric @ 120 or other_metric @ 120)",
+			start:   time.Unix(480, 0),
+			end:     time.Unix(540, 0),
+			wantMin: 115001,
+			wantMax: 120000,
+		},
+		{
+			name:    "uniform short range includes metadata lookback",
+			query:   "info(last_over_time(metric[1s]))",
+			start:   time.Unix(480, 0),
+			end:     time.Unix(540, 0),
+			wantMin: 475001,
+			wantMax: 540000,
+		},
+		{
+			name:    "uniform fixed short range includes metadata lookback",
+			query:   "info(last_over_time(metric[1s] @ 120))",
+			start:   time.Unix(480, 0),
+			end:     time.Unix(540, 0),
+			wantMin: 115001,
+			wantMax: 120000,
+		},
+		{
+			name:    "uniform offset short range includes metadata lookback",
+			query:   "info(last_over_time(metric[1s] offset 2m))",
+			start:   time.Unix(480, 0),
+			end:     time.Unix(540, 0),
+			wantMin: 355001,
+			wantMax: 420000,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := testParser.ParseExpr(tc.query)
+			require.NoError(t, err)
+			expr, err = promql.PreprocessExpr(expr, tc.start, tc.end, time.Minute)
+			require.NoError(t, err)
+
+			stmt := &parser.EvalStmt{
+				Expr:          expr,
+				Start:         tc.start,
+				End:           tc.end,
+				Interval:      time.Minute,
+				LookbackDelta: lookbackDelta,
+			}
+			gotMin, gotMax := promql.FindMinMaxTime(stmt)
+			require.Equal(t, tc.wantMin, gotMin)
+			require.Equal(t, tc.wantMax, gotMax)
+		})
+	}
+}
+
+func TestInfoIncludesMetadataLookbackInQuerierBounds(t *testing.T) {
+	testStorage := promqltest.LoadedStorage(t, `
+		load 1m
+			metric{instance="a", job="1"} _ _ _ _ _ _ _ _ _ _ 1
+			target_info{instance="a", job="1", version="v1"} _ _ _ _ _ _ 1
+	`)
+	queryable := hintsClampingQueryable{Queryable: testStorage}
+	engine := promqltest.NewTestEngine(t, false, defaultLookbackDelta, promqltest.DefaultMaxSamplesPerQuery)
+
+	query, err := engine.NewInstantQuery(t.Context(), queryable, nil, "info(last_over_time(metric[1m]))", time.Unix(600, 0))
+	require.NoError(t, err)
+	t.Cleanup(query.Close)
+
+	result := query.Exec(t.Context())
+	require.NoError(t, result.Err)
+	vector, err := result.Vector()
+	require.NoError(t, err)
+	require.Len(t, vector, 1)
+	testutil.RequireEqual(t, labels.FromStrings("__name__", "metric", "instance", "a", "job", "1", "version", "v1"), vector[0].Metric)
 }
 
 func TestEngineShutdown(t *testing.T) {

--- a/promql/info.go
+++ b/promql/info.go
@@ -38,13 +38,16 @@ var identifyingLabels = []string{"instance", "job"}
 
 // evalInfo implements the info PromQL function.
 func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (parser.Value, annotations.Annotations) {
-	// The @ timestamp and offset on the first argument also govern at which time the info
-	// series are evaluated and matched (not just which series are selected), so that info(v @ T)
-	// enriches with the info series as of T at every step, independent of the evaluation time.
-	// They must be extracted before evaluating the first argument: evaluating a subquery
-	// replaces it in the expression with a materialized matrix selector that no longer carries
-	// the modifiers of the selectors inside the subquery.
-	nodeTimestamp, offset := infoSelectTimestampAndOffset(args[0])
+	// Extract modifiers before evaluating the first argument: evaluating a subquery replaces it
+	// with a materialized matrix selector that no longer carries the modifiers inside it.
+	selectTimestamp, selectOffset, uniformReference := infoSelectTimestampAndOffset(args[0])
+	evalTimestamp, evalOffset := selectTimestamp, selectOffset
+	if !uniformReference {
+		// Keep the existing first-selector hints, but don't apply a reference to every info series
+		// unless the expression provides a single shared selector reference.
+		evalTimestamp = nil
+		evalOffset = 0
+	}
 
 	val, annots := ev.eval(ctx, args[0])
 	mat := val.(Matrix)
@@ -81,8 +84,8 @@ func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (par
 		}
 	}
 
-	selectHints := ev.infoSelectHints(nodeTimestamp, offset)
-	infoSeries, ws, err := ev.fetchInfoSeries(ctx, mat, ignoreSeries, dataLabelMatchers, selectHints, nodeTimestamp, offset)
+	selectHints := ev.infoSelectHints(selectTimestamp, selectOffset)
+	infoSeries, ws, err := ev.fetchInfoSeries(ctx, mat, ignoreSeries, dataLabelMatchers, selectHints, evalTimestamp, evalOffset)
 	if err != nil {
 		ev.error(err)
 	}
@@ -113,31 +116,84 @@ func effectiveInfoNameMatchers(matchers []*labels.Matcher) []*labels.Matcher {
 	return []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, targetInfo)}
 }
 
-// infoSelectTimestampAndOffset returns the @ timestamp (nil if unset) and offset that govern
-// selection and evaluation of the info series, given expr (the first argument to an info call).
-// The reference time is derived from the first vector selector found in expr: the innermost @
-// timestamp among the selector and its enclosing subqueries anchors it (the evaluation time if
-// none is set), shifted by the offsets accumulated from the selector up to and including the
-// anchoring node.
-func infoSelectTimestampAndOffset(expr parser.Expr) (nodeTimestamp *int64, offset time.Duration) {
-	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
-		n, ok := node.(*parser.VectorSelector)
-		if !ok {
-			return nil
+type infoSeriesReference struct {
+	timestamp *int64
+	offset    time.Duration
+}
+
+func (r infoSeriesReference) equal(other infoSeriesReference) bool {
+	if r.timestamp == nil || other.timestamp == nil {
+		return r.timestamp == nil && other.timestamp == nil &&
+			durationMilliseconds(r.offset) == durationMilliseconds(other.offset)
+	}
+	return *r.timestamp-durationMilliseconds(r.offset) == *other.timestamp-durationMilliseconds(other.offset)
+}
+
+// infoSelectTimestampAndOffset returns the first vector-producing selector's reference and
+// whether every vector-producing path has a selector with the same effective reference time.
+func infoSelectTimestampAndOffset(expr parser.Expr) (nodeTimestamp *int64, offset time.Duration, uniform bool) {
+	var (
+		first         infoSeriesReference
+		found         bool
+		referenceFree bool
+	)
+	uniform = true
+
+	var inspect func(parser.Expr, []parser.Node) bool
+	inspect = func(expr parser.Expr, path []parser.Node) bool {
+		if expr.Type() != parser.ValueTypeVector && expr.Type() != parser.ValueTypeMatrix {
+			return false
 		}
-		nodeTimestamp = n.Timestamp
-		offset = n.OriginalOffset
-		// Enclosing subqueries shift the selector's reference time: their offsets add up until
-		// an @ timestamp anchors it, making any modifiers further out irrelevant.
-		for i := len(path) - 1; nodeTimestamp == nil && i >= 0; i-- {
-			if sq, ok := path[i].(*parser.SubqueryExpr); ok {
-				offset += sq.OriginalOffset
-				nodeTimestamp = sq.Timestamp
+
+		if n, ok := expr.(*parser.VectorSelector); ok {
+			ref := infoSeriesReference{
+				timestamp: n.Timestamp,
+				offset:    n.OriginalOffset,
+			}
+			// Enclosing subqueries shift the selector's reference time: their offsets add up until
+			// an @ timestamp anchors it, making any modifiers further out irrelevant.
+			for i := len(path) - 1; ref.timestamp == nil && i >= 0; i-- {
+				if sq, ok := path[i].(*parser.SubqueryExpr); ok {
+					ref.offset += sq.OriginalOffset
+					ref.timestamp = sq.Timestamp
+				}
+			}
+
+			if !found {
+				first = ref
+				found = true
+			} else if !first.equal(ref) {
+				uniform = false
+			}
+			return true
+		}
+
+		path = append(path, expr)
+		if call, ok := expr.(*parser.Call); ok && call.Func.Name == "info" {
+			// The second argument is selector syntax, but it is not evaluated as a vector.
+			return inspect(call.Args[0], path)
+		}
+
+		hasSelector := false
+		for child := range parser.ChildrenIter(expr) {
+			childExpr, ok := child.(parser.Expr)
+			if ok && inspect(childExpr, path) {
+				hasSelector = true
 			}
 		}
-		return errors.New("end traversal")
-	})
-	return nodeTimestamp, offset
+		if !hasSelector {
+			// Selector-free vectors use the evaluator time, which cannot be replaced by a
+			// selector reference from another vector-producing path.
+			referenceFree = true
+		}
+		return hasSelector
+	}
+
+	inspect(expr, nil)
+	if !found {
+		return nil, 0, false
+	}
+	return first.timestamp, first.offset, uniform && !referenceFree
 }
 
 // infoSelectHints calculates the storage.SelectHints for selecting info series, given the

--- a/promql/info.go
+++ b/promql/info.go
@@ -40,14 +40,7 @@ var identifyingLabels = []string{"instance", "job"}
 func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (parser.Value, annotations.Annotations) {
 	// Extract modifiers before evaluating the first argument: evaluating a subquery replaces it
 	// with a materialized matrix selector that no longer carries the modifiers inside it.
-	selectTimestamp, selectOffset, uniformReference := infoSelectTimestampAndOffset(args[0])
-	evalTimestamp, evalOffset := selectTimestamp, selectOffset
-	if !uniformReference {
-		// Keep the existing first-selector hints, but don't apply a reference to every info series
-		// unless the expression provides a single shared selector reference.
-		evalTimestamp = nil
-		evalOffset = 0
-	}
+	nodeTimestamp, offset := infoSeriesSelectTimestampAndOffset(args[0])
 
 	val, annots := ev.eval(ctx, args[0])
 	mat := val.(Matrix)
@@ -84,8 +77,8 @@ func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (par
 		}
 	}
 
-	selectHints := ev.infoSelectHints(selectTimestamp, selectOffset)
-	infoSeries, ws, err := ev.fetchInfoSeries(ctx, mat, ignoreSeries, dataLabelMatchers, selectHints, evalTimestamp, evalOffset)
+	selectHints := ev.infoSelectHints(nodeTimestamp, offset)
+	infoSeries, ws, err := ev.fetchInfoSeries(ctx, mat, ignoreSeries, dataLabelMatchers, selectHints, nodeTimestamp, offset)
 	if err != nil {
 		ev.error(err)
 	}
@@ -196,8 +189,20 @@ func infoSelectTimestampAndOffset(expr parser.Expr) (nodeTimestamp *int64, offse
 	return first.timestamp, first.offset, uniform && !referenceFree
 }
 
+// infoSeriesSelectTimestampAndOffset returns the reference used to select and
+// evaluate info series. Inputs without a shared reference use the evaluation time.
+func infoSeriesSelectTimestampAndOffset(expr parser.Expr) (*int64, time.Duration) {
+	nodeTimestamp, offset, uniformReference := infoSelectTimestampAndOffset(expr)
+	if !uniformReference {
+		return nil, 0
+	}
+	return nodeTimestamp, offset
+}
+
 // infoSelectHints calculates the storage.SelectHints for selecting info series, given the
-// @ timestamp (nil if unset) and offset that govern the first argument to the info call.
+// shared @ timestamp and offset of the info call's first argument. nodeTimestamp is nil both
+// when the first argument has no @ timestamp and when it has no single shared reference, in
+// which case info series are selected across the whole query range.
 func (ev *evaluator) infoSelectHints(nodeTimestamp *int64, offset time.Duration) storage.SelectHints {
 	offsetMs := durationMilliseconds(offset)
 

--- a/promql/promqltest/testdata/info.test
+++ b/promql/promqltest/testdata/info.test
@@ -298,29 +298,33 @@ eval instant at 8m info(metric * scalar(metric @ 120))
 eval instant at 8m info(scalar(metric offset 6m) * metric)
     {instance="a", job="1", version="new"} 16
 
-# Different reference times on vector-producing operands are ambiguous. Preserve the previous
-# evaluation-time matching rather than applying the first selector's old info labels to both.
+# Different reference times on vector-producing operands are ambiguous: there is no single
+# shared reference, so info series are selected and matched at each evaluation step instead of
+# being pinned to the first selector's reference.
 eval range from 8m to 9m step 1m info(metric @ 120 or other_metric)
-    metric{instance="a", job="1"} 2 2
-    other_metric{instance="b", job="1"} 8 8
+    metric{instance="a", job="1", version="new"} 2 2
+    other_metric{instance="b", job="1", version="new"} 8 8
+
+# Operand order within the first argument must not affect which info series are selected.
+eval range from 8m to 9m step 1m info(other_metric or metric @ 120)
+    metric{instance="a", job="1", version="new"} 2 2
+    other_metric{instance="b", job="1", version="new"} 8 8
 
 # When all vector inputs are fixed at different times, info() still uses evaluation-time
 # matching. It must remain step-dependent so shared timestamps don't depend on the range start.
 eval range from 4m to 9m step 1m info(metric @ 120 or other_metric @ 480)
-    metric{instance="a", job="1", version="old"} 2 2 2 _ _ _
-    metric{instance="a", job="1"} _ _ _ 2 2 2
-    other_metric{instance="b", job="1", version="old"} 8 8 8 _ _ _
-    other_metric{instance="b", job="1"} _ _ _ 8 8 8
+    metric{instance="a", job="1", version="new"} 2 2 2 2 2 2
+    other_metric{instance="b", job="1", version="new"} 8 8 8 8 8 8
 
 eval range from 8m to 9m step 1m info(metric @ 120 or other_metric @ 480)
-    metric{instance="a", job="1"} 2 2
-    other_metric{instance="b", job="1"} 8 8
+    metric{instance="a", job="1", version="new"} 2 2
+    other_metric{instance="b", job="1", version="new"} 8 8
 
 # The optional data label selector is syntax rather than an evaluated vector. Its modifiers
 # must not make preprocessing wrap it and change the concrete type expected by info().
 eval range from 8m to 9m step 1m info(metric @ 120 or other_metric @ 480, {version=~".*"} @ 120)
-    metric{instance="a", job="1"} 2 2
-    other_metric{instance="b", job="1"} 8 8
+    metric{instance="a", job="1", version="new"} 2 2
+    other_metric{instance="b", job="1", version="new"} 8 8
 
 # A selector-free vector has no pinned reference for info series. Enrichment must therefore
 # follow each evaluation step instead of being fixed to the range start.
@@ -332,15 +336,15 @@ eval range from 4m to 8m step 1m info(label_replace(label_replace(vector(1), "in
     {instance="a", job="1", version="new"} 1 1 1 1 1
 
 # A fixed selector in another vector-producing branch does not provide a shared reference for
-# selector-free vectors. It must not pin their enrichment to its historical timestamp, regardless
-# of operand order.
+# selector-free vectors. It must not pin their info series selection or enrichment to its
+# historical timestamp, regardless of operand order.
 eval range from 8m to 9m step 1m info(label_replace(label_replace(vector(1), "instance", "a", "__name__", ".*"), "job", "1", "__name__", ".*") or other_metric @ 120, {version=~".*"})
-    {instance="a", job="1"} 1 1
-    other_metric{instance="b", job="1"} 2 2
+    {instance="a", job="1", version="new"} 1 1
+    other_metric{instance="b", job="1", version="new"} 2 2
 
 eval range from 8m to 9m step 1m info(other_metric @ 120 or label_replace(label_replace(vector(1), "instance", "a", "__name__", ".*"), "job", "1", "__name__", ".*"), {version=~".*"})
-    {instance="a", job="1"} 1 1
-    other_metric{instance="b", job="1"} 2 2
+    {instance="a", job="1", version="new"} 1 1
+    other_metric{instance="b", job="1", version="new"} 2 2
 
 # Syntactically different fixed modifiers that resolve to the same lookup time stay uniform.
 eval range from 8m to 9m step 1m info(metric @ 180 offset 1m or other_metric @ 120)
@@ -351,7 +355,31 @@ eval range from 8m to 9m step 1m info(metric @ 180 offset 1m or other_metric @ 1
 # nested selector-free input also does not share the sibling selector's historical reference.
 eval range from 8m to 9m step 1m info(info(vector(1), {foo=~".*"}) or metric @ 120)
     {} 1 1
-    metric{instance="a", job="1"} 2 2
+    metric{instance="a", job="1", version="new"} 2 2
+
+clear
+
+# Mixed fixed references use evaluation-time info labels. The replacement info series starts
+# after the latest data selector reference, so the query-wide storage bounds must include it.
+load 1m
+    metric{instance="a", job="1"} 0+1x8
+    other_metric{instance="b", job="1"} 0+1x8
+    target_info{instance="a", job="1", version="old"} _ _ _ _ _ _ _ _ 1 stale
+    target_info{instance="a", job="1", version="new"} _ _ _ _ _ _ _ _ _ 1
+    target_info{instance="b", job="1", version="old"} _ _ _ _ _ _ _ _ 1 stale
+    target_info{instance="b", job="1", version="new"} _ _ _ _ _ _ _ _ _ 1
+
+eval range from 8m to 9m step 1m info(metric @ 120 or other_metric @ 480)
+    metric{instance="a", job="1", version="old"} 2 _
+    metric{instance="a", job="1", version="new"} _ 2
+    other_metric{instance="b", job="1", version="old"} 8 _
+    other_metric{instance="b", job="1", version="new"} _ 8
+
+eval range from 8m to 9m step 1m info(other_metric @ 480 or metric @ 120)
+    metric{instance="a", job="1", version="old"} 2 _
+    metric{instance="a", job="1", version="new"} _ 2
+    other_metric{instance="b", job="1", version="old"} 8 _
+    other_metric{instance="b", job="1", version="new"} _ 8
 
 clear
 

--- a/promql/promqltest/testdata/info.test
+++ b/promql/promqltest/testdata/info.test
@@ -255,8 +255,11 @@ clear
 # one is found.
 load 1m
     metric{instance="a", job="1"} 0 1 2 3 4 5 6 7 8
+    other_metric{instance="b", job="1"} 0 1 2 3 4 5 6 7 8
     target_info{instance="a", job="1", version="old"} 1 1 1 stale
     target_info{instance="a", job="1", version="new"} _ _ _ 1 1 1 1 1 1
+    target_info{instance="b", job="1", version="old"} 1 1 1 stale
+    target_info{instance="b", job="1", version="new"} _ _ _ 1 1 1 1 1 1
 
 # The info series is matched as of ts-2m, like the base samples, so enrichment reflects the
 # version current at the offset-shifted time and switches when that time crosses the flip at 3m.
@@ -282,6 +285,73 @@ eval instant at 40m info(last_over_time((metric offset 1m)[10m:1m] @ 180))
 eval range from 8m to 9m step 1m info(last_over_time(metric[5m:1m] offset 6m))
     metric{instance="a", job="1", version="old"} 2 _
     metric{instance="a", job="1", version="new"} _ 3
+
+# Modifiers in scalar-only subexpressions do not shift enrichment for the vector operand.
+# Reordering scalar-vector multiplication therefore produces the same current info labels.
+# Multiplication drops the metric name, which info() must not restore.
+eval instant at 8m info(scalar(metric @ 120) * metric)
+    {instance="a", job="1", version="new"} 16
+
+eval instant at 8m info(metric * scalar(metric @ 120))
+    {instance="a", job="1", version="new"} 16
+
+eval instant at 8m info(scalar(metric offset 6m) * metric)
+    {instance="a", job="1", version="new"} 16
+
+# Different reference times on vector-producing operands are ambiguous. Preserve the previous
+# evaluation-time matching rather than applying the first selector's old info labels to both.
+eval range from 8m to 9m step 1m info(metric @ 120 or other_metric)
+    metric{instance="a", job="1"} 2 2
+    other_metric{instance="b", job="1"} 8 8
+
+# When all vector inputs are fixed at different times, info() still uses evaluation-time
+# matching. It must remain step-dependent so shared timestamps don't depend on the range start.
+eval range from 4m to 9m step 1m info(metric @ 120 or other_metric @ 480)
+    metric{instance="a", job="1", version="old"} 2 2 2 _ _ _
+    metric{instance="a", job="1"} _ _ _ 2 2 2
+    other_metric{instance="b", job="1", version="old"} 8 8 8 _ _ _
+    other_metric{instance="b", job="1"} _ _ _ 8 8 8
+
+eval range from 8m to 9m step 1m info(metric @ 120 or other_metric @ 480)
+    metric{instance="a", job="1"} 2 2
+    other_metric{instance="b", job="1"} 8 8
+
+# The optional data label selector is syntax rather than an evaluated vector. Its modifiers
+# must not make preprocessing wrap it and change the concrete type expected by info().
+eval range from 8m to 9m step 1m info(metric @ 120 or other_metric @ 480, {version=~".*"} @ 120)
+    metric{instance="a", job="1"} 2 2
+    other_metric{instance="b", job="1"} 8 8
+
+# A selector-free vector has no pinned reference for info series. Enrichment must therefore
+# follow each evaluation step instead of being fixed to the range start.
+eval range from 2m to 8m step 1m info(label_replace(label_replace(vector(1), "instance", "a", "__name__", ".*"), "job", "1", "__name__", ".*"), {version=~".*"})
+    {instance="a", job="1", version="old"} 1 _ _ _ _ _ _
+    {instance="a", job="1", version="new"} _ 1 1 1 1 1 1
+
+eval range from 4m to 8m step 1m info(label_replace(label_replace(vector(1), "instance", "a", "__name__", ".*"), "job", "1", "__name__", ".*"), {version=~".*"})
+    {instance="a", job="1", version="new"} 1 1 1 1 1
+
+# A fixed selector in another vector-producing branch does not provide a shared reference for
+# selector-free vectors. It must not pin their enrichment to its historical timestamp, regardless
+# of operand order.
+eval range from 8m to 9m step 1m info(label_replace(label_replace(vector(1), "instance", "a", "__name__", ".*"), "job", "1", "__name__", ".*") or other_metric @ 120, {version=~".*"})
+    {instance="a", job="1"} 1 1
+    other_metric{instance="b", job="1"} 2 2
+
+eval range from 8m to 9m step 1m info(other_metric @ 120 or label_replace(label_replace(vector(1), "instance", "a", "__name__", ".*"), "job", "1", "__name__", ".*"), {version=~".*"})
+    {instance="a", job="1"} 1 1
+    other_metric{instance="b", job="1"} 2 2
+
+# Syntactically different fixed modifiers that resolve to the same lookup time stay uniform.
+eval range from 8m to 9m step 1m info(metric @ 180 offset 1m or other_metric @ 120)
+    metric{instance="a", job="1", version="old"} 2 2
+    other_metric{instance="b", job="1", version="old"} 2 2
+
+# A nested info data-label selector is selector syntax, not a vector-producing data source. The
+# nested selector-free input also does not share the sibling selector's historical reference.
+eval range from 8m to 9m step 1m info(info(vector(1), {foo=~".*"}) or metric @ 120)
+    {} 1 1
+    metric{instance="a", job="1"} 2 2
 
 clear
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
PR #19266 made `info()` evaluate info series using the `@` modifier or offset from its input. However, it derived that time from the first vector selector in the expression, which is only correct when every vector-producing path refers to the same effective time.

For composite expressions, the first selector may be irrelevant or may not represent the whole input. For example:

- In `info(scalar(foo @ 120) * metric)`, the scalar-only selector must not determine when `metric` is enriched. Reordering the operands should not change the result.
- In `info(metric @ 120 or other_metric @ 480)`, there is no single timestamp that can correctly represent both vector branches.
- A selector-free branch such as `vector(1)` must not inherit the historical timestamp of a sibling selector.

This PR uses a selector reference for evaluating info series only when every vector-producing path is backed by a selector with the same effective reference time. Otherwise, `info()` remains step-dependent and evaluates enrichment at each query step. Equivalent references, such as `@ 180 offset 1m` and `@ 120`, remain eligible for step-invariant evaluation.

The optional second argument to `info()` remains unwrapped because it is label-selector syntax rather than an evaluated vector.

Tests cover scalar-only selectors, mixed and equivalent references, selector-free branches in either operand position, nested `info()` calls, and preprocessing behavior. Most of the large `engine_test.go` diff is mechanical indentation from grouping the preprocessing tests under a common parent test.

Follow-up to #19266.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] PromQL: Fix `info()` enrichment for composite expressions with mixed `@`/offset references or selector-free vector branches, preventing metadata from being evaluated at an unrelated timestamp
```
