### PR TITLE
discovery/aws: don't panic on ECS tasks with absent optional fields

### DIFF
--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -876,6 +876,11 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 						networkMode = "awsvpc"
 						var eniID string
 						for _, detail := range eniAttachment.Details {
+							// Name and Value are both optional in the ECS API.
+							// Skip the entry rather than dereferencing nil.
+							if detail.Name == nil || detail.Value == nil {
+								continue
+							}
 							switch *detail.Name {
 							case "privateIPv4Address":
 								ipAddress = *detail.Value
@@ -906,10 +911,10 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 								ec2InstancePrivateIP = info.privateIP
 								ec2InstancePublicIP = info.publicIP
 							} else {
-								d.logger.Debug("EC2 instance info not found", "instance", ec2InstanceID, "task", *task.TaskArn)
+								d.logger.Debug("EC2 instance info not found", "instance", ec2InstanceID, "task", aws.ToString(task.TaskArn))
 							}
 						} else {
-							d.logger.Debug("Container instance not found in map", "arn", *task.ContainerInstanceArn, "task", *task.TaskArn)
+							d.logger.Debug("Container instance not found in map", "arn", *task.ContainerInstanceArn, "task", aws.ToString(task.TaskArn))
 						}
 					}
 
@@ -932,20 +937,42 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 						return
 					}
 
+					// Only IPAddress, Region, LaunchType, HealthStatus and
+					// NetworkMode are always available here: the first is
+					// checked above and the rest are not pointers. Every other
+					// field is optional in the ECS API, so emit its label only
+					// when present rather than dereferencing nil.
 					labels := model.LabelSet{
-						ecsLabelClusterARN:       model.LabelValue(*cluster.ClusterArn),
-						ecsLabelCluster:          model.LabelValue(*cluster.ClusterName),
-						ecsLabelTaskGroup:        model.LabelValue(*task.Group),
-						ecsLabelTaskARN:          model.LabelValue(*task.TaskArn),
-						ecsLabelTaskDefinition:   model.LabelValue(*task.TaskDefinitionArn),
-						ecsLabelIPAddress:        model.LabelValue(ipAddress),
-						ecsLabelRegion:           model.LabelValue(d.region),
-						ecsLabelLaunchType:       model.LabelValue(task.LaunchType),
-						ecsLabelAvailabilityZone: model.LabelValue(*task.AvailabilityZone),
-						ecsLabelDesiredStatus:    model.LabelValue(*task.DesiredStatus),
-						ecsLabelLastStatus:       model.LabelValue(*task.LastStatus),
-						ecsLabelHealthStatus:     model.LabelValue(task.HealthStatus),
-						ecsLabelNetworkMode:      model.LabelValue(networkMode),
+						ecsLabelIPAddress:    model.LabelValue(ipAddress),
+						ecsLabelRegion:       model.LabelValue(d.region),
+						ecsLabelLaunchType:   model.LabelValue(task.LaunchType),
+						ecsLabelHealthStatus: model.LabelValue(task.HealthStatus),
+						ecsLabelNetworkMode:  model.LabelValue(networkMode),
+					}
+
+					if cluster.ClusterArn != nil {
+						labels[ecsLabelClusterARN] = model.LabelValue(*cluster.ClusterArn)
+					}
+					if cluster.ClusterName != nil {
+						labels[ecsLabelCluster] = model.LabelValue(*cluster.ClusterName)
+					}
+					if task.Group != nil {
+						labels[ecsLabelTaskGroup] = model.LabelValue(*task.Group)
+					}
+					if task.TaskArn != nil {
+						labels[ecsLabelTaskARN] = model.LabelValue(*task.TaskArn)
+					}
+					if task.TaskDefinitionArn != nil {
+						labels[ecsLabelTaskDefinition] = model.LabelValue(*task.TaskDefinitionArn)
+					}
+					if task.AvailabilityZone != nil {
+						labels[ecsLabelAvailabilityZone] = model.LabelValue(*task.AvailabilityZone)
+					}
+					if task.DesiredStatus != nil {
+						labels[ecsLabelDesiredStatus] = model.LabelValue(*task.DesiredStatus)
+					}
+					if task.LastStatus != nil {
+						labels[ecsLabelLastStatus] = model.LabelValue(*task.LastStatus)
 					}
 
 					// Add subnet ID when available (awsvpc mode from ENI, bridge/host from EC2 instance)
@@ -990,10 +1017,10 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					}
 
 					// If this task belongs to a service, add service information and tags.
-					if serviceName, isServiceTask := strings.CutPrefix(*task.Group, "service:"); isServiceTask {
+					if serviceName, isServiceTask := strings.CutPrefix(aws.ToString(task.Group), "service:"); isServiceTask {
 						service, ok := services[serviceName]
 						if !ok {
-							d.logger.Debug("Service not found for task", "task", *task.TaskArn, "service", serviceName)
+							d.logger.Debug("Service not found for task", "task", aws.ToString(task.TaskArn), "service", serviceName)
 						}
 						if service.ServiceName != nil {
 							labels[ecsLabelService] = model.LabelValue(*service.ServiceName)

--- a/discovery/aws/ecs_test.go
+++ b/discovery/aws/ecs_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -1497,6 +1498,67 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Every pointer blanked here is optional in the ECS API and was
+			// dereferenced without a nil check. A task that has not been placed
+			// yet has no AvailabilityZone, and an attachment detail is a
+			// KeyValuePair whose Name and Value are both optional, so a single
+			// absent field panicked the whole refresh instead of degrading the
+			// one target.
+			name: "TaskWithNilOptionalFields",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("nil-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/nil-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				tasks: []ecsTypes.Task{
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/nil-cluster/task-nil"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/nil-cluster"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/nil-task:1"),
+						LaunchType:        ecsTypes.LaunchTypeFargate,
+						// Group, LastStatus, DesiredStatus and AvailabilityZone
+						// are all absent.
+						Attachments: []ecsTypes.Attachment{
+							{
+								Type: strptr("ElasticNetworkInterface"),
+								Details: []ecsTypes.KeyValuePair{
+									// A detail with no Name at all.
+									{},
+									// A known key whose Value is absent.
+									{Name: strptr("subnetId")},
+									{Name: strptr("privateIPv4Address"), Value: strptr("10.0.4.10")},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "us-west-2",
+					Targets: []model.LabelSet{
+						{
+							model.AddressLabel:       model.LabelValue("10.0.4.10:80"),
+							"__meta_ecs_cluster":     model.LabelValue("nil-cluster"),
+							"__meta_ecs_cluster_arn": model.LabelValue("arn:aws:ecs:us-west-2:123456789012:cluster/nil-cluster"),
+							"__meta_ecs_task_arn":    model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task/nil-cluster/task-nil"),
+							"__meta_ecs_task_definition": model.LabelValue(
+								"arn:aws:ecs:us-west-2:123456789012:task-definition/nil-task:1"),
+							"__meta_ecs_region":        model.LabelValue("us-west-2"),
+							"__meta_ecs_ip_address":    model.LabelValue("10.0.4.10"),
+							"__meta_ecs_launch_type":   model.LabelValue("FARGATE"),
+							"__meta_ecs_health_status": model.LabelValue(""),
+							"__meta_ecs_network_mode":  model.LabelValue("awsvpc"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1513,6 +1575,10 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 					RequestConcurrency: 1,
 				},
 				region: tt.ecsData.region,
+				// NewECSDiscovery substitutes a no-op logger when none is
+				// supplied; construct the same thing here so the debug paths
+				// are exercised rather than panicking on a nil logger.
+				logger: promslog.NewNopLogger(),
 			}
 
 			groups, err := d.refresh(ctx)


### PR DESCRIPTION
ECS SD dereferences optional task fields without guarding them. Any task missing one
panics the refresh goroutine and takes the process down instead of degrading a single
target.

`types.Task.Group`, `TaskArn`, `LastStatus`, `DesiredStatus`, `AvailabilityZone`,
`ClusterArn`, `ClusterName` and `TaskDefinitionArn` are all optional — none carry the
SDK's `This member is required.` marker. `Group` is dereferenced twice, including in
the `strings.CutPrefix(*task.Group, "service:")` added by the recent service-lookup
refactor, so a task with no group panics there.

The ENI attachment loop is the one that fires first: it switches on `*detail.Name`
and `*detail.Value`, and both members of `KeyValuePair` are optional.

Changes:

- Guard the eight optional fields in the label literal.
- `aws.ToString(task.Group)` in the service-name check, and for the three
  `logger.Debug` sites — the idiom already used throughout `msk.go`.
- Guard `*detail.Name` / `*detail.Value` in the ENI loop.

Tests fail on main at `ecs.go:879` without the fix.

`TestECSDiscoveryRefresh` builds `&ECSDiscovery{...}` directly rather than going
through `NewECSDiscovery`, so `d.logger` is nil and any `Debug` call panics; the new
cases set `logger: promslog.NewNopLogger()`, which is what the constructor substitutes
anyway.

Follow-up to #19324, same bug class. `elasticache.go` has it too and is ready as a
separate PR.

```release-notes
[BUGFIX] discovery/aws: Don't panic on ECS tasks with absent optional fields.
```
