### PR TITLE
discovery/kubernetes: populate loadbalancer IP from status.ingress

### DIFF
--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -234,11 +235,27 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
 		}
 
 		if svc.Spec.Type == apiv1.ServiceTypeLoadBalancer {
-			labelSet[serviceLoadBalancerIP] = lv(svc.Spec.LoadBalancerIP)
+			labelSet[serviceLoadBalancerIP] = lv(loadBalancerIPs(svc))
 		}
 
 		tg.Targets = append(tg.Targets, labelSet)
 	}
 
 	return tg
+}
+
+// loadBalancerIPs returns the LoadBalancer addresses from status.ingress,
+// falling back to the deprecated spec.loadBalancerIP. Multiple ingress IPs
+// are joined with commas so relabeling can extract them.
+func loadBalancerIPs(svc *apiv1.Service) string {
+	var ips []string
+	for _, ing := range svc.Status.LoadBalancer.Ingress {
+		if ing.IP != "" {
+			ips = append(ips, ing.IP)
+		}
+	}
+	if len(ips) > 0 {
+		return strings.Join(ips, ",")
+	}
+	return svc.Spec.LoadBalancerIP
 }

--- a/discovery/kubernetes/service_test.go
+++ b/discovery/kubernetes/service_test.go
@@ -113,6 +113,34 @@ func makeLoadBalancerService() *v1.Service {
 	}
 }
 
+func makeLoadBalancerServiceFromIngress() *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testservice-lb-ingress",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "testport",
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(31900),
+				},
+			},
+			Type:      v1.ServiceTypeLoadBalancer,
+			ClusterIP: "10.0.0.1",
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{IP: "192.168.1.15"},
+					{IP: "2001:db8::1"},
+				},
+			},
+		},
+	}
+}
+
 func TestServiceDiscoveryAdd(t *testing.T) {
 	t.Parallel()
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{})
@@ -126,8 +154,10 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 			c.CoreV1().Services(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
 			obj = makeLoadBalancerService()
 			c.CoreV1().Services(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+			obj = makeLoadBalancerServiceFromIngress()
+			c.CoreV1().Services(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
 		},
-		expectedMaxItems: 3,
+		expectedMaxItems: 4,
 		expectedRes: map[string]*targetgroup.Group{
 			"svc/default/testservice": {
 				Targets: []model.LabelSet{
@@ -180,6 +210,24 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 					"__meta_kubernetes_namespace":    "default",
 				},
 				Source: "svc/default/testservice-loadbalancer",
+			},
+			"svc/default/testservice-lb-ingress": {
+				Targets: []model.LabelSet{
+					{
+						"__meta_kubernetes_service_port_protocol": "TCP",
+						"__address__":                               "testservice-lb-ingress.default.svc:31900",
+						"__meta_kubernetes_service_type":            "LoadBalancer",
+						"__meta_kubernetes_service_port_name":       "testport",
+						"__meta_kubernetes_service_port_number":     "31900",
+						"__meta_kubernetes_service_cluster_ip":      "10.0.0.1",
+						"__meta_kubernetes_service_loadbalancer_ip": "192.168.1.15,2001:db8::1",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_service_name": "testservice-lb-ingress",
+					"__meta_kubernetes_namespace":    "default",
+				},
+				Source: "svc/default/testservice-lb-ingress",
 			},
 		},
 	}.Run(t)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2469,7 +2469,7 @@ Available meta labels:
 * `__meta_kubernetes_service_annotation_<annotationname>`: Each annotation from the service object.
 * `__meta_kubernetes_service_annotationpresent_<annotationname>`: "true" for each annotation of the service object.
 * `__meta_kubernetes_service_cluster_ip`: The cluster IP address of the service. (Does not apply to services of type ExternalName)
-* `__meta_kubernetes_service_loadbalancer_ip`: The IP address of the loadbalancer. (Applies to services of type LoadBalancer)
+* `__meta_kubernetes_service_loadbalancer_ip`: The IP address of the load balancer, taken from `status.loadBalancer.ingress` (comma-separated when there are multiple). Falls back to the deprecated `spec.loadBalancerIP`. (Applies to services of type LoadBalancer)
 * `__meta_kubernetes_service_external_name`: The DNS name of the service. (Applies to services of type ExternalName)
 * `__meta_kubernetes_service_label_<labelname>`: Each label from the service object, with any unsupported characters converted to an underscore.
 * `__meta_kubernetes_service_labelpresent_<labelname>`: `true` for each label of the service object, with any unsupported characters converted to an underscore.


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #14398

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] discovery/kubernetes: Populate `__meta_kubernetes_service_loadbalancer_ip` from `status.loadBalancer.ingress`, falling back to deprecated `spec.loadBalancerIP`.
```

Kubernetes 1.24 dropped automatic `spec.loadBalancerIP`. Controllers (MetalLB, AKS, …) now only write IPs to `status.loadBalancer.ingress`, so the meta label was empty.

This PR:
- Prefers ingress IPs (comma-separated for dual-stack)
- Falls back to `spec.loadBalancerIP` when status has no IPs
- Leaves hostname-only ingress (EKS) for a follow-up, as discussed on the issue

Related: #17136 (stalled on DCO). @machine424 @brancz @rexagod
