### PR TITLE
config: promote retry_on_http_429 to GA

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -249,7 +249,7 @@ var (
 		// Backoff times for retrying a batch of samples on recoverable errors.
 		MinBackoff:       model.Duration(30 * time.Millisecond),
 		MaxBackoff:       model.Duration(5 * time.Second),
-		RetryOnRateLimit: true,
+		RetryOnRateLimit: false,
 	}
 
 	// DefaultMetadataConfig is the default metadata configuration for a remote write endpoint.

--- a/config/config.go
+++ b/config/config.go
@@ -247,8 +247,9 @@ var (
 		BatchSendDeadline: model.Duration(5 * time.Second),
 
 		// Backoff times for retrying a batch of samples on recoverable errors.
-		MinBackoff: model.Duration(30 * time.Millisecond),
-		MaxBackoff: model.Duration(5 * time.Second),
+		MinBackoff:       model.Duration(30 * time.Millisecond),
+		MaxBackoff:       model.Duration(5 * time.Second),
+		RetryOnRateLimit: true,
 	}
 
 	// DefaultMetadataConfig is the default metadata configuration for a remote write endpoint.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -4042,7 +4042,6 @@ queue_config:
   # Maximum retry delay.
   [ max_backoff: <duration> | default = 5s ]
   # Retry upon receiving a 429 status code from the remote-write storage.
-  # This is experimental and might change in the future.
   [ retry_on_http_429: <boolean> | default = false ]
   # If set, any sample that is older than sample_age_limit
   # will not be sent to the remote storage. The default value is 0s,


### PR DESCRIPTION
Fixes #19263

This PR promotes `retry_on_http_429` in `remote_write` configuration to GA while keeping default = false (leaving the default behavior change for a separate discussion/PR per maintainer feedback).

### Details
- Removed experimental note for `retry_on_http_429` in documentation docs/configuration/configuration.md.
- Maintained RetryOnRateLimit default as `false`.

```release-notes
[FEATURE] remote_write: promote retry_on_http_429 option to GA.
```