### PR TITLE
Add more spans to tracing

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -37,6 +37,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/prometheus/prometheus/model/histogram"
@@ -787,11 +788,20 @@ func durationMilliseconds(d time.Duration) int64 {
 func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.EvalStmt) (parser.Value, annotations.Annotations, error) {
 	prepareSpanTimer, ctxPrepare := query.stats.GetSpanTimer(ctx, stats.QueryPreparationTime, ng.metrics.queryPrepareTime, ng.metrics.queryPrepareTimeHistogram)
 	mint, maxt := FindMinMaxTime(s)
+
+	_, querierSpan := otel.Tracer("").Start(ctxPrepare, "Querier", trace.WithAttributes(
+		attribute.Int64("mint", mint),
+		attribute.Int64("maxt", maxt),
+	))
 	querier, err := query.queryable.Querier(mint, maxt)
 	if err != nil {
+		querierSpan.RecordError(err)
+		querierSpan.SetStatus(codes.Error, err.Error())
+		querierSpan.End()
 		prepareSpanTimer.Finish()
 		return nil, nil, err
 	}
+	querierSpan.End()
 	defer querier.Close()
 
 	ng.populateSeries(ctxPrepare, querier, s)
@@ -1065,7 +1075,13 @@ func (ng *Engine) populateSeries(ctx context.Context, querier storage.Querier, s
 			}
 			evalRange = 0
 			hints.By, hints.Grouping = extractGroupsFromPath(path)
-			n.UnexpandedSeriesSet = querier.Select(ctx, false, hints, n.LabelMatchers...)
+			selectCtx, selectSpan := otel.Tracer("").Start(ctx, "querierSelect", trace.WithAttributes(
+				attribute.String("selector", n.String()),
+				attribute.Int64("start", hints.Start),
+				attribute.Int64("end", hints.End),
+			))
+			n.UnexpandedSeriesSet = querier.Select(selectCtx, false, hints, n.LabelMatchers...)
+			selectSpan.End()
 		case *parser.MatrixSelector:
 			evalRange = n.Range
 		}
@@ -1113,8 +1129,11 @@ func checkAndExpandSeriesSet(ctx context.Context, expr parser.Expr) (annotations
 		if e.Series != nil {
 			return nil, nil
 		}
-		span := trace.SpanFromContext(ctx)
-		span.AddEvent("expand start", trace.WithAttributes(attribute.String("selector", e.String())))
+		// This span is created only when a selector is read from storage. The
+		// result is cached in e.Series. At most one span is produced per storage
+		// selector per query. The span is not produced per step or per series.
+		ctx, span := otel.Tracer("").Start(ctx, "promqlExpandSeries", trace.WithAttributes(attribute.String("selector", e.String())))
+		defer span.End()
 		series, ws, err := expandSeriesSet(ctx, e.UnexpandedSeriesSet)
 		if e.SkipHistogramBuckets {
 			for i := range series {
@@ -1122,7 +1141,11 @@ func checkAndExpandSeriesSet(ctx context.Context, expr parser.Expr) (annotations
 			}
 		}
 		e.Series = series
-		span.AddEvent("expand end", trace.WithAttributes(attribute.Int("num_series", len(series))))
+		span.SetAttributes(attribute.Int("num_series", len(series)))
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
 		return ws, err
 	}
 	return nil, nil

--- a/rules/group.go
+++ b/rules/group.go
@@ -513,7 +513,12 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 
 		logger := g.logger.With("name", rule.Name(), "index", i)
 		ctx, sp := otel.Tracer("").Start(ctx, "rule")
-		sp.SetAttributes(attribute.String("name", rule.Name()))
+		sp.SetAttributes(
+			attribute.String("group", g.Name()),
+			attribute.String("name", rule.Name()),
+			attribute.Stringer("query_offset", ruleQueryOffset),
+			attribute.Int("index", i),
+		)
 		defer func(t time.Time) {
 			sp.End()
 
@@ -548,6 +553,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 		rule.SetHealth(HealthGood)
 		rule.SetLastError(nil)
 		samplesTotal.Add(float64(len(vector)))
+		sp.SetAttributes(attribute.Int("num_series", len(vector)))
 
 		if ar, ok := rule.(*AlertingRule); ok {
 			ar.sendAlerts(ctx, ts, g.opts.ResendDelay, g.interval, g.opts.NotifyFunc)
@@ -558,10 +564,22 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			numDuplicates = 0
 		)
 
+		// The appender can block on storage and for simple queries it can
+		// be the majority of trace duration. Trace it using dedicated span
+		// so it's clear from the trace where did all the duration go.
+		_, appenderSp := otel.Tracer("").Start(ctx, "newAppender")
 		app := g.opts.Appendable.Appender(ctx)
+		appenderSp.End()
 		seriesReturned := make(map[string]labels.Labels, len(g.seriesInPreviousEval[i]))
 		defer func() {
-			if err := app.Commit(); err != nil {
+			_, commitSp := otel.Tracer("").Start(ctx, "ruleCommit")
+			err := app.Commit()
+			if err != nil {
+				commitSp.RecordError(err)
+				commitSp.SetStatus(codes.Error, err.Error())
+			}
+			commitSp.End()
+			if err != nil {
 				rule.SetHealth(HealthBad)
 				rule.SetLastError(err)
 				sp.SetStatus(codes.Error, err.Error())
@@ -572,6 +590,11 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			}
 			g.seriesInPreviousEval[i] = seriesReturned
 		}()
+
+		// Trace the time to write the evaluation result samples into the
+		// appender. This span ends before the commit span starts.
+		_, appendSp := otel.Tracer("").Start(ctx, "ruleAppendResults")
+		defer appendSp.End()
 
 		for _, s := range vector {
 			if s.H != nil {

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -29,6 +29,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -84,6 +87,25 @@ func DefaultEvalIterationFunc(ctx context.Context, g *Group, evalTimestamp time.
 	g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Inc()
 
 	start := time.Now()
+
+	// Start the group evaluation span at the scheduled evaluation time.
+	// This allows our trace to show if the actual evaluation was delayed.
+	ctx, sp := otel.Tracer("").Start(ctx, "rule group", trace.WithTimestamp(evalTimestamp))
+	sp.SetAttributes(
+		attribute.String("name", g.Name()),
+		attribute.String("file", g.File()),
+		attribute.Stringer("interval", g.interval),
+		attribute.String("scheduled", evalTimestamp.Format(time.RFC3339Nano)),
+	)
+	defer sp.End()
+
+	// If there's a delay then record that as a dedicated span, so it's clear
+	// from the trace that the whole group evaluated later then scheduled.
+	if start.After(evalTimestamp) {
+		_, delaySp := otel.Tracer("").Start(ctx, "scheduleDelay", trace.WithTimestamp(evalTimestamp))
+		delaySp.End(trace.WithTimestamp(start))
+	}
+
 	g.Eval(ctx, evalTimestamp)
 	timeSinceStart := time.Since(start)
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -41,6 +41,8 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
 
@@ -743,7 +745,8 @@ func (s *targetScraper) scrape(ctx context.Context) (*http.Response, error) {
 
 		s.req = req
 	}
-	ctx, span := otel.Tracer("").Start(ctx, "Scrape", trace.WithSpanKind(trace.SpanKindClient))
+	ctx, span := otel.Tracer("").Start(ctx, "scrapeRequest", trace.WithSpanKind(trace.SpanKindClient))
+	span.SetAttributes(attribute.String("url", s.URL().Redacted()))
 	defer span.End()
 
 	// If the target has a unix socket path, pass it via the context so the
@@ -1347,6 +1350,9 @@ func (sl *scrapeLoop) appender() scrapeLoopAppendAdapter {
 func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- error) time.Time {
 	start := time.Now()
 
+	spanCtx, span := otel.Tracer("").Start(sl.appenderCtx, "scrape")
+	defer span.End()
+
 	// Only record after the first scrape.
 	if !last.IsZero() {
 		sl.metrics.targetIntervalLength.WithLabelValues(sl.interval.String()).Observe(
@@ -1360,13 +1366,21 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 	var total, added, seriesAdded, bytesRead int
 	var err, appErr, scrapeErr error
 
+	_, appenderSpan := otel.Tracer("").Start(spanCtx, "newAppender")
 	app := sl.appender()
+	appenderSpan.End()
 	defer func() {
 		if err != nil {
 			_ = app.Rollback()
 			return
 		}
+		_, commitSpan := otel.Tracer("").Start(spanCtx, "scrapeCommit")
 		err = app.Commit()
+		if err != nil {
+			commitSpan.RecordError(err)
+			commitSpan.SetStatus(codes.Error, err.Error())
+		}
+		commitSpan.End()
 		if sl.reportExtraMetrics {
 			totalDuration := time.Since(start)
 			// Record total scrape duration metric.
@@ -1378,7 +1392,14 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 	}()
 
 	defer func() {
-		if err = sl.report(app, appendTime, time.Since(start), total, added, seriesAdded, bytesRead, scrapeErr); err != nil {
+		_, reportSpan := otel.Tracer("").Start(spanCtx, "scrapeReport")
+		err = sl.report(app, appendTime, time.Since(start), total, added, seriesAdded, bytesRead, scrapeErr)
+		if err != nil {
+			reportSpan.RecordError(err)
+			reportSpan.SetStatus(codes.Error, err.Error())
+		}
+		reportSpan.End()
+		if err != nil {
 			sl.l.Warn("Appending scrape report failed", "err", err)
 		}
 	}()
@@ -1405,13 +1426,20 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 	var resp *http.Response
 	var b []byte
 	var buf *bytes.Buffer
-	scrapeCtx, cancel := context.WithTimeout(sl.parentCtx, sl.timeout)
+	scrapeCtx, cancel := context.WithTimeout(trace.ContextWithSpan(sl.parentCtx, span), sl.timeout)
 	resp, scrapeErr = sl.scraper.scrape(scrapeCtx)
 	if scrapeErr == nil {
 		b = sl.buffers.Get(sl.lastScrapeSize).([]byte)
 		defer sl.buffers.Put(b)
 		buf = bytes.NewBuffer(b)
+		// Trace the response body read and decompression into the buffer.
+		_, readSpan := otel.Tracer("").Start(spanCtx, "scrapeRead")
 		contentType, scrapeErr = sl.scraper.readResponse(scrapeCtx, resp, buf)
+		if scrapeErr != nil {
+			readSpan.RecordError(scrapeErr)
+			readSpan.SetStatus(codes.Error, scrapeErr.Error())
+		}
+		readSpan.End()
 	}
 	cancel()
 
@@ -1444,7 +1472,13 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 
 	// A failed scrape is the same as an empty scrape,
 	// we still call sl.append to trigger stale markers.
+	_, appendSpan := otel.Tracer("").Start(spanCtx, "scrapeAppend")
 	total, added, seriesAdded, appErr = app.append(b, contentType, appendTime)
+	if appErr != nil {
+		appendSpan.RecordError(appErr)
+		appendSpan.SetStatus(codes.Error, appErr.Error())
+	}
+	appendSpan.End()
 	if appErr != nil {
 		_ = app.Rollback()
 		app = sl.appender()
@@ -1460,6 +1494,17 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 
 	if scrapeErr == nil {
 		scrapeErr = appErr
+	}
+
+	span.SetAttributes(
+		attribute.Int("samples_scraped", total),
+		attribute.Int("samples_added", added),
+		attribute.Int("series_added", seriesAdded),
+		attribute.Int("bytes", bytesRead),
+	)
+	if scrapeErr != nil {
+		span.RecordError(scrapeErr)
+		span.SetStatus(codes.Error, scrapeErr.Error())
 	}
 
 	return start

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -41,6 +41,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/prometheus/prometheus/config"
@@ -523,6 +527,26 @@ func (*API) options(*http.Request) apiFuncResult {
 	return apiFuncResult{nil, nil, nil, nil}
 }
 
+func setQueryResultSpanAttributes(span trace.Span, qry promql.Query, value parser.Value) {
+	var resultSeries int
+	switch v := value.(type) {
+	case promql.Matrix:
+		resultSeries = v.Len()
+	case promql.Vector:
+		resultSeries = len(v)
+	}
+
+	var totalSamples int64
+	if s := qry.Stats(); s != nil && s.Samples != nil {
+		totalSamples = s.Samples.TotalSamples
+	}
+
+	span.SetAttributes(
+		attribute.Int("result_series", resultSeries),
+		attribute.Int64("total_samples", totalSamples),
+	)
+}
+
 func (api *API) query(r *http.Request) (result apiFuncResult) {
 	limit, err := parseLimitParam(r.FormValue("limit"))
 	if err != nil {
@@ -548,8 +572,19 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
+
+	ctx, span := otel.Tracer("").Start(ctx, "promqlInstantQuery")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("query", r.FormValue("query")),
+		attribute.String("timeout", r.FormValue("timeout")),
+		attribute.String("time", ts.Format(time.RFC3339Nano)),
+	)
+
 	qry, err := api.QueryEngine.NewInstantQuery(ctx, api.Queryable, opts, r.FormValue("query"), ts)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return invalidParamError(err, "query")
 	}
 
@@ -566,8 +601,11 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 
 	res := qry.Exec(ctx)
 	if res.Err != nil {
+		span.RecordError(res.Err)
+		span.SetStatus(codes.Error, res.Err.Error())
 		return apiFuncResult{nil, returnAPIError(res.Err), res.Warnings, qry.Close}
 	}
+	setQueryResultSpanAttributes(span, qry, res.Value)
 
 	warnings := res.Warnings
 	if limit > 0 {
@@ -706,8 +744,21 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
+
+	ctx, span := otel.Tracer("").Start(ctx, "promqlRangeQuery")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("query", r.FormValue("query")),
+		attribute.String("timeout", r.FormValue("timeout")),
+		attribute.String("start", start.Format(time.RFC3339Nano)),
+		attribute.String("end", end.Format(time.RFC3339Nano)),
+		attribute.Stringer("step", step),
+	)
+
 	qry, err := api.QueryEngine.NewRangeQuery(ctx, api.Queryable, opts, r.FormValue("query"), start, end, step)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return invalidParamError(err, "query")
 	}
 	// From now on, we must only return with a finalizer in the result (to
@@ -723,8 +774,11 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 
 	res := qry.Exec(ctx)
 	if res.Err != nil {
+		span.RecordError(res.Err)
+		span.SetStatus(codes.Error, res.Err.Error())
 		return apiFuncResult{nil, returnAPIError(res.Err), res.Warnings, qry.Close}
 	}
+	setQueryResultSpanAttributes(span, qry, res.Value)
 
 	warnings := res.Warnings
 	if limit > 0 {


### PR DESCRIPTION
I was trying to use tracing to debug some rules skipping evaluation and other random slowness but I find current set of spans not really giving me enough information. This adds a bunch more spans all over the place:

- engine now shows a span per series selected from tsdb, so a query that's doing a ton of selects shows them all more clearly
- rule evaluations now start with the group, so you can lookup a group run and clearly see if rules are running concurrently, which rules are slowing which others etc
- there's a span for scheduling delay of rule evaluation, which helps to understand why a rule running time() returns lagging results from queries - if it gets scheduled late (because time() returns time of when it was suppose to run I think)
- there are spans for appenders and commits, so it's clear when rules are blocked on isolation and writes
- scrape is now broken down more so it's more clear where does all the time go

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[ENHANCEMENT] Tracing: add more spans to scrapes, API queries and rule evaluations

```
