### PR TITLE
discovery/file: wait for a matching snapshot instead of failing on empty updates

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -14,6 +14,7 @@
 package file
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -216,31 +217,45 @@ func (t *testRunner) targets() []*targetgroup.Group {
 func (t *testRunner) requireUpdate(ref time.Time, expected []*targetgroup.Group) {
 	t.Helper()
 
+	want, err := json.Marshal(expected)
+	require.NoError(t, err)
+
 	timeout := time.After(defaultWait)
 	for {
 		select {
 		case <-timeout:
-			t.Fatal("Expected update but got none")
+			t.Fatalf("Expected update but got none, last: %s", t.targetGroupsJSON(t.targets()))
 		case <-time.After(defaultWait / 10):
 			if ref.Equal(t.lastReceive()) {
 				// No update received.
 				break
 			}
 
-			// We can receive partial updates so only check the result when the
-			// expected number of groups is reached.
+			// File SD can emit an empty snapshot (matching group count) before
+			// the file contents are visible. Keep waiting until the groups
+			// match rather than failing on the first incomplete update.
 			tgs := t.targets()
-			if len(tgs) != len(expected) {
-				t.Logf("skipping update: expected %d targets, got %d", len(expected), len(tgs))
+			got, err := json.Marshal(tgs)
+			require.NoError(t, err)
+			if !bytes.Equal(want, got) {
+				t.Logf("skipping incomplete update: %s", got)
 				break
 			}
-			t.requireTargetGroups(expected, tgs)
 			if ref.After(time.Time{}) {
 				t.Logf("update received after %v", t.lastReceive().Sub(ref))
 			}
 			return
 		}
 	}
+}
+
+func (t *testRunner) targetGroupsJSON(tgs []*targetgroup.Group) string {
+	t.Helper()
+	b, err := json.Marshal(tgs)
+	if err != nil {
+		return err.Error()
+	}
+	return string(b)
 }
 
 func (t *testRunner) requireTargetGroups(expected, got []*targetgroup.Group) {


### PR DESCRIPTION
#18259 stopped tests from truncating SD files to zero bytes, but `requireUpdate` still treated the first snapshot with the expected *number* of groups as the result. File SD can emit empty groups (`[{"targets":[]},{"targets":[]}]`) before the file contents are visible, so `TestInvalidFileUpdate` and `TestUpdateFileWithPartialWrites` still flake.

Wait until the groups match the expected snapshot (or time out). #18259 can stay; this is the remaining race in the test helper.

cc @machine424 @bwplotka @krajorama

Fixes #18269

#### Which issue(s) does the PR fix:

Fixes #18269

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```
