### PR TITLE
promql/parser: reject offset expressions and @ start()/end() before range selectors

### DIFF
--- a/promql/parser/generated_parser.y
+++ b/promql/parser/generated_parser.y
@@ -650,9 +650,9 @@ matrix_selector : expr LEFT_BRACKET positive_duration_expr RIGHT_BRACKET
                         vs, ok := $1.(*VectorSelector)
                         if !ok{
                                 errMsg = "ranges only allowed for vector selectors"
-                        } else if vs.OriginalOffset != 0{
+                        } else if vs.OriginalOffset != 0 || vs.OriginalOffsetExpr != nil {
                                 errMsg = "no offset modifiers allowed before range"
-                        } else if vs.Timestamp != nil {
+                        } else if vs.Timestamp != nil || vs.StartOrEnd != 0 {
                                 errMsg = "no @ modifiers allowed before range"
                         }
 

--- a/promql/parser/generated_parser.y.go
+++ b/promql/parser/generated_parser.y.go
@@ -1711,9 +1711,9 @@ yydefault:
 			vs, ok := yyDollar[1].node.(*VectorSelector)
 			if !ok {
 				errMsg = "ranges only allowed for vector selectors"
-			} else if vs.OriginalOffset != 0 {
+			} else if vs.OriginalOffset != 0 || vs.OriginalOffsetExpr != nil {
 				errMsg = "no offset modifiers allowed before range"
-			} else if vs.Timestamp != nil {
+			} else if vs.Timestamp != nil || vs.StartOrEnd != 0 {
 				errMsg = "no @ modifiers allowed before range"
 			}
 

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -2804,6 +2804,39 @@ var testExpr = []struct {
 		},
 	},
 	{
+		input: `some_metric @ start() [5m]`,
+		fail:  true,
+		errors: ParseErrors{
+			ParseErr{
+				PositionRange: posrange.PositionRange{Start: 22, End: 26},
+				Err:           errors.New("no @ modifiers allowed before range"),
+				Query:         `some_metric @ start() [5m]`,
+			},
+		},
+	},
+	{
+		input: `some_metric @ end()[5m]`,
+		fail:  true,
+		errors: ParseErrors{
+			ParseErr{
+				PositionRange: posrange.PositionRange{Start: 19, End: 23},
+				Err:           errors.New("no @ modifiers allowed before range"),
+				Query:         `some_metric @ end()[5m]`,
+			},
+		},
+	},
+	{
+		input: `some_metric offset step()[5m]`,
+		fail:  true,
+		errors: ParseErrors{
+			ParseErr{
+				PositionRange: posrange.PositionRange{Start: 25, End: 29},
+				Err:           errors.New("no offset modifiers allowed before range"),
+				Query:         `some_metric offset step()[5m]`,
+			},
+		},
+	},
+	{
 		input: `(foo + bar)[5m]`,
 		fail:  true,
 		errors: ParseErrors{


### PR DESCRIPTION
`matrix_selector` already rejects `foo offset 5m[5m]` and `foo @ 1234[5m]`, but it only looked at `OriginalOffset` and `Timestamp`. Duration-expression offsets and `@ start()` / `@ end()` live in `OriginalOffsetExpr` and `StartOrEnd`, so these still parsed:

```promql
foo offset step()[5m]
foo @ start()[5m]
foo @ end()[5m]
```

The valid forms remain `foo[5m] offset step()` and `foo[5m] @ start()`.

This is the range-selector counterpart of #17060 / #17852, which covers the same mistake on subquery selectors. I left subquery productions alone to avoid overlapping that PR; they still need a `StartOrEnd` check there (`foo @ start()[5m:1s]`).

cc @roidelapluie @vpranckaitis @bboreham

Related to #17060

#### Which issue(s) does the PR fix:

Related to #17060

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] PromQL: Reject duration-expression offsets and `@ start()` / `@ end()` before range selectors, matching the existing rejection of literal offsets and `@ <timestamp>`.
```
