### PR TITLE
tsdb: document that OOO chunk IDs are no longer monotonically increasing

### DIFF
--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -76,7 +76,10 @@ func (p HeadChunkRef) Unpack() (HeadSeriesRef, HeadChunkID) {
 }
 
 // HeadChunkID refers to a specific chunk in a series (memSeries) in the Head.
-// Each memSeries has its own monotonically increasing number to refer to its chunks.
+// Each memSeries has its own number to refer to its chunks: it is monotonically
+// increasing for in-order chunks, while out-of-order chunk IDs wrap around modulo
+// 2^23 (see oooHeadChunkID in tsdb/head_read.go), so they only increase between
+// wrap-arounds.
 // If the HeadChunkID value is...
 //   - memSeries.firstChunkID+len(memSeries.mmappedChunks), it's the head chunk.
 //   - less than the above, but >= memSeries.firstID, then it's

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -420,8 +420,8 @@ const oooChunkIDMask = 1 << 23
 //
 // The position is wrapped modulo oooChunkIDMask so that firstOOOChunkID can
 // grow indefinitely without overflowing the 23-bit ID space. Correctness
-// requires len(oooMmappedChunks) << oooChunkIDMask, which is enforced by the
-// guard in mmapCurrentOOOHeadChunk.
+// requires len(oooMmappedChunks) to stay far below oooChunkIDMask, which is
+// enforced by the guard in mmapCurrentOOOHeadChunk.
 func (s *memSeries) oooHeadChunkID(pos int) chunks.HeadChunkID {
 	return ((chunks.HeadChunkID(pos) + s.ooo.firstOOOChunkID) & (oooChunkIDMask - 1)) | oooChunkIDMask
 }

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -420,7 +420,7 @@ const oooChunkIDMask = 1 << 23
 //
 // The position is wrapped modulo oooChunkIDMask so that firstOOOChunkID can
 // grow indefinitely without overflowing the 23-bit ID space. Correctness
-// requires len(oooMmappedChunks) to stay far below oooChunkIDMask, which is
+// requires len(oooMmappedChunks) to stay below oooChunkIDMask, which is
 // enforced by the guard in mmapCurrentOOOHeadChunk.
 func (s *memSeries) oooHeadChunkID(pos int) chunks.HeadChunkID {
 	return ((chunks.HeadChunkID(pos) + s.ooo.firstOOOChunkID) & (oooChunkIDMask - 1)) | oooChunkIDMask


### PR DESCRIPTION
Follow-up to #19216: the HeadChunkID doc still promised a monotonically increasing per-series number, which no longer holds for out-of-order chunk IDs now that they wrap modulo 2^23. Also spell out the "much less than" relation in the oooHeadChunkID comment, where << is easy to misread as a bit-shift.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
