### PR TITLE
docs: note that Kubernetes pod __address__ may omit the port

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2484,6 +2484,7 @@ Available meta labels:
 The `pod` role discovers all pods and exposes their containers as targets. For each declared
 port of a container, a single target is generated. If a container has no specified ports,
 a port-free target per container is created for manually adding a port via relabeling.
+In that case `__address__` is set to the pod IP only, without a port.
 
 Available meta labels:
 
@@ -3563,6 +3564,9 @@ You can also use special labels like `__address__`, `__scheme__`, `__metrics_pat
 override the respective settings in the scrape configuration.
 
 The `__address__` label is set to the `<host>:<port>` address of the target.
+Some service discovery implementations omit the port when none is known, so
+that it can be added via relabeling. Kubernetes pod discovery does this for
+containers that declare no ports; `__address__` is then the pod IP only.
 After relabeling, the `instance` label is set to the value of `__address__` by default if
 it was not set during relabeling.
 


### PR DESCRIPTION
The generic relabel docs say `__address__` is always `<host>:<port>`. Kubernetes pod SD sets `__address__` to the pod IP with no port when a container declares none, so a port can be added via relabeling. That is already described under the `pod` role; this makes the relabel section match.

cc @brancz @rexagod @machine424

Fixes #11678

#### Which issue(s) does the PR fix:

Fixes #11678

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```
