### PR TITLE
scrape: use a dedicated HTTP client per unix socket target

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -93,7 +93,10 @@ type scrapePool struct {
 	mtx    sync.Mutex
 	config *config.ScrapeConfig
 	client *http.Client
-	loops  map[uint64]loop
+	// unixSocketClients caches dedicated HTTP clients for targets scraped
+	// through a unix domain socket, keyed by socket path. See clientForTarget.
+	unixSocketClients map[string]*http.Client
+	loops             map[uint64]loop
 
 	symbolTable           *labels.SymbolTable
 	lastSymbolTableCheck  time.Time
@@ -194,6 +197,36 @@ func (sp *scrapePool) newLoop(opts scrapeLoopOptions) loop {
 	return newScrapeLoop(opts)
 }
 
+// clientForTarget returns the HTTP client that scrapes of the given target
+// must use. Targets scraped through a unix domain socket get a dedicated
+// client per socket path: the HTTP transport pools idle connections by
+// scheme and host:port only, so sharing one client across sockets could
+// reuse a connection dialed to one socket for a target on another one.
+// Must be called with sp.mtx held.
+func (sp *scrapePool) clientForTarget(t *Target) *http.Client {
+	socketPath := t.labels.Get(UnixSocketLabel)
+	if socketPath == "" {
+		return sp.client
+	}
+	if client, ok := sp.unixSocketClients[socketPath]; ok {
+		return client
+	}
+	client, err := newUnixSocketScrapeClient(socketPath, sp.config.HTTPClientConfig, sp.config.JobName, sp.options.HTTPClientOptions...)
+	if err != nil {
+		// The same configuration was already used to build sp.client, so
+		// this should never happen. Fail the target's scrapes rather than
+		// falling back to the shared client, which would silently dial the
+		// target's __address__ over TCP instead of the socket.
+		sp.logger.Error("Failed to create unix socket scrape client", "socket_path", socketPath, "err", err)
+		client = &http.Client{Transport: failingRoundTripper{err: fmt.Errorf("creating unix socket scrape client for %q: %w", socketPath, err)}}
+	}
+	if sp.unixSocketClients == nil {
+		sp.unixSocketClients = make(map[string]*http.Client)
+	}
+	sp.unixSocketClients[socketPath] = client
+	return client
+}
+
 func (sp *scrapePool) ActiveTargets() []*Target {
 	sp.targetMtx.Lock()
 	defer sp.targetMtx.Unlock()
@@ -259,6 +292,9 @@ func (sp *scrapePool) stop() {
 	// context (via sl.parentCtx) and would fail if the context was cancelled early.
 	sp.cancel()
 	sp.client.CloseIdleConnections()
+	for _, c := range sp.unixSocketClients {
+		c.CloseIdleConnections()
+	}
 
 	if sp.config != nil {
 		sp.metrics.targetScrapePoolSyncsCounter.DeleteLabelValues(sp.config.JobName)
@@ -286,20 +322,27 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 		return err
 	}
 
-	reuseCache := reusableCache(sp.config, cfg)
-	sp.config = cfg
-	oldClient := sp.client
-	sp.client = client
-
 	// Validate scheme so we don't need to do it later.
 
 	if _, err = config.ToEscapingScheme(cfg.MetricNameEscapingScheme, cfg.MetricNameValidationScheme); err != nil {
 		return fmt.Errorf("scrapePool.reload: invalid metric name escaping scheme, %w", err)
 	}
+
+	reuseCache := reusableCache(sp.config, cfg)
+	sp.config = cfg
+	oldClient := sp.client
+	sp.client = client
+	// The new configuration may change the HTTP client settings, so the
+	// per-socket clients are rebuilt by restartLoops below.
+	oldUnixSocketClients := sp.unixSocketClients
+	sp.unixSocketClients = nil
 	sp.metrics.targetScrapePoolTargetLimit.WithLabelValues(sp.config.JobName).Set(float64(sp.config.TargetLimit))
 
 	sp.restartLoops(reuseCache)
 	oldClient.CloseIdleConnections()
+	for _, c := range oldUnixSocketClients {
+		c.CloseIdleConnections()
+	}
 	sp.metrics.targetReloadIntervalLength.WithLabelValues(time.Duration(sp.config.ScrapeInterval).String()).Observe(
 		time.Since(start).Seconds(),
 	)
@@ -331,7 +374,7 @@ func (sp *scrapePool) restartLoops(reuseCache bool) {
 			target: t,
 			scraper: &targetScraper{
 				Target:               t,
-				client:               sp.client,
+				client:               sp.clientForTarget(t),
 				timeout:              targetTimeout,
 				bodySizeLimit:        int64(sp.config.BodySizeLimit),
 				acceptHeader:         acceptHeader(sp.config.ScrapeProtocols, escapingScheme),
@@ -439,8 +482,16 @@ func (sp *scrapePool) sync(targets []*Target) {
 
 	sp.targetMtx.Lock()
 	escapingScheme, _ := config.ToEscapingScheme(sp.config.MetricNameEscapingScheme, sp.config.MetricNameValidationScheme)
+	var socketsInUse map[string]struct{}
 	for _, t := range targets {
 		hash := t.hash()
+
+		if socketPath := t.labels.Get(UnixSocketLabel); socketPath != "" {
+			if socketsInUse == nil {
+				socketsInUse = make(map[string]struct{})
+			}
+			socketsInUse[socketPath] = struct{}{}
+		}
 
 		if _, ok := sp.activeTargets[hash]; !ok {
 			// The scrape interval and timeout labels are set to the config's values initially,
@@ -455,7 +506,7 @@ func (sp *scrapePool) sync(targets []*Target) {
 				target: t,
 				scraper: &targetScraper{
 					Target:               t,
-					client:               sp.client,
+					client:               sp.clientForTarget(t),
 					timeout:              targetTimeout,
 					bodySizeLimit:        int64(sp.config.BodySizeLimit),
 					acceptHeader:         acceptHeader(sp.config.ScrapeProtocols, escapingScheme),
@@ -500,6 +551,15 @@ func (sp *scrapePool) sync(targets []*Target) {
 
 			delete(sp.loops, hash)
 			delete(sp.activeTargets, hash)
+		}
+	}
+
+	// Drop cached unix socket clients whose socket is no longer scraped by
+	// any target.
+	for socketPath, client := range sp.unixSocketClients {
+		if _, ok := socketsInUse[socketPath]; !ok {
+			client.CloseIdleConnections()
+			delete(sp.unixSocketClients, socketPath)
 		}
 	}
 
@@ -745,12 +805,6 @@ func (s *targetScraper) scrape(ctx context.Context) (*http.Response, error) {
 	}
 	ctx, span := otel.Tracer("").Start(ctx, "Scrape", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
-
-	// If the target has a unix socket path, pass it via the context so the
-	// custom DialContext can dial the socket instead of the URL host.
-	if socketPath := s.labels.Get(UnixSocketLabel); socketPath != "" {
-		ctx = context.WithValue(ctx, unixSocketContextKey{}, socketPath)
-	}
 
 	return s.client.Do(s.req.WithContext(ctx))
 }
@@ -2300,26 +2354,34 @@ func pickSchema(bucketFactor float64) int32 {
 // the specified Unix domain socket instead of the target's __address__.
 const UnixSocketLabel = "__unix_socket__"
 
-// unixSocketContextKey is used to pass the unix socket path
-// from the scraper to the custom DialContext via the request context.
-type unixSocketContextKey struct{}
-
-func newScrapeClient(cfg config_util.HTTPClientConfig, name string, optFuncs ...config_util.HTTPClientOption) (*http.Client, error) {
-	// Register a custom dial function so that when a unix socket path is
-	// present on the request context, connections are routed through the
-	// unix socket instead of the URL host. Using WithDialContextFunc
-	// ensures the dial function is installed during transport construction,
-	// before any auth or TLS file-watching wrappers are applied.
-	// Prepend so that callers can override this default via optFuncs.
+// newUnixSocketScrapeClient returns a scrape client that dials the given
+// unix domain socket instead of the request URL host. Each socket path needs
+// its own client: the HTTP transport pools idle connections by scheme and
+// host:port only, so a client shared across sockets could reuse a connection
+// dialed to a different socket.
+func newUnixSocketScrapeClient(socketPath string, cfg config_util.HTTPClientConfig, name string, optFuncs ...config_util.HTTPClientOption) (*http.Client, error) {
+	// Using WithDialContextFunc ensures the dial function is installed
+	// during transport construction, before any auth or TLS file-watching
+	// wrappers are applied. Prepend so that callers can override this
+	// default via optFuncs.
 	optFuncs = append([]config_util.HTTPClientOption{config_util.WithDialContextFunc(
-		func(ctx context.Context, network, addr string) (net.Conn, error) {
-			if socketPath, ok := ctx.Value(unixSocketContextKey{}).(string); ok && socketPath != "" {
-				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
-			}
-			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 		},
 	)}, optFuncs...)
+	return newScrapeClient(cfg, name, optFuncs...)
+}
 
+// failingRoundTripper fails every request with a fixed error. It stands in
+// for a scrape client that could not be built, so that the affected targets
+// fail to scrape instead of silently scraping the wrong endpoint.
+type failingRoundTripper struct{ err error }
+
+func (rt failingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, rt.err
+}
+
+func newScrapeClient(cfg config_util.HTTPClientConfig, name string, optFuncs ...config_util.HTTPClientOption) (*http.Client, error) {
 	client, err := config_util.NewClientFromConfig(cfg, name, optFuncs...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating HTTP client: %w", err)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -4902,6 +4902,77 @@ func TestTargetScraperScrapeOverUnixSocketTLS(t *testing.T) {
 	require.Equal(t, "metric_a 1\nmetric_b 2\n", buf.String())
 }
 
+func TestTargetScraperUnixSocketConnectionsAreNotShared(t *testing.T) {
+	// Two targets sharing the same __address__ but scraped through different
+	// unix sockets must never exchange pooled keep-alive connections,
+	// otherwise one target would receive the other target's metrics.
+	tempDir, err := os.MkdirTemp("", "uds-pool-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	payloads := map[string]string{}
+	var targets []*Target
+	for i := range 2 {
+		socketPath := filepath.Join(tempDir, fmt.Sprintf("s%d", i))
+		listener, err := net.Listen("unix", socketPath)
+		require.NoError(t, err)
+		t.Cleanup(func() { listener.Close() })
+
+		payload := fmt.Sprintf("metric_a %d\n", i)
+		payloads[socketPath] = payload
+		server := &http.Server{
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+				_, _ = w.Write([]byte(payload))
+			}),
+		}
+		go server.Serve(listener)
+		t.Cleanup(func() { server.Close() })
+
+		targets = append(targets, &Target{
+			labels: labels.FromStrings(
+				model.SchemeLabel, "http",
+				model.AddressLabel, "localhost:9090",
+				model.MetricsPathLabel, "/metrics",
+				model.ScrapeIntervalLabel, "1s",
+				model.ScrapeTimeoutLabel, "1s",
+				UnixSocketLabel, socketPath,
+			),
+			scrapeConfig: &config.ScrapeConfig{},
+		})
+	}
+
+	var scrapers []*targetScraper
+	sp := newTestScrapePool(t, nil, false, func(opts scrapeLoopOptions) loop {
+		scrapers = append(scrapers, opts.scraper.(*targetScraper))
+		return &testLoop{
+			startFunc: func(time.Duration, time.Duration, chan<- error) {},
+			stopFunc:  func() {},
+		}
+	})
+	client, err := newScrapeClient(config_util.HTTPClientConfig{}, "test_job")
+	require.NoError(t, err)
+	sp.client = client
+
+	sp.sync(targets)
+	require.Len(t, scrapers, 2)
+
+	// Scrape each target twice so the second round is served from pooled
+	// keep-alive connections.
+	for range 2 {
+		for _, ts := range scrapers {
+			var buf bytes.Buffer
+			resp, err := ts.scrape(context.Background())
+			require.NoError(t, err)
+			_, err = ts.readResponse(context.Background(), resp, &buf)
+			require.NoError(t, err)
+			require.Equal(t, payloads[ts.labels.Get(UnixSocketLabel)], buf.String())
+		}
+	}
+
+	sp.stop()
+}
+
 func TestTargetScrapeScrapeCancel(t *testing.T) {
 	block := make(chan struct{})
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -4815,7 +4815,7 @@ func TestTargetScraperScrapeOverUnixSocket(t *testing.T) {
 	defer server.Close()
 
 	// Create a client with a DialContext that routes to the unix socket.
-	client, err := newScrapeClient(config_util.HTTPClientConfig{}, "test_job")
+	client, err := newUnixSocketScrapeClient(socketPath, config_util.HTTPClientConfig{}, "test_job")
 	require.NoError(t, err)
 
 	// No __address__ set — falls back to "localhost".
@@ -4870,7 +4870,7 @@ func TestTargetScraperScrapeOverUnixSocketTLS(t *testing.T) {
 	defer server.Close()
 
 	// Create a client configured to trust the test CA.
-	client, err := newScrapeClient(config_util.HTTPClientConfig{
+	client, err := newUnixSocketScrapeClient(socketPath, config_util.HTTPClientConfig{
 		TLSConfig: config_util.TLSConfig{
 			CAFile: caCertPath,
 		},


### PR DESCRIPTION
Unix socket scrape support passes the socket path to a shared HTTP client's
`DialContext` via the request context. But the transport keys idle connections
on scheme and `host:port` only, so two targets sharing the same `__address__`
with different `__scrape_unix_socket__` paths can reuse each other's pooled
connections and scrape the wrong endpoint. The same applies to a plain TCP
target sharing that address.

This gives each unix socket path its own scrape client, cached per scrape pool
and rebuilt on reload.

First commit adds a failing test exposing the mix-up, second one fixes it.
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
