### PR TITLE
chore(textparse): pin golex and validate generated lexers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1
   check_generated_parser:
-    # Checks generated parser and UI functions list. Not renaming as it is a required check.
+    # Checks generated parser, textparse lexers, and UI functions list. Not renaming as it is a required check.
     name: Check generated parser
     runs-on: ubuntu-latest
     container:
@@ -307,6 +307,7 @@ jobs:
           enable_npm: true
           cache_key_suffix: parser
       - run: make install-goyacc check-generated-parser
+      - run: make install-golex check-generated-textparse-lexers
       - run: make check-generated-promql-functions
   golangci:
     name: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ TSDB_BENCHMARK_OUTPUT_DIR ?= ./benchout
 
 GOLANGCI_LINT_OPTS ?= --timeout 4m
 GOYACC_VERSION ?= v0.6.0
+GOLEX_VERSION ?= v1.1.0
 
 include Makefile.common
 
@@ -169,6 +170,21 @@ check-generated-parser: clean-parser promql/parser/generated_parser.y.go
 install-goyacc:
 	@echo ">> installing goyacc $(GOYACC_VERSION)"
 	@go install golang.org/x/tools/cmd/goyacc@$(GOYACC_VERSION)
+
+.PHONY: generate-textparse-lexers
+generate-textparse-lexers:
+	@echo ">> generating textparse lexers"
+	@PATH="$(FIRST_GOPATH)/bin:$$PATH" $(GO) generate ./model/textparse
+
+.PHONY: check-generated-textparse-lexers
+check-generated-textparse-lexers: generate-textparse-lexers
+	@echo ">> checking generated textparse lexers"
+	@git diff --exit-code -- model/textparse/promlex.l.go model/textparse/openmetricslex.l.go || (echo "Generated textparse lexer files are out of date. Please run 'make generate-textparse-lexers' and commit the changes." && false)
+
+.PHONY: install-golex
+install-golex:
+	@echo ">> installing golex $(GOLEX_VERSION)"
+	@$(GO) install modernc.org/golex@$(GOLEX_VERSION)
 
 .PHONY: test
 # If we only want to test go code we have to change the test target

--- a/model/textparse/README.md
+++ b/model/textparse/README.md
@@ -1,6 +1,12 @@
 # Making changes to textparse lexers
-In the rare case that you need to update the textparse lexers, edit promlex.l or openmetricslex.l and then run the following command: 
-`golex -o=promlex.l.go promlex.l`
 
-Note that you need golex installed: 
-`go get -u modernc.org/golex`
+In the rare case that you need to update the textparse lexers, edit `promlex.l`
+or `openmetricslex.l`. The root `Makefile` pins `modernc.org/golex` v1.1.0 and
+provides the following regeneration targets, which you can run from the
+repository root:
+
+```sh
+make install-golex generate-textparse-lexers
+```
+
+This regenerates both `promlex.l.go` and `openmetricslex.l.go`.

--- a/model/textparse/openmetricslex.l.go
+++ b/model/textparse/openmetricslex.l.go
@@ -74,10 +74,10 @@ yystart1:
 
 yystate2:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate3
 	}
 
@@ -101,43 +101,43 @@ yystate5:
 yystate6:
 	c = l.next()
 yystart6:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'E':
+	case c == 'E':
 		goto yystate7
-	case 'H':
+	case c == 'H':
 		goto yystate11
-	case 'T':
+	case c == 'T':
 		goto yystate16
-	case 'U':
+	case c == 'U':
 		goto yystate21
 	}
 
 yystate7:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'O':
+	case c == 'O':
 		goto yystate8
 	}
 
 yystate8:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'F':
+	case c == 'F':
 		goto yystate9
 	}
 
 yystate9:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyrule5
-	case '\n':
+	case c == '\n':
 		goto yystate10
 	}
 
@@ -147,37 +147,37 @@ yystate10:
 
 yystate11:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'E':
+	case c == 'E':
 		goto yystate12
 	}
 
 yystate12:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'L':
+	case c == 'L':
 		goto yystate13
 	}
 
 yystate13:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'P':
+	case c == 'P':
 		goto yystate14
 	}
 
 yystate14:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate15
 	}
 
@@ -187,37 +187,37 @@ yystate15:
 
 yystate16:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'Y':
+	case c == 'Y':
 		goto yystate17
 	}
 
 yystate17:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'P':
+	case c == 'P':
 		goto yystate18
 	}
 
 yystate18:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'E':
+	case c == 'E':
 		goto yystate19
 	}
 
 yystate19:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate20
 	}
 
@@ -227,37 +227,37 @@ yystate20:
 
 yystate21:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'N':
+	case c == 'N':
 		goto yystate22
 	}
 
 yystate22:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'I':
+	case c == 'I':
 		goto yystate23
 	}
 
 yystate23:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'T':
+	case c == 'T':
 		goto yystate24
 	}
 
 yystate24:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate25
 	}
 
@@ -315,10 +315,10 @@ yystate30:
 yystate31:
 	c = l.next()
 yystart31:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate32
 	}
 
@@ -405,10 +405,10 @@ yystate41:
 yystate42:
 	c = l.next()
 yystart42:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case '"':
+	case c == '"':
 		goto yystate43
 	}
 
@@ -441,12 +441,12 @@ yystate45:
 yystate46:
 	c = l.next()
 yystart46:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate47
-	case '{':
+	case c == '{':
 		goto yystate49
 	}
 
@@ -475,12 +475,12 @@ yystate49:
 yystate50:
 	c = l.next()
 yystart50:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate52
-	case '\n':
+	case c == '\n':
 		goto yystate51
 	}
 
@@ -521,10 +521,10 @@ yystate54:
 
 yystate55:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case '{':
+	case c == '{':
 		goto yystate56
 	}
 
@@ -600,12 +600,12 @@ yystate64:
 yystate65:
 	c = l.next()
 yystart65:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate66
-	case '"':
+	case c == '"':
 		goto yystate68
 	}
 
@@ -656,12 +656,12 @@ yystate70:
 yystate71:
 	c = l.next()
 yystart71:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate73
-	case '\n':
+	case c == '\n':
 		goto yystate72
 	}
 
@@ -696,61 +696,61 @@ yyrule2: // HELP{S}
 	{
 		l.state = sMeta1
 		return tHelp
-
+		goto yystate0
 	}
 yyrule3: // TYPE{S}
 	{
 		l.state = sMeta1
 		return tType
-
+		goto yystate0
 	}
 yyrule4: // UNIT{S}
 	{
 		l.state = sMeta1
 		return tUnit
-
+		goto yystate0
 	}
 yyrule5: // "EOF"\n?
 	{
 		l.state = sInit
 		return tEOFWord
-
+		goto yystate0
 	}
 yyrule6: // \"(\\.|[^\\"])*\"
 	{
 		l.state = sMeta2
 		return tMName
-
+		goto yystate0
 	}
 yyrule7: // {M}({M}|{D})*
 	{
 		l.state = sMeta2
 		return tMName
-
+		goto yystate0
 	}
 yyrule8: // {S}{C}*\n
 	{
 		l.state = sInit
 		return tText
-
+		goto yystate0
 	}
 yyrule9: // {M}({M}|{D})*
 	{
 		l.state = sValue
 		return tMName
-
+		goto yystate0
 	}
 yyrule10: // \{
 	{
 		l.state = sLabels
 		return tBraceOpen
-
+		goto yystate0
 	}
 yyrule11: // \{
 	{
 		l.state = sLabels
 		return tBraceOpen
-
+		goto yystate0
 	}
 yyrule12: // {L}({L}|{D})*
 	{
@@ -760,19 +760,19 @@ yyrule13: // \"(\\.|[^\\"])*\"
 	{
 		l.state = sLabels
 		return tQString
-
+		goto yystate0
 	}
 yyrule14: // \}
 	{
 		l.state = sValue
 		return tBraceClose
-
+		goto yystate0
 	}
 yyrule15: // =
 	{
 		l.state = sLValue
 		return tEqual
-
+		goto yystate0
 	}
 yyrule16: // ,
 	{
@@ -782,13 +782,13 @@ yyrule17: // \"(\\.|[^\\"\n])*\"
 	{
 		l.state = sLabels
 		return tLValue
-
+		goto yystate0
 	}
 yyrule18: // {S}[^ \n]+
 	{
 		l.state = sTimestamp
 		return tValue
-
+		goto yystate0
 	}
 yyrule19: // {S}[^ \n]+
 	{
@@ -798,13 +798,13 @@ yyrule20: // \n
 	{
 		l.state = sInit
 		return tLinebreak
-
+		goto yystate0
 	}
 yyrule21: // {S}#{S}\{
 	{
 		l.state = sExemplar
 		return tComment
-
+		goto yystate0
 	}
 yyrule22: // {L}({L}|{D})*
 	{
@@ -814,25 +814,25 @@ yyrule23: // \"(\\.|[^\\"\n])*\"
 	{
 		l.state = sExemplar
 		return tQString
-
+		goto yystate0
 	}
 yyrule24: // \}
 	{
 		l.state = sEValue
 		return tBraceClose
-
+		goto yystate0
 	}
 yyrule25: // =
 	{
 		l.state = sEValue
 		return tEqual
-
+		goto yystate0
 	}
 yyrule26: // \"(\\.|[^\\"\n])*\"
 	{
 		l.state = sExemplar
 		return tLValue
-
+		goto yystate0
 	}
 yyrule27: // ,
 	{
@@ -842,7 +842,7 @@ yyrule28: // {S}[^ \n]+
 	{
 		l.state = sETimestamp
 		return tValue
-
+		goto yystate0
 	}
 yyrule29: // {S}[^ \n]+
 	{
@@ -852,7 +852,7 @@ yyrule30: // \n
 	if true { // avoid go vet determining the below panic will not be reached
 		l.state = sInit
 		return tLinebreak
-
+		goto yystate0
 	}
 	panic("unreachable")
 

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go get -u modernc.org/golex
 //go:generate golex -o=openmetricslex.l.go openmetricslex.l
 
 package textparse

--- a/model/textparse/promlex.l.go
+++ b/model/textparse/promlex.l.go
@@ -92,10 +92,10 @@ yystate2:
 
 yystate3:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyrule3
-	case '\t', ' ':
+	case c == '\t' || c == ' ':
 		goto yystate3
 	}
 
@@ -105,19 +105,19 @@ yystate4:
 
 yystate5:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyrule5
-	case '\t', ' ':
+	case c == '\t' || c == ' ':
 		goto yystate6
 	}
 
 yystate6:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyrule4
-	case '\t', ' ':
+	case c == '\t' || c == ' ':
 		goto yystate6
 	}
 
@@ -137,104 +137,104 @@ yystate8:
 yystate9:
 	c = l.next()
 yystart9:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'H':
+	case c == 'H':
 		goto yystate10
-	case 'T':
+	case c == 'T':
 		goto yystate15
-	case '\t', ' ':
+	case c == '\t' || c == ' ':
 		goto yystate3
 	}
 
 yystate10:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'E':
+	case c == 'E':
 		goto yystate11
 	}
 
 yystate11:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'L':
+	case c == 'L':
 		goto yystate12
 	}
 
 yystate12:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'P':
+	case c == 'P':
 		goto yystate13
 	}
 
 yystate13:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case '\t', ' ':
+	case c == '\t' || c == ' ':
 		goto yystate14
 	}
 
 yystate14:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyrule6
-	case '\t', ' ':
+	case c == '\t' || c == ' ':
 		goto yystate14
 	}
 
 yystate15:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'Y':
+	case c == 'Y':
 		goto yystate16
 	}
 
 yystate16:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'P':
+	case c == 'P':
 		goto yystate17
 	}
 
 yystate17:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'E':
+	case c == 'E':
 		goto yystate18
 	}
 
 yystate18:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case '\t', ' ':
+	case c == '\t' || c == ' ':
 		goto yystate19
 	}
 
 yystate19:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyrule7
-	case '\t', ' ':
+	case c == '\t' || c == ' ':
 		goto yystate19
 	}
 
@@ -389,12 +389,12 @@ yystate35:
 yystate36:
 	c = l.next()
 yystart36:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case '"':
+	case c == '"':
 		goto yystate37
-	case '\t', ' ':
+	case c == '\t' || c == ' ':
 		goto yystate3
 	}
 
@@ -486,7 +486,7 @@ yyrule2: // \n
 	{
 		l.state = sInit
 		return tLinebreak
-
+		goto yystate0
 	}
 yyrule3: // [ \t]+
 	{
@@ -505,49 +505,49 @@ yyrule6: // HELP[\t ]+
 	{
 		l.state = sMeta1
 		return tHelp
-
+		goto yystate0
 	}
 yyrule7: // TYPE[\t ]+
 	{
 		l.state = sMeta1
 		return tType
-
+		goto yystate0
 	}
 yyrule8: // \"(\\.|[^\\"])*\"
 	{
 		l.state = sMeta2
 		return tMName
-
+		goto yystate0
 	}
 yyrule9: // {M}({M}|{D})*
 	{
 		l.state = sMeta2
 		return tMName
-
+		goto yystate0
 	}
 yyrule10: // {C}*
 	{
 		l.state = sInit
 		return tText
-
+		goto yystate0
 	}
 yyrule11: // {M}({M}|{D})*
 	{
 		l.state = sValue
 		return tMName
-
+		goto yystate0
 	}
 yyrule12: // \{
 	{
 		l.state = sLabels
 		return tBraceOpen
-
+		goto yystate0
 	}
 yyrule13: // \{
 	{
 		l.state = sLabels
 		return tBraceOpen
-
+		goto yystate0
 	}
 yyrule14: // {L}({L}|{D})*
 	{
@@ -557,19 +557,19 @@ yyrule15: // \"(\\.|[^\\"])*\"
 	{
 		l.state = sLabels
 		return tQString
-
+		goto yystate0
 	}
 yyrule16: // \}
 	{
 		l.state = sValue
 		return tBraceClose
-
+		goto yystate0
 	}
 yyrule17: // =
 	{
 		l.state = sLValue
 		return tEqual
-
+		goto yystate0
 	}
 yyrule18: // ,
 	{
@@ -579,13 +579,13 @@ yyrule19: // \"(\\.|[^\\"])*\"
 	{
 		l.state = sLabels
 		return tLValue
-
+		goto yystate0
 	}
 yyrule20: // [^{ \t\n]+
 	{
 		l.state = sTimestamp
 		return tValue
-
+		goto yystate0
 	}
 yyrule21: // {D}+
 	{
@@ -595,7 +595,7 @@ yyrule22: // \n
 	if true { // avoid go vet determining the below panic will not be reached
 		l.state = sInit
 		return tLinebreak
-
+		goto yystate0
 	}
 	panic("unreachable")
 

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go get -u modernc.org/golex
 //go:generate golex -o=promlex.l.go promlex.l
 
 package textparse


### PR DESCRIPTION
I am working on a perf PR in #19393 for the textparse lexer, I have noticed the generated code diverged.

So this pins the textparse lexer generator to golex v1.1.0, regenerate both lexer outputs, and will verify them in CI.

Benchmarks are not recording any regression:

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/textparse
cpu: Apple M2 Max
                                        │ base-prom.txt │          after-prom.txt           │
                                        │    sec/op     │   sec/op     vs base              │
ParsePromText/parser=promtext-12            768.0µ ± 0%   772.4µ ± 1%  +0.58% (p=0.009 n=6)
ParsePromText_NoMeta/parser=promtext-12     597.4µ ± 1%   603.7µ ± 3%  +1.06% (p=0.015 n=6)
ParseOMText-12                              32.39µ ± 1%   32.53µ ± 1%       ~ (p=0.100 n=6)
geomean                                     245.9µ        247.6µ       +0.70%

                                        │ base-prom.txt │           after-prom.txt           │
                                        │      B/s      │     B/s       vs base              │
ParsePromText/parser=promtext-12           236.2Mi ± 0%   234.8Mi ± 1%  -0.58% (p=0.009 n=6)
ParsePromText_NoMeta/parser=promtext-12    236.5Mi ± 1%   234.0Mi ± 3%  -1.05% (p=0.015 n=6)
ParseOMText-12                             131.8Mi ± 1%   131.2Mi ± 1%       ~ (p=0.100 n=6)
geomean                                    194.5Mi        193.2Mi       -0.69%

                                        │ base-prom.txt │           after-prom.txt           │
                                        │     B/op      │     B/op      vs base              │
ParsePromText/parser=promtext-12           310.9Ki ± 0%   310.9Ki ± 0%       ~ (p=0.314 n=6)
ParsePromText_NoMeta/parser=promtext-12    303.8Ki ± 0%   303.8Ki ± 0%       ~ (p=0.182 n=6)
ParseOMText-12                             10.88Ki ± 0%   10.88Ki ± 0%       ~ (p=1.000 n=6)
geomean                                    100.9Ki        100.9Ki       +0.00%

                                        │ base-prom.txt │           after-prom.txt            │
                                        │   allocs/op   │  allocs/op   vs base                │
ParsePromText/parser=promtext-12            4.655k ± 0%   4.655k ± 0%       ~ (p=1.000 n=6) ¹
ParsePromText_NoMeta/parser=promtext-12     3.722k ± 0%   3.722k ± 0%       ~ (p=1.000 n=6) ¹
ParseOMText-12                               231.0 ± 0%    231.0 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                     1.588k        1.588k       +0.00%
¹ all samples are equal
```

```release-notes
NONE
```