### PR TITLE
scrape: avoid a full-body copy of every scrape response

### DIFF
--- a/model/textparse/benchmark_test.go
+++ b/model/textparse/benchmark_test.go
@@ -344,8 +344,6 @@ Inner2:
 		 -benchtime 2s -count 6 -cpu 2 -benchmem -timeout 999m \
 	 | tee ${bench}.txt
 */
-// BenchmarkNewPromParser covers the exact-sized case, which is what scrape's
-// buffer pool hands over for bodies past its largest bucket.
 func BenchmarkNewPromParser(b *testing.B) {
 	data := readTestdataFile(b, "alltypes.237mfs.prom.txt")
 	require.Equal(b, byte('\n'), data[len(data)-1])

--- a/model/textparse/benchmark_test.go
+++ b/model/textparse/benchmark_test.go
@@ -337,3 +337,43 @@ Inner2:
 		}
 	})
 }
+
+/*
+	export bench=v1 && go test ./model/textparse/... \
+		 -run '^$' -bench '^BenchmarkNewPromParser' \
+		 -benchtime 2s -count 6 -cpu 2 -benchmem -timeout 999m \
+	 | tee ${bench}.txt
+*/
+// BenchmarkNewPromParser covers the exact-sized case, which is what scrape's
+// buffer pool hands over for bodies past its largest bucket.
+func BenchmarkNewPromParser(b *testing.B) {
+	data := readTestdataFile(b, "alltypes.237mfs.prom.txt")
+	require.Equal(b, byte('\n'), data[len(data)-1])
+
+	for _, tcase := range []struct {
+		name string
+		body []byte
+	}{
+		{name: "exact", body: exactSized(data)},
+		{name: "no-newline", body: exactSized(data[:len(data)-1])},
+		{name: "spare-cap", body: append(make([]byte, 0, len(data)+1), data...)},
+	} {
+		b.Run(tcase.name, func(b *testing.B) {
+			st := labels.NewSymbolTable()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				benchNewParserSink = NewPromParser(tcase.body, st, false)
+			}
+		})
+	}
+}
+
+var benchNewParserSink Parser
+
+func exactSized(b []byte) []byte {
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
+}

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -172,10 +172,20 @@ type PromParser struct {
 // NewPromParser returns a new parser of the byte slice.
 func NewPromParser(b []byte, st *labels.SymbolTable, enableTypeAndUnitLabels bool) Parser {
 	return &PromParser{
-		l:                       &promlexer{b: append(b, '\n')},
+		l:                       &promlexer{b: appendLineTerminator(b)},
 		builder:                 labels.NewScratchBuilderWithSymbolTable(st, 16),
 		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
 	}
+}
+
+// appendLineTerminator gives the lexer the trailing newline it needs to
+// terminate the final entry. Appending unconditionally would copy the whole
+// body when b has no spare capacity, and the copy lives as long as the parser.
+func appendLineTerminator(b []byte) []byte {
+	if len(b) > 0 && b[len(b)-1] == '\n' {
+		return b
+	}
+	return append(b, '\n')
 }
 
 // Series returns the bytes of the series, the timestamp if set, and the value

--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -16,6 +16,7 @@ package textparse
 import (
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -627,4 +628,30 @@ func TestPromNullByteHandling(t *testing.T) {
 
 		require.EqualError(t, err, c.err, "test %d", i)
 	}
+}
+
+func TestPromParserLineTerminator(t *testing.T) {
+	const body = `# HELP go_goroutines Number of goroutines.
+# TYPE go_goroutines gauge
+go_goroutines 33
+`
+	withNewline := []byte(body)
+	withoutNewline := []byte(strings.TrimSuffix(body, "\n"))
+
+	want := testParse(t, NewPromParser(withNewline, labels.NewSymbolTable(), false))
+	require.NotEmpty(t, want)
+	requireEntries(t, want, testParse(t, NewPromParser(withoutNewline, labels.NewSymbolTable(), false)))
+
+	// Same backing array means the body was not copied.
+	exact := make([]byte, len(withNewline))
+	copy(exact, withNewline)
+	p := NewPromParser(exact, labels.NewSymbolTable(), false).(*PromParser)
+	require.Equal(t, &exact[0], &p.l.b[0])
+
+	p = NewPromParser(withoutNewline, labels.NewSymbolTable(), false).(*PromParser)
+	require.Len(t, p.l.b, len(withoutNewline)+1)
+	require.Equal(t, byte('\n'), p.l.b[len(p.l.b)-1])
+
+	p = NewPromParser(nil, labels.NewSymbolTable(), false).(*PromParser)
+	require.Equal(t, []byte("\n"), p.l.b)
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -126,6 +126,11 @@ type labelLimits struct {
 
 const maxAheadTime = 10 * time.Minute
 
+// scrapeBufferSlack avoids copying the whole body at the end of a scrape:
+// bytes.Buffer.ReadFrom reallocates unless this much capacity is spare, and
+// keeping cap > len also lets textparse append its line terminator in place.
+const scrapeBufferSlack = bytes.MinRead
+
 // returning an empty label set is interpreted as "drop".
 type labelsMutator func(labels.Labels) labels.Labels
 
@@ -1462,7 +1467,7 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 	scrapeCtx, cancel := context.WithTimeout(sl.parentCtx, sl.timeout)
 	resp, scrapeErr = sl.scraper.scrape(scrapeCtx)
 	if scrapeErr == nil {
-		b = sl.buffers.Get(sl.lastScrapeSize).([]byte)
+		b = sl.buffers.Get(sl.lastScrapeSize + scrapeBufferSlack).([]byte)
 		defer sl.buffers.Put(b)
 		buf = bytes.NewBuffer(b)
 		contentType, scrapeErr = sl.scraper.readResponse(scrapeCtx, resp, buf)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2644,6 +2644,84 @@ func BenchmarkScrapeLoopScrapeAndReport(b *testing.B) {
 	}
 }
 
+// BenchmarkScrapeLoopLargeBody covers bodies past the pool's largest bucket,
+// where pool.Get stops padding to a bucket size. The test pool tops out at
+// 729000 bytes, so a few MiB is enough to get there.
+func BenchmarkScrapeLoopLargeBody(b *testing.B) {
+	for _, bodySize := range []int{1 << 20, 4 << 20, 16 << 20} {
+		b.Run(fmt.Sprintf("%dMiB", bodySize>>20), func(b *testing.B) {
+			body := makeLargeTextBody(bodySize)
+
+			s := teststorage.New(b)
+			sl, scraper := newTestScrapeLoop(b, withAppendable(s, false), func(sl *scrapeLoop) {
+				sl.fallbackScrapeProtocol = "text/plain"
+			})
+			scraper.scrapeFunc = func(_ context.Context, writer io.Writer) error {
+				_, err := writer.Write(body)
+				return err
+			}
+
+			ts := time.Time{}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				ts = ts.Add(time.Second)
+				sl.scrapeAndReport(time.Time{}, ts, nil)
+				require.NoError(b, scraper.lastError)
+			}
+		})
+	}
+}
+
+// makeLargeTextBody builds an exposition body of at least targetBytes.
+func makeLargeTextBody(targetBytes int) []byte {
+	var sb bytes.Buffer
+	sb.WriteString("# HELP bench_metric Synthetic metric for the large body benchmark.\n")
+	sb.WriteString("# TYPE bench_metric counter\n")
+	for i := 0; sb.Len() < targetBytes; i++ {
+		_, _ = fmt.Fprintf(&sb, "bench_metric{instance=\"i%06d\",shard=\"s%03d\"} %d\n", i, i%512, i)
+	}
+	return sb.Bytes()
+}
+
+// TestScrapeLoopBodyBufferSlack guards the slack that keeps
+// bytes.Buffer.ReadFrom from reallocating and copying the body.
+func TestScrapeLoopBodyBufferSlack(t *testing.T) {
+	for _, bodySize := range []int{
+		1 << 10,
+		729000, // the largest bucket
+		729001, // above it, where pool.Get stops padding to a bucket size
+		2 << 20,
+	} {
+		t.Run(fmt.Sprintf("body=%d", bodySize), func(t *testing.T) {
+			body := makeLargeTextBody(bodySize)
+
+			var gotCap int
+			sl, scraper := newTestScrapeLoop(t, withAppendable(teststorage.NewAppendable(), false), func(sl *scrapeLoop) {
+				sl.fallbackScrapeProtocol = "text/plain"
+			})
+			scraper.scrapeFunc = func(_ context.Context, w io.Writer) error {
+				gotCap = cap(w.(*bytes.Buffer).Bytes())
+				_, err := w.Write(body)
+				return err
+			}
+
+			// The first scrape primes lastScrapeSize.
+			ts := time.Time{}
+			sl.scrapeAndReport(time.Time{}, ts, nil)
+			require.NoError(t, scraper.lastError)
+			require.Equal(t, len(body), sl.lastScrapeSize)
+
+			sl.scrapeAndReport(time.Time{}, ts.Add(time.Second), nil)
+			require.NoError(t, scraper.lastError)
+
+			require.GreaterOrEqual(t, gotCap, len(body)+bytes.MinRead,
+				"scrape read buffer must keep at least bytes.MinRead spare capacity to avoid a full-body copy")
+		})
+	}
+}
+
 func TestSetOptionsHandlingStaleness(t *testing.T) {
 	foreachAppendable(t, func(t *testing.T, appV2 bool) {
 		testSetOptionsHandlingStaleness(t, appV2)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2644,9 +2644,6 @@ func BenchmarkScrapeLoopScrapeAndReport(b *testing.B) {
 	}
 }
 
-// BenchmarkScrapeLoopLargeBody covers bodies past the pool's largest bucket,
-// where pool.Get stops padding to a bucket size. The test pool tops out at
-// 729000 bytes, so a few MiB is enough to get there.
 func BenchmarkScrapeLoopLargeBody(b *testing.B) {
 	for _, bodySize := range []int{1 << 20, 4 << 20, 16 << 20} {
 		b.Run(fmt.Sprintf("%dMiB", bodySize>>20), func(b *testing.B) {
@@ -2690,8 +2687,8 @@ func makeLargeTextBody(targetBytes int) []byte {
 func TestScrapeLoopBodyBufferSlack(t *testing.T) {
 	for _, bodySize := range []int{
 		1 << 10,
-		729000, // the largest bucket
-		729001, // above it, where pool.Get stops padding to a bucket size
+		729000, // The largest bucket.
+		729001, // Above it, where pool.Get stops padding to a bucket size.
 		2 << 20,
 	} {
 		t.Run(fmt.Sprintf("body=%d", bodySize), func(t *testing.T) {


### PR DESCRIPTION
Avoid a full-body copy when checking for EOF or appending a redundant parser newline.

Fixes prometheus/prometheus#19395.

## Benchmarks

Production baseline: `6a8453ce4`. Candidate production code: `6e69d6efa`. The gzip benchmark was measured with the same harness-only response-body cleanup on both sides (`f5c7cf38d`); that cleanup is not part of the final code diff.

Go 1.26.1, darwin/arm64, Apple M4 Pro. Six paired runs, alternating order, with `-benchtime=500ms -count=1 -benchmem -cpu=2 -p=1`.

All 100 original cases are included, plus five added scenarios. Original benchmark setup is preserved except for closing HTTP responses in `BenchmarkTargetScraperGzip`, which previously failed the leak check. Added scenarios use the PR harness with a 190,191-byte fixture and a smaller pool to exercise the unpooled path.

One existing text-format append case measures about 2% slower in this run. All timings and allocations are retained below; this is not a claim that every workload improves.

<details>
<summary>Complete before/after comparison</summary>

```text
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/textparse
cpu: Apple M4 Pro
                                                  │   baseline   │             candidate              │
                                                  │    sec/op    │    sec/op     vs base              │
ParsePromText/parser=promtext-2                     567.4µ ±  6%   570.5µ ±  9%       ~ (p=0.818 n=6)
ParsePromText/parser=omtext-2                       44.59m ±  6%   44.86m ±  3%       ~ (p=0.937 n=6)
ParsePromText/parser=expfmt-promtext-2              2.455m ±  5%   2.483m ±  5%       ~ (p=0.818 n=6)
ParsePromText_NoMeta/parser=promtext-2              431.5µ ±  5%   439.6µ ± 10%       ~ (p=0.132 n=6)
ParsePromText_NoMeta/parser=expfmt-promtext-2       1.764m ±  2%   1.748m ±  7%       ~ (p=0.589 n=6)
ParseOMText-2                                       22.98µ ±  1%   23.01µ ±  7%       ~ (p=0.937 n=6)
ParseOM2Text-2                                      14.00µ ±  3%   14.14µ ±  4%       ~ (p=1.000 n=6)
ParseOM1VsOM2_AllTypes/parser=omtext-2              238.9µ ±  3%   237.7µ ±  2%       ~ (p=0.485 n=6)
ParseOM1VsOM2_AllTypes/parser=om2text-2             32.68µ ±  5%   32.76µ ±  3%       ~ (p=0.937 n=6)
ParseOM1VsOM2_CT/parser=omtext-2                    35.29µ ±  2%   35.38µ ± 10%       ~ (p=1.000 n=6)
ParseOM1VsOM2_CT/parser=om2text-2                   17.19µ ±  3%   17.08µ ± 15%       ~ (p=1.000 n=6)
ParseOM1VsOM2_Histograms/parser=omtext-2            384.0µ ±  1%   387.0µ ±  5%       ~ (p=0.818 n=6)
ParseOM1VsOM2_Histograms/parser=om2text-2           34.90µ ±  4%   34.39µ ±  9%       ~ (p=0.699 n=6)
ParsePromProto-2                                    15.81µ ±  6%   16.00µ ±  9%       ~ (p=0.937 n=6)
ParseOpenMetricsNHCB/parser=omtext-2                164.5µ ±  3%   166.4µ ±  3%       ~ (p=0.937 n=6)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-2      20.19µ ± 21%   20.54µ ±  9%       ~ (p=0.937 n=6)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-2   34.64µ ±  3%   35.17µ ±  5%       ~ (p=0.394 n=6)
StartTimestampPromProto/case=no-ct-2                1.740n ±  2%   1.740n ±  3%       ~ (p=0.615 n=6)
StartTimestampPromProto/case=ct-2                   1.797n ±  1%   1.801n ±  3%       ~ (p=0.667 n=6)
ParsePromText/parser=promtext-exact-2               583.6µ ±  4%   570.7µ ±  5%       ~ (p=0.240 n=6)
geomean                                             47.35µ         47.50µ        +0.32%

                                                  │    baseline    │               candidate               │
                                                  │      B/op      │     B/op      vs base                 │
ParsePromText/parser=promtext-2                     310.7Ki ± 0%     310.7Ki ± 0%        ~ (p=0.777 n=6)
ParsePromText/parser=omtext-2                       579.9Ki ± 0%     579.9Ki ± 0%        ~ (p=0.227 n=6)
ParsePromText/parser=expfmt-promtext-2              2.342Mi ± 0%     2.342Mi ± 0%        ~ (p=0.732 n=6)
ParsePromText_NoMeta/parser=promtext-2              303.8Ki ± 0%     303.8Ki ± 0%        ~ (p=0.361 n=6)
ParsePromText_NoMeta/parser=expfmt-promtext-2       1.705Mi ± 0%     1.705Mi ± 0%        ~ (p=0.210 n=6)
ParseOMText-2                                       10.88Ki ± 0%     10.88Ki ± 0%        ~ (p=1.000 n=6) ¹
ParseOM2Text-2                                      9.657Ki ± 0%     9.657Ki ± 0%        ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_AllTypes/parser=omtext-2              28.07Ki ± 0%     28.07Ki ± 0%        ~ (p=0.567 n=6)
ParseOM1VsOM2_AllTypes/parser=om2text-2             19.24Ki ± 0%     19.24Ki ± 0%        ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_CT/parser=omtext-2                    13.99Ki ± 0%     13.99Ki ± 0%        ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_CT/parser=om2text-2                   12.97Ki ± 0%     12.97Ki ± 0%        ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_Histograms/parser=omtext-2            39.19Ki ± 0%     39.19Ki ± 0%        ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_Histograms/parser=om2text-2           24.75Ki ± 0%     24.75Ki ± 0%        ~ (p=1.000 n=6)
ParsePromProto-2                                    19.63Ki ± 0%     19.63Ki ± 0%        ~ (p=1.000 n=6) ¹
ParseOpenMetricsNHCB/parser=omtext-2                22.39Ki ± 0%     22.39Ki ± 0%        ~ (p=1.000 n=6) ¹
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-2      13.99Ki ± 0%     13.99Ki ± 0%        ~ (p=0.455 n=6)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-2   14.89Ki ± 0%     14.89Ki ± 0%        ~ (p=0.545 n=6)
StartTimestampPromProto/case=no-ct-2                  0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
StartTimestampPromProto/case=ct-2                     0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ParsePromText/parser=promtext-exact-2               550.8Ki ± 0%     310.7Ki ± 0%  -43.58% (p=0.002 n=6)
geomean                                                          ²                  -2.82%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                  │   baseline    │              candidate              │
                                                  │   allocs/op   │  allocs/op   vs base                │
ParsePromText/parser=promtext-2                     4.655k ± 0%     4.655k ± 0%       ~ (p=1.000 n=6) ¹
ParsePromText/parser=omtext-2                       10.82k ± 0%     10.82k ± 0%       ~ (p=1.000 n=6)
ParsePromText/parser=expfmt-promtext-2              54.83k ± 0%     54.83k ± 0%       ~ (p=0.455 n=6)
ParsePromText_NoMeta/parser=promtext-2              3.722k ± 0%     3.722k ± 0%       ~ (p=1.000 n=6) ¹
ParsePromText_NoMeta/parser=expfmt-promtext-2       45.71k ± 0%     45.71k ± 0%       ~ (p=1.000 n=6) ¹
ParseOMText-2                                        231.0 ± 0%      231.0 ± 0%       ~ (p=1.000 n=6) ¹
ParseOM2Text-2                                       232.0 ± 0%      232.0 ± 0%       ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_AllTypes/parser=omtext-2               794.0 ± 0%      794.0 ± 0%       ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_AllTypes/parser=om2text-2              415.0 ± 0%      415.0 ± 0%       ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_CT/parser=omtext-2                     409.0 ± 0%      409.0 ± 0%       ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_CT/parser=om2text-2                    224.0 ± 0%      224.0 ± 0%       ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_Histograms/parser=omtext-2             935.0 ± 0%      935.0 ± 0%       ~ (p=1.000 n=6) ¹
ParseOM1VsOM2_Histograms/parser=om2text-2            480.0 ± 0%      480.0 ± 0%       ~ (p=1.000 n=6) ¹
ParsePromProto-2                                     383.0 ± 0%      383.0 ± 0%       ~ (p=1.000 n=6) ¹
ParseOpenMetricsNHCB/parser=omtext-2                 375.0 ± 0%      375.0 ± 0%       ~ (p=1.000 n=6) ¹
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-2       163.0 ± 0%      163.0 ± 0%       ~ (p=1.000 n=6) ¹
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-2    181.0 ± 0%      181.0 ± 0%       ~ (p=1.000 n=6) ¹
StartTimestampPromProto/case=no-ct-2                 0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
StartTimestampPromProto/case=ct-2                    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
ParsePromText/parser=promtext-exact-2               4.656k ± 0%     4.655k ± 0%  -0.02% (p=0.002 n=6)
geomean                                                         ²                -0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                  │   baseline    │              candidate              │
                                                  │      B/s      │      B/s       vs base              │
ParsePromText/parser=promtext-2                     319.6Mi ±  6%   318.0Mi ±  8%       ~ (p=0.818 n=6)
ParsePromText/parser=omtext-2                       4.067Mi ±  5%   4.044Mi ±  3%       ~ (p=0.777 n=6)
ParsePromText/parser=expfmt-promtext-2              73.88Mi ±  4%   73.05Mi ±  5%       ~ (p=0.818 n=6)
ParsePromText_NoMeta/parser=promtext-2              327.3Mi ±  5%   321.3Mi ±  9%       ~ (p=0.132 n=6)
ParsePromText_NoMeta/parser=expfmt-promtext-2       80.06Mi ±  2%   80.80Mi ±  7%       ~ (p=0.589 n=6)
ParseOMText-2                                       185.8Mi ±  1%   185.6Mi ±  6%       ~ (p=0.937 n=6)
ParseOM2Text-2                                      184.2Mi ±  3%   182.6Mi ±  4%       ~ (p=1.000 n=6)
ParseOM1VsOM2_AllTypes/parser=omtext-2              42.32Mi ±  3%   42.54Mi ±  2%       ~ (p=0.485 n=6)
ParseOM1VsOM2_AllTypes/parser=om2text-2             187.6Mi ±  5%   187.1Mi ±  3%       ~ (p=0.937 n=6)
ParseOM1VsOM2_CT/parser=omtext-2                    164.6Mi ±  2%   164.2Mi ±  9%       ~ (p=1.000 n=6)
ParseOM1VsOM2_CT/parser=om2text-2                   152.6Mi ±  3%   153.6Mi ± 13%       ~ (p=1.000 n=6)
ParseOM1VsOM2_Histograms/parser=omtext-2            24.70Mi ±  1%   24.50Mi ±  5%       ~ (p=0.818 n=6)
ParseOM1VsOM2_Histograms/parser=om2text-2           90.13Mi ±  4%   91.48Mi ±  8%       ~ (p=0.667 n=6)
ParsePromProto-2                                    233.6Mi ±  5%   230.9Mi ±  8%       ~ (p=0.937 n=6)
ParseOpenMetricsNHCB/parser=omtext-2                24.29Mi ±  3%   24.03Mi ±  3%       ~ (p=0.937 n=6)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-2      197.9Mi ± 17%   194.6Mi ±  8%       ~ (p=0.937 n=6)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-2   115.4Mi ±  3%   113.6Mi ±  5%       ~ (p=0.394 n=6)
ParsePromText/parser=promtext-exact-2               310.8Mi ±  4%   317.9Mi ±  5%       ~ (p=0.240 n=6)
geomean                                             102.4Mi         102.1Mi        -0.33%

pkg: github.com/prometheus/prometheus/scrape
                                                                                                              │   baseline   │             candidate              │
                                                                                                              │    sec/op    │    sec/op     vs base              │
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2     302.8µ ±  4%   301.1µ ±  3%       ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2       299.1µ ±  2%   298.0µ ±  4%       ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2    375.4µ ±  4%   376.4µ ±  4%       ~ (p=0.937 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2    493.2µ ±  1%   497.9µ ±  2%       ~ (p=0.310 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2      500.4µ ±  4%   510.0µ ±  4%       ~ (p=0.937 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2   429.5µ ±  4%   422.8µ ±  5%       ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2      296.5µ ±  3%   296.4µ ±  5%       ~ (p=0.699 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2        297.9µ ±  2%   296.3µ ±  3%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2     375.1µ ±  3%   369.1µ ±  9%       ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2     492.9µ ±  3%   497.6µ ±  3%       ~ (p=0.394 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2       504.6µ ±  4%   502.5µ ±  5%       ~ (p=0.937 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2    429.1µ ±  5%   419.9µ ±  6%       ~ (p=0.589 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2      306.1µ ±  4%   303.1µ ±  3%       ~ (p=0.699 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2        308.0µ ±  3%   306.0µ ±  2%       ~ (p=0.589 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2     386.2µ ±  3%   384.2µ ±  2%       ~ (p=0.937 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2     502.3µ ±  4%   512.1µ ±  2%  +1.96% (p=0.041 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2       44.85m ±  7%   44.78m ±  1%       ~ (p=0.699 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2    430.2µ ±  3%   426.9µ ±  2%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2       314.6µ ±  2%   315.7µ ±  2%       ~ (p=0.485 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2         322.9µ ±  3%   318.9µ ±  1%       ~ (p=0.180 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2      385.8µ ±  3%   386.3µ ±  2%       ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2      513.3µ ±  3%   517.7µ ±  3%       ~ (p=0.310 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2        44.91m ±  3%   44.51m ±  3%       ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2     440.8µ ±  4%   438.6µ ±  3%       ~ (p=0.937 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2      321.4µ ±  3%   316.1µ ±  5%       ~ (p=0.699 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2        322.1µ ±  2%   322.9µ ±  3%       ~ (p=0.699 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2     389.4µ ±  2%   383.6µ ±  4%       ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2     495.6µ ±  3%   497.9µ ±  2%       ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2       504.3µ ±  2%   505.0µ ±  3%       ~ (p=0.699 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2    435.5µ ±  3%   431.8µ ±  2%       ~ (p=0.589 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2       322.0µ ±  3%   320.3µ ±  2%       ~ (p=0.589 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2         323.6µ ±  3%   325.8µ ±  2%       ~ (p=0.093 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2      390.2µ ±  2%   390.0µ ±  8%       ~ (p=0.699 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2      499.0µ ±  3%   503.8µ ±  3%       ~ (p=0.240 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2        512.0µ ±  4%   504.6µ ±  2%       ~ (p=0.699 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2     433.6µ ±  3%   434.5µ ±  4%       ~ (p=0.937 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2       336.1µ ±  2%   336.7µ ±  3%       ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2         342.3µ ±  2%   340.2µ ±  4%       ~ (p=0.937 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2      403.6µ ±  3%   401.7µ ±  4%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2      514.1µ ±  2%   520.2µ ±  3%       ~ (p=0.240 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2        44.73m ±  3%   45.50m ±  4%       ~ (p=0.394 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2     450.2µ ±  2%   448.4µ ±  3%       ~ (p=0.485 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2        362.1µ ±  2%   365.0µ ±  3%       ~ (p=0.485 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2          372.8µ ±  2%   368.1µ ±  3%       ~ (p=0.180 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2       437.0µ ±  2%   434.0µ ±  2%       ~ (p=0.589 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2       545.3µ ±  2%   553.1µ ±  3%       ~ (p=0.180 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2         44.85m ±  2%   44.86m ±  2%       ~ (p=0.937 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2      479.6µ ±  2%   478.7µ ±  2%       ~ (p=0.589 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Counters-2                            407.8µ ±  2%   406.5µ ±  2%       ~ (p=0.937 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Histograms-2                          1.158m ±  2%   1.152m ±  4%       ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100IntHistograms-2                       1.530m ±  2%   1.495m ±  5%       ~ (p=0.394 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100FloatHistograms-2                     28.41µ ±  2%   28.38µ ±  4%       ~ (p=0.818 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=237FamsAllTypes-2                        5.717m ±  5%   5.672m ±  2%       ~ (p=0.310 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Counters-2                             411.0µ ±  4%   409.0µ ±  2%       ~ (p=0.699 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Histograms-2                           1.160m ±  2%   1.165m ±  2%       ~ (p=0.937 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100IntHistograms-2                        1.508m ±  1%   1.509m ±  2%       ~ (p=0.818 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100FloatHistograms-2                      45.28µ ±  3%   45.71µ ±  2%       ~ (p=0.485 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=237FamsAllTypes-2                         5.767m ±  4%   5.777m ±  2%       ~ (p=0.937 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Counters-2                             412.2µ ±  1%   408.5µ ±  1%       ~ (p=0.394 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Histograms-2                           1.242m ±  5%   1.215m ±  4%       ~ (p=0.180 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100IntHistograms-2                        1.547m ±  1%   1.542m ±  2%       ~ (p=0.589 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100FloatHistograms-2                      31.24µ ±  2%   31.20µ ±  1%       ~ (p=0.589 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=237FamsAllTypes-2                         5.736m ±  1%   5.668m ±  4%       ~ (p=0.240 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Counters-2                              411.9µ ±  2%   407.7µ ±  2%       ~ (p=0.589 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Histograms-2                            1.236m ±  2%   1.229m ±  7%       ~ (p=0.485 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100IntHistograms-2                         1.549m ±  1%   1.538m ±  1%       ~ (p=0.240 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100FloatHistograms-2                       48.75µ ±  5%   48.71µ ±  2%       ~ (p=0.699 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=237FamsAllTypes-2                          5.788m ±  2%   5.829m ±  2%       ~ (p=0.394 n=6)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=false-2                                                          797.3µ ±  2%   801.2µ ±  3%       ~ (p=0.818 n=6)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=true-2                                                           1.247m ± 11%   1.231m ±  6%       ~ (p=0.310 n=6)
ScrapeLoopScrapeAndReport/appV2=false-2                                                                         581.3µ ±  7%   584.1µ ±  3%       ~ (p=0.937 n=6)
ScrapeLoopScrapeAndReport/appV2=true-2                                                                          45.36m ±  3%   44.83m ±  2%       ~ (p=0.310 n=6)
TargetScraperGzip/metrics=1-2                                                                                   172.0µ ±  6%   170.4µ ±  4%       ~ (p=0.310 n=6)
TargetScraperGzip/metrics=100-2                                                                                 169.6µ ±  5%   168.7µ ±  4%       ~ (p=0.818 n=6)
TargetScraperGzip/metrics=1000-2                                                                                172.5µ ±  6%   171.0µ ±  5%       ~ (p=0.589 n=6)
TargetScraperGzip/metrics=10000-2                                                                               173.7µ ±  3%   171.0µ ±  6%       ~ (p=0.310 n=6)
TargetScraperGzip/metrics=100000-2                                                                              181.5µ ±  3%   183.7µ ±  4%       ~ (p=0.310 n=6)
ScrapePoolRestartLoops-2                                                                                        1.790m ± 15%   1.741m ± 26%       ~ (p=0.699 n=6)
TargetsFromGroup/1_targets-2                                                                                    4.812µ ±  7%   4.903µ ±  3%       ~ (p=0.485 n=6)
TargetsFromGroup/10_targets-2                                                                                   59.39µ ±  7%   59.85µ ±  5%       ~ (p=0.937 n=6)
TargetsFromGroup/100_targets-2                                                                                  665.2µ ±  8%   671.1µ ±  4%       ~ (p=0.937 n=6)
ScrapeLoopScrapeAndReport/appV2=false/pooled=true-2                                                             585.8µ ±  2%   595.9µ ±  3%       ~ (p=0.589 n=6)
ScrapeLoopScrapeAndReport/appV2=false/pooled=false-2                                                            620.0µ ±  5%   596.3µ ±  2%  -3.82% (p=0.002 n=6)
ScrapeLoopScrapeAndReport/appV2=true/pooled=true-2                                                              45.07m ±  1%   45.32m ±  3%       ~ (p=0.485 n=6)
ScrapeLoopScrapeAndReport/appV2=true/pooled=false-2                                                             44.95m ±  1%   45.22m ±  8%       ~ (p=0.818 n=6)
geomean                                                                                                         629.8µ         628.2µ        -0.25%

                                                                                                              │   baseline    │               candidate                │
                                                                                                              │     B/op      │     B/op       vs base                 │
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2      1.649Ki ± 1%   1.653Ki ±  2%        ~ (p=0.968 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2        1.788Ki ± 1%   1.787Ki ±  1%        ~ (p=0.777 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2     110.2Ki ± 0%   110.2Ki ±  0%        ~ (p=0.132 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2     2.407Ki ± 2%   2.421Ki ±  2%        ~ (p=0.394 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2       2.572Ki ± 1%   2.565Ki ±  3%        ~ (p=0.848 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2    73.81Ki ± 0%   73.84Ki ±  0%        ~ (p=0.056 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2       1.649Ki ± 1%   1.645Ki ±  2%        ~ (p=0.727 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2         1.791Ki ± 1%   1.789Ki ±  0%        ~ (p=0.968 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2      110.2Ki ± 0%   110.2Ki ±  0%        ~ (p=0.699 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2      2.397Ki ± 2%   2.395Ki ±  2%        ~ (p=0.615 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2        2.560Ki ± 1%   2.594Ki ±  5%        ~ (p=0.223 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2     73.82Ki ± 0%   73.81Ki ±  0%        ~ (p=0.848 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2       1.705Ki ± 1%   1.704Ki ±  1%        ~ (p=0.788 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2         1.854Ki ± 1%   1.845Ki ±  4%        ~ (p=0.394 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2      110.3Ki ± 0%   110.3Ki ±  0%        ~ (p=0.461 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2      2.466Ki ± 2%   2.492Ki ±  2%   +1.07% (p=0.037 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2        358.1Ki ± 1%   358.1Ki ±  1%        ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2     73.86Ki ± 0%   73.86Ki ±  0%        ~ (p=0.909 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2        1.715Ki ± 1%   1.716Ki ±  1%        ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2          1.865Ki ± 1%   1.861Ki ±  1%        ~ (p=0.394 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2       110.3Ki ± 0%   110.3Ki ±  0%        ~ (p=0.251 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2       2.490Ki ± 3%   2.491Ki ±  2%        ~ (p=0.729 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2         354.5Ki ± 1%   361.6Ki ±  2%   +2.02% (p=0.019 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2      73.88Ki ± 0%   73.87Ki ±  0%        ~ (p=0.818 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2       3.690Ki ± 3%   3.679Ki ±  2%        ~ (p=0.589 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2         3.809Ki ± 1%   3.799Ki ±  3%        ~ (p=0.937 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2      112.9Ki ± 0%   112.7Ki ±  0%        ~ (p=0.132 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2      4.756Ki ± 3%   4.819Ki ±  4%        ~ (p=0.589 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2        4.875Ki ± 2%   4.928Ki ±  2%        ~ (p=0.169 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2     76.02Ki ± 0%   75.96Ki ±  0%        ~ (p=0.331 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2        3.809Ki ± 2%   3.811Ki ±  2%        ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2          3.952Ki ± 2%   3.936Ki ±  2%        ~ (p=0.970 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2       112.9Ki ± 0%   113.1Ki ±  0%        ~ (p=0.093 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2       5.016Ki ± 3%   5.036Ki ±  3%        ~ (p=0.329 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2         5.185Ki ± 3%   5.162Ki ±  2%        ~ (p=0.853 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2      76.18Ki ± 0%   76.15Ki ±  0%        ~ (p=0.554 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2        3.815Ki ± 2%   3.848Ki ±  2%        ~ (p=0.331 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2          3.985Ki ± 2%   3.966Ki ±  9%        ~ (p=0.513 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2       113.1Ki ± 0%   113.0Ki ±  0%        ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2       4.913Ki ± 5%   5.017Ki ± 10%        ~ (p=0.180 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2         556.3Ki ± 0%   556.3Ki ±  4%        ~ (p=0.519 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2      76.10Ki ± 0%   76.07Ki ±  0%        ~ (p=0.288 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2         4.179Ki ± 2%   4.202Ki ± 10%        ~ (p=0.511 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2           4.353Ki ± 8%   4.338Ki ±  2%        ~ (p=0.699 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2        113.2Ki ± 1%   113.6Ki ±  1%        ~ (p=0.180 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2        5.410Ki ± 2%   5.455Ki ±  3%        ~ (p=0.485 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2          581.3Ki ± 1%   581.4Ki ±  0%        ~ (p=0.240 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2       76.50Ki ± 1%   76.52Ki ±  0%        ~ (p=0.937 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Counters-2                             13.12Ki ± 0%   13.12Ki ±  0%        ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Histograms-2                           243.8Ki ± 0%   243.8Ki ±  0%        ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100IntHistograms-2                        617.4Ki ± 0%   617.4Ki ±  0%        ~ (p=0.245 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100FloatHistograms-2                      22.17Ki ± 0%   22.17Ki ±  0%        ~ (p=1.000 n=6) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=237FamsAllTypes-2                         499.1Ki ± 0%   499.1Ki ±  0%        ~ (p=0.251 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Counters-2                              13.13Ki ± 0%   13.13Ki ±  0%        ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Histograms-2                            243.8Ki ± 0%   243.8Ki ±  0%        ~ (p=0.331 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100IntHistograms-2                         617.4Ki ± 0%   617.4Ki ±  0%        ~ (p=0.210 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100FloatHistograms-2                       40.13Ki ± 0%   40.13Ki ±  0%        ~ (p=1.000 n=6) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=237FamsAllTypes-2                          564.6Ki ± 0%   564.6Ki ±  0%        ~ (p=0.446 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Counters-2                              13.64Ki ± 1%   13.63Ki ±  0%        ~ (p=0.288 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Histograms-2                            250.5Ki ± 0%   250.4Ki ±  0%        ~ (p=0.240 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100IntHistograms-2                         618.9Ki ± 0%   618.9Ki ±  0%        ~ (p=0.701 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100FloatHistograms-2                       22.54Ki ± 0%   22.55Ki ±  0%        ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=237FamsAllTypes-2                          510.5Ki ± 0%   510.1Ki ±  0%        ~ (p=0.132 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Counters-2                               13.64Ki ± 0%   13.63Ki ±  1%        ~ (p=0.292 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Histograms-2                             250.6Ki ± 0%   250.8Ki ±  1%        ~ (p=0.589 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100IntHistograms-2                          618.9Ki ± 0%   619.0Ki ±  0%        ~ (p=0.818 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100FloatHistograms-2                        40.55Ki ± 0%   40.55Ki ±  0%        ~ (p=0.970 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=237FamsAllTypes-2                           574.0Ki ± 0%   573.6Ki ±  0%        ~ (p=0.132 n=6)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=false-2                                                           137.1Ki ± 1%   137.2Ki ±  0%        ~ (p=0.623 n=6)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=true-2                                                            250.5Ki ± 0%   250.5Ki ±  0%        ~ (p=0.818 n=6)
ScrapeLoopScrapeAndReport/appV2=false-2                                                                          13.19Ki ± 2%   13.27Ki ±  3%        ~ (p=0.589 n=6)
ScrapeLoopScrapeAndReport/appV2=true-2                                                                           645.8Ki ± 1%   645.8Ki ±  1%        ~ (p=0.855 n=6)
TargetScraperGzip/metrics=1-2                                                                                    25.13Ki ± 0%   25.13Ki ±  0%        ~ (p=0.740 n=6)
TargetScraperGzip/metrics=100-2                                                                                  25.52Ki ± 0%   25.52Ki ±  0%   +0.01% (p=0.045 n=6)
TargetScraperGzip/metrics=1000-2                                                                                 26.12Ki ± 0%   26.12Ki ±  0%        ~ (p=0.853 n=6)
TargetScraperGzip/metrics=10000-2                                                                                26.55Ki ± 0%   26.56Ki ±  0%        ~ (p=0.913 n=6)
TargetScraperGzip/metrics=100000-2                                                                               27.13Ki ± 0%   27.13Ki ±  0%        ~ (p=0.848 n=6)
ScrapePoolRestartLoops-2                                                                                         1.887Mi ± 0%   1.887Mi ±  0%        ~ (p=0.240 n=6)
TargetsFromGroup/1_targets-2                                                                                     1.181Ki ± 0%   1.181Ki ±  0%        ~ (p=1.000 n=6) ¹
TargetsFromGroup/10_targets-2                                                                                    11.80Ki ± 0%   11.80Ki ±  0%        ~ (p=1.000 n=6)
TargetsFromGroup/100_targets-2                                                                                   118.1Ki ± 0%   118.0Ki ±  0%        ~ (p=0.725 n=6)
ScrapeLoopScrapeAndReport/appV2=false/pooled=true-2                                                              13.80Ki ± 4%   14.11Ki ±  7%        ~ (p=0.699 n=6)
ScrapeLoopScrapeAndReport/appV2=false/pooled=false-2                                                             584.3Ki ± 0%   206.3Ki ±  0%  -64.69% (p=0.002 n=6)
ScrapeLoopScrapeAndReport/appV2=true/pooled=true-2                                                               670.2Ki ± 1%   666.7Ki ±  4%        ~ (p=0.310 n=6)
ScrapeLoopScrapeAndReport/appV2=true/pooled=false-2                                                             1177.4Ki ± 1%   824.1Ki ±  1%  -30.01% (p=0.002 n=6)
geomean                                                                                                          33.12Ki        32.62Ki         -1.50%
¹ all samples are equal

                                                                                                              │  baseline   │              candidate              │
                                                                                                              │  allocs/op  │  allocs/op   vs base                │
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2      17.00 ± 0%    17.00 ± 6%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2        18.00 ± 6%    18.00 ± 6%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2     32.50 ± 2%    32.00 ± 0%       ~ (p=0.182 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2     21.00 ± 0%    21.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2       22.00 ± 5%    22.00 ± 5%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2   2.236k ± 0%   2.236k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2       17.00 ± 6%    17.00 ± 6%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2         18.00 ± 6%    18.00 ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2      32.00 ± 0%    32.00 ± 3%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2      21.00 ± 0%    21.00 ± 5%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2        22.00 ± 0%    22.50 ± 7%       ~ (p=0.182 n=6)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2    2.236k ± 0%   2.236k ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2       18.00 ± 0%    18.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2         19.00 ± 0%    19.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2      33.00 ± 3%    33.00 ± 3%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2      22.00 ± 0%    22.50 ± 2%       ~ (p=0.182 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2       6.915k ± 0%   6.915k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2    2.237k ± 0%   2.237k ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2        18.00 ± 0%    18.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2          19.00 ± 0%    19.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2       34.00 ± 3%    34.00 ± 3%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2       23.00 ± 4%    23.00 ± 4%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2        6.886k ± 1%   6.945k ± 1%  +0.86% (p=0.048 n=6)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2     2.237k ± 0%   2.237k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2       27.00 ± 0%    27.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2         28.00 ± 0%    28.00 ± 4%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2      44.00 ± 5%    44.00 ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2      32.00 ± 0%    32.00 ± 3%       ~ (p=0.455 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2        33.00 ± 0%    33.00 ± 3%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2    2.246k ± 0%   2.246k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2        27.00 ± 0%    27.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2          28.00 ± 0%    28.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2       44.00 ± 0%    44.00 ± 2%       ~ (p=0.455 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2       32.00 ± 0%    32.00 ± 3%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2         33.00 ± 0%    33.00 ± 3%       ~ (p=0.455 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2     2.246k ± 0%   2.246k ± 0%       ~ (p=0.455 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2        28.50 ± 2%    29.00 ± 3%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-2          29.50 ± 2%    29.50 ± 2%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-2       46.00 ± 2%    45.00 ± 2%       ~ (p=0.567 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2       33.00 ± 3%    34.00 ± 3%       ~ (p=0.177 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2        7.682k ± 0%   7.682k ± 1%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2     2.248k ± 0%   2.248k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-2         29.50 ± 2%    29.50 ± 8%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-2           31.00 ± 3%    30.00 ± 3%       ~ (p=0.567 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-2        46.00 ± 2%    47.00 ± 2%       ~ (p=0.567 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-2        35.00 ± 3%    35.00 ± 3%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-2         7.683k ± 0%   7.683k ± 0%       ~ (p=0.991 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-2      2.248k ± 0%   2.248k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Counters-2                             414.0 ± 0%    414.0 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Histograms-2                          4.838k ± 0%   4.838k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100IntHistograms-2                       10.03k ± 0%   10.03k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100FloatHistograms-2                      326.0 ± 0%    326.0 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=237FamsAllTypes-2                        7.764k ± 0%   7.764k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Counters-2                              414.0 ± 0%    414.0 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Histograms-2                           4.838k ± 0%   4.838k ± 0%       ~ (p=0.545 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100IntHistograms-2                        10.03k ± 0%   10.03k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100FloatHistograms-2                       626.0 ± 0%    626.0 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=237FamsAllTypes-2                         8.702k ± 0%   8.702k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Counters-2                              417.0 ± 0%    417.0 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Histograms-2                           4.864k ± 0%   4.864k ± 0%       ~ (p=0.448 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100IntHistograms-2                        10.04k ± 0%   10.04k ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100FloatHistograms-2                       329.0 ± 0%    329.0 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=237FamsAllTypes-2                         7.813k ± 0%   7.811k ± 0%       ~ (p=0.145 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Counters-2                               417.0 ± 0%    417.0 ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Histograms-2                            4.865k ± 0%   4.865k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100IntHistograms-2                         10.04k ± 0%   10.04k ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100FloatHistograms-2                        629.0 ± 0%    629.0 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=237FamsAllTypes-2                          8.750k ± 0%   8.748k ± 0%       ~ (p=0.201 n=6)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=false-2                                                          2.449k ± 0%   2.449k ± 0%       ~ (p=0.636 n=6)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=true-2                                                           4.864k ± 0%   4.864k ± 0%       ~ (p=0.870 n=6)
ScrapeLoopScrapeAndReport/appV2=false-2                                                                          141.0 ± 1%    141.5 ± 2%       ~ (p=0.563 n=6)
ScrapeLoopScrapeAndReport/appV2=true-2                                                                          8.503k ± 0%   8.503k ± 0%       ~ (p=0.864 n=6)
TargetScraperGzip/metrics=1-2                                                                                    154.0 ± 0%    154.0 ± 0%       ~ (p=1.000 n=6) ¹
TargetScraperGzip/metrics=100-2                                                                                  159.0 ± 0%    159.0 ± 0%       ~ (p=1.000 n=6) ¹
TargetScraperGzip/metrics=1000-2                                                                                 168.0 ± 0%    168.0 ± 0%       ~ (p=1.000 n=6) ¹
TargetScraperGzip/metrics=10000-2                                                                                172.0 ± 0%    172.0 ± 0%       ~ (p=1.000 n=6) ¹
TargetScraperGzip/metrics=100000-2                                                                               178.0 ± 0%    178.0 ± 0%       ~ (p=1.000 n=6) ¹
ScrapePoolRestartLoops-2                                                                                        28.01k ± 0%   28.00k ± 0%       ~ (p=0.545 n=6)
TargetsFromGroup/1_targets-2                                                                                     36.00 ± 0%    36.00 ± 0%       ~ (p=1.000 n=6) ¹
TargetsFromGroup/10_targets-2                                                                                    360.0 ± 0%    360.0 ± 0%       ~ (p=1.000 n=6) ¹
TargetsFromGroup/100_targets-2                                                                                  3.600k ± 0%   3.600k ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopScrapeAndReport/appV2=false/pooled=true-2                                                              143.0 ± 3%    143.5 ± 4%       ~ (p=0.872 n=6)
ScrapeLoopScrapeAndReport/appV2=false/pooled=false-2                                                             147.5 ± 3%    146.0 ± 2%       ~ (p=0.318 n=6)
ScrapeLoopScrapeAndReport/appV2=true/pooled=true-2                                                              8.506k ± 0%   8.505k ± 2%       ~ (p=0.264 n=6)
ScrapeLoopScrapeAndReport/appV2=true/pooled=false-2                                                             8.509k ± 0%   8.507k ± 0%  -0.02% (p=0.011 n=6)
geomean                                                                                                          294.1         294.3       +0.06%
¹ all samples are equal
```

</details>

```release-notes
[PERF] Scrape: Avoid unnecessary copies of scrape response bodies.
```
