### PR TITLE
tsdb: avoid retaining oversized record buffers

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -334,6 +334,11 @@ func (h *Head) putTypeMap(b map[chunks.HeadSeriesRef]sampleType) {
 	h.typeMapPool.Put(b)
 }
 
+// maxPooledBytesBufferCapacity is the maximum capacity retained for reusable
+// record buffers. Larger buffers are released after use to avoid retaining
+// one-off large batches.
+const maxPooledBytesBufferCapacity = 1_000_000
+
 func (h *Head) getBytesBuffer() []byte {
 	b := h.bytesPool.Get()
 	if b == nil {
@@ -343,6 +348,9 @@ func (h *Head) getBytesBuffer() []byte {
 }
 
 func (h *Head) putBytesBuffer(b []byte) {
+	if cap(b) > maxPooledBytesBufferCapacity {
+		return
+	}
 	h.bytesPool.Put(b[:0])
 }
 

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -252,6 +252,29 @@ func BenchmarkHeadAppender_AppendCommit(b *testing.B) {
 	}
 }
 
+func BenchmarkHeadBytesBufferPool(b *testing.B) {
+	for _, capacity := range []int{maxPooledBytesBufferCapacity, maxPooledBytesBufferCapacity + 1} {
+		b.Run(fmt.Sprintf("capacity=%d", capacity), func(b *testing.B) {
+			h := &Head{}
+			buf := make([]byte, 0, capacity)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				h.putBytesBuffer(buf)
+				buf = h.getBytesBuffer()
+				if cap(buf) < capacity {
+					buf = make([]byte, 0, capacity)
+				}
+			}
+
+			b.StopTimer()
+			h.putBytesBuffer(buf)
+			b.ReportMetric(float64(cap(h.getBytesBuffer())), "retained-cap-B")
+		})
+	}
+}
+
 func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 	chunkDir := b.TempDir()
 	// Put a series, select it. GC it and then access it.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -103,6 +103,14 @@ func newTestHeadWithOptions(t testing.TB, compressWAL compression.Type, opts *He
 	return h, wal
 }
 
+func TestHeadDoesNotPoolOversizedBytesBuffer(t *testing.T) {
+	h := &Head{}
+	h.putBytesBuffer(make([]byte, 0, maxPooledBytesBufferCapacity+1))
+
+	reused := h.getBytesBuffer()
+	require.LessOrEqual(t, cap(reused), maxPooledBytesBufferCapacity)
+}
+
 func BenchmarkCreateSeries(b *testing.B) {
 	series := genSeries(b.N, 10, 0, 0)
 	h, _ := newTestHead(b, 10000, compression.None, false)


### PR DESCRIPTION
Bounds the reusable TSDB record-buffer pool at 1 MB so unusually large OOO/WBL batches can be collected after commit. Buffers at or below the limit remain reusable.

Adds a regression test for the retention limit and a benchmark covering both sides of the threshold. In six benchmark runs, the 1 MB case stayed at about 29.5 ns/op with zero allocations. For the oversized case, retained capacity dropped from 976.563 KiB to 1 KiB; a deliberately repeated oversized workload reallocates about 985 KiB/op, which is the intended memory/CPU tradeoff.

#### Which issue(s) does the PR fix:

Fixes #19397

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] TSDB: Avoid retaining oversized out-of-order record buffers after commit.
```

Validation: `go test ./...`, focused test x100, race-focused test x50, `golangci-lint run --timeout 4m ./tsdb/...`, and benchmark x6 with benchstat.