### PR TITLE
discovery/aws: don't panic on ElastiCache caches with absent optional fields

### DIFF
--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -528,6 +528,9 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 			return fmt.Errorf("failed to describe serverless caches: %w", err)
 		}
 		for _, cache := range caches {
+			if cache.ARN == nil {
+				continue
+			}
 			clustersMu.Lock()
 			clusters = append(clusters, *cache.ARN)
 			clustersMu.Unlock()
@@ -541,6 +544,9 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 			return fmt.Errorf("failed to describe cache clusters: %w", err)
 		}
 		for _, cluster := range cacheClusters {
+			if cluster.ARN == nil {
+				continue
+			}
 			clustersMu.Lock()
 			clusters = append(clusters, *cluster.ARN)
 			clustersMu.Unlock()
@@ -568,7 +574,11 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 			return fmt.Errorf("failed to describe serverless caches: %w", err)
 		}
 		for _, cache := range caches {
-			addServerlessCacheTargets(tg, &cache, tagsByResourceARN[*cache.ARN])
+			var tags []types.Tag
+			if cache.ARN != nil {
+				tags = tagsByResourceARN[*cache.ARN]
+			}
+			addServerlessCacheTargets(tg, &cache, tags)
 		}
 		return nil
 	})
@@ -579,7 +589,11 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 			return fmt.Errorf("failed to describe cache clusters: %w", err)
 		}
 		for _, cluster := range cacheClusters {
-			addCacheClusterTargets(tg, &cluster, tagsByResourceARN[*cluster.ARN])
+			var tags []types.Tag
+			if cluster.ARN != nil {
+				tags = tagsByResourceARN[*cluster.ARN]
+			}
+			addCacheClusterTargets(tg, &cluster, tags)
 		}
 		return nil
 	})
@@ -621,14 +635,14 @@ func splitCacheDeploymentOptions(caches []string, logger *slog.Logger) (serverle
 // addServerlessCacheTargets adds targets for a serverless cache to the target group.
 func addServerlessCacheTargets(tg *targetgroup.Group, cache *types.ServerlessCache, tags []types.Tag) {
 	labels := model.LabelSet{
-		elasticacheLabelDeploymentOption:                  model.LabelValue("serverless"),
-		elasticacheLabelServerlessCacheARN:                model.LabelValue(*cache.ARN),
-		elasticacheLabelServerlessCacheName:               model.LabelValue(*cache.ServerlessCacheName),
-		elasticacheLabelServerlessCacheStatus:             model.LabelValue(*cache.Status),
-		elasticacheLabelServerlessCacheEngine:             model.LabelValue(*cache.Engine),
-		elasticacheLabelServerlessCacheFullEngineVersion:  model.LabelValue(*cache.FullEngineVersion),
-		elasticacheLabelServerlessCacheMajorEngineVersion: model.LabelValue(*cache.MajorEngineVersion),
+		elasticacheLabelDeploymentOption: model.LabelValue("serverless"),
 	}
+	setStringLabel(labels, elasticacheLabelServerlessCacheARN, cache.ARN)
+	setStringLabel(labels, elasticacheLabelServerlessCacheName, cache.ServerlessCacheName)
+	setStringLabel(labels, elasticacheLabelServerlessCacheStatus, cache.Status)
+	setStringLabel(labels, elasticacheLabelServerlessCacheEngine, cache.Engine)
+	setStringLabel(labels, elasticacheLabelServerlessCacheFullEngineVersion, cache.FullEngineVersion)
+	setStringLabel(labels, elasticacheLabelServerlessCacheMajorEngineVersion, cache.MajorEngineVersion)
 
 	if cache.Description != nil {
 		labels[elasticacheLabelServerlessCacheDescription] = model.LabelValue(*cache.Description)
@@ -719,11 +733,11 @@ func addServerlessCacheTargets(tg *targetgroup.Group, cache *types.ServerlessCac
 func addCacheClusterTargets(tg *targetgroup.Group, cluster *types.CacheCluster, tags []types.Tag) {
 	// Build common labels that apply to all nodes in this cluster
 	commonLabels := model.LabelSet{
-		elasticacheLabelDeploymentOption:   model.LabelValue("node"),
-		elasticacheLabelCacheClusterARN:    model.LabelValue(*cluster.ARN),
-		elasticacheLabelCacheClusterID:     model.LabelValue(*cluster.CacheClusterId),
-		elasticacheLabelCacheClusterStatus: model.LabelValue(*cluster.CacheClusterStatus),
+		elasticacheLabelDeploymentOption: model.LabelValue("node"),
 	}
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterARN, cluster.ARN)
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterID, cluster.CacheClusterId)
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterStatus, cluster.CacheClusterStatus)
 
 	if cluster.AtRestEncryptionEnabled != nil {
 		commonLabels[elasticacheLabelCacheClusterAtRestEncryptionEnabled] = model.LabelValue(strconv.FormatBool(*cluster.AtRestEncryptionEnabled))
@@ -947,5 +961,11 @@ func addCacheClusterTargets(tg *targetgroup.Group, cluster *types.CacheCluster, 
 		}
 
 		tg.Targets = append(tg.Targets, labels)
+	}
+}
+
+func setStringLabel(ls model.LabelSet, name model.LabelName, v *string) {
+	if v != nil {
+		ls[name] = model.LabelValue(*v)
 	}
 }

--- a/discovery/aws/elasticache_test.go
+++ b/discovery/aws/elasticache_test.go
@@ -249,6 +249,13 @@ func TestAddServerlessCacheTargets(t *testing.T) {
 				"__address__": "my-cache.serverless.use1.cache.amazonaws.com:6379",
 			},
 		},
+		{
+			name:  "ServerlessCacheWithNilOptionalFields",
+			cache: &types.ServerlessCache{},
+			expectedLabels: model.LabelSet{
+				"__meta_elasticache_deployment_option": "serverless",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -443,6 +450,18 @@ func TestAddCacheClusterTargets(t *testing.T) {
 					"__meta_elasticache_cache_cluster_node_endpoint_address":  "node-cluster-001.abc123.0001.use1.cache.amazonaws.com",
 					"__meta_elasticache_cache_cluster_node_endpoint_port":     "6379",
 					"__address__": "node-cluster-001.abc123.0001.use1.cache.amazonaws.com:6379",
+				},
+			},
+		},
+		{
+			name: "CacheClusterWithNilOptionalFields",
+			cluster: &types.CacheCluster{
+				CacheNodes: []types.CacheNode{{}},
+			},
+			expectedTargetCount: 1,
+			expectedLabels: []model.LabelSet{
+				{
+					"__meta_elasticache_deployment_option": "node",
 				},
 			},
 		},


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Follow-up to #19396 (same nil-deref class in AWS SD).

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] discovery/aws: Don't panic on ElastiCache caches or clusters with absent optional fields.
```

`addServerlessCacheTargets` / `addCacheClusterTargets` dereferenced `ARN`, `ServerlessCacheName`, `Status`, `Engine`, `CacheClusterId`, etc. without nil checks. A cache missing any of those panics the refresh goroutine and takes the process down.

Optional fields now omit the label instead of dereferencing. Refresh also skips tag lookup when `ARN` is nil.

@matt-gp @sysadmind
