### PR TITLE
tsdb: release oversized head-chunk cache for single-chunk series

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -560,15 +560,15 @@ func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 		return nil
 	}
 
-	key := headChunkCacheKeyFor(s)
-	h.releaseOversizedCacheOnSeriesSwitch(key.ref)
-	// A series with at most one head chunk takes the direct lookup path. Release
-	// an oversized cache when moving to such a series, but preserve it while it
-	// still serves the same series.
+	// Release an oversized cache before the direct lookup path for a series with
+	// at most one head chunk, while preserving it when it still serves the same
+	// series.
+	h.releaseOversizedCacheOnSeriesSwitch(storage.SeriesRef(s.ref))
 	if s.headChunks == nil || s.headChunks.prev == nil {
 		return nil
 	}
 
+	key := headChunkCacheKeyFor(s)
 	if key == h.cachedKey {
 		return h.cachedHeadChunks
 	}

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -526,9 +526,19 @@ func (h *headChunkReader) Close() error {
 		h.isoState.Close()
 	}
 	// Release the cache so a closed reader retains no chunk data.
+	h.resetCache()
+	return nil
+}
+
+func (h *headChunkReader) resetCache() {
 	h.cachedKey = headChunkCacheKey{}
 	h.cachedHeadChunks = nil
-	return nil
+}
+
+func (h *headChunkReader) releaseOversizedCacheOnSeriesSwitch(ref storage.SeriesRef) {
+	if cap(h.cachedHeadChunks) > headChunksBufMaxCap && ref != h.cachedKey.ref {
+		h.resetCache()
+	}
 }
 
 // EnableChunkCache enables the head-chunk cache for sequential chunk access
@@ -545,12 +555,20 @@ func (h *headChunkReader) EnableChunkCache() {
 // The series lock must be held; the fingerprint comparison is only consistent
 // against concurrent appends, mmapping, and truncation under that lock.
 func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
-	// Skip if the cache is disabled (instant queries) or there are no head chunks or there's only one.
-	if !h.enableCache || s.headChunks == nil || s.headChunks.prev == nil {
+	// Skip if the cache is disabled (instant queries).
+	if !h.enableCache {
 		return nil
 	}
 
 	key := headChunkCacheKeyFor(s)
+	h.releaseOversizedCacheOnSeriesSwitch(key.ref)
+	// A series with at most one head chunk takes the direct lookup path. Release
+	// an oversized cache when moving to such a series, but preserve it while it
+	// still serves the same series.
+	if s.headChunks == nil || s.headChunks.prev == nil {
+		return nil
+	}
+
 	if key == h.cachedKey {
 		return h.cachedHeadChunks
 	}
@@ -560,7 +578,7 @@ func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 	// from one series to the next (the headChunksBufMaxCap policy used for
 	// headChunksBuf) — but keep a large array while it still serves the same
 	// series.
-	if c := cap(buf); c == 0 || (c > headChunksBufMaxCap && key.ref != h.cachedKey.ref) {
+	if cap(buf) == 0 {
 		buf = make([]*memChunk, 0, s.headChunkCount.Load())
 	}
 	h.cachedHeadChunks = collectHeadChunks(s.headChunks, buf)

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -712,10 +712,12 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		h, _ := newTestHeadWithOptions(t, compression.None, opts)
 
 		// The big series gets more than headChunksBufMaxCap head chunks
-		// (ChunkRange=1 cuts a chunk per sample); the small series a few.
+		// (ChunkRange=1 cuts a chunk per sample), the small series a few,
+		// and the single series exactly one.
 		app := h.Appender(t.Context())
 		big := labels.FromStrings("__name__", "big")
 		small := labels.FromStrings("__name__", "small")
+		single := labels.FromStrings("__name__", "single")
 		for i := range int64(headChunksBufMaxCap) + 10 {
 			_, err := app.Append(0, big, i, float64(i))
 			require.NoError(t, err)
@@ -724,12 +726,19 @@ func TestHeadChunkReaderCache(t *testing.T) {
 			_, err := app.Append(0, small, i, float64(i))
 			require.NoError(t, err)
 		}
+		_, err := app.Append(0, single, 0, 0)
+		require.NoError(t, err)
 		require.NoError(t, app.Commit())
 
 		bigSeries := h.series.getByHash(big.Hash(), big)
 		require.NotNil(t, bigSeries)
 		smallSeries := h.series.getByHash(small.Hash(), small)
 		require.NotNil(t, smallSeries)
+		singleSeries := h.series.getByHash(single.Hash(), single)
+		require.NotNil(t, singleSeries)
+		require.Greater(t, bigSeries.headChunkCount.Load(), uint32(headChunksBufMaxCap))
+		require.Greater(t, smallSeries.headChunkCount.Load(), uint32(1))
+		require.Equal(t, uint32(1), singleSeries.headChunkCount.Load())
 
 		cr, err := h.chunksRange(0, 10000, nil)
 		require.NoError(t, err)
@@ -747,6 +756,48 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(smallRef)}, false)
 		require.NoError(t, err)
 		require.LessOrEqual(t, cap(cr.cachedHeadChunks), headChunksBufMaxCap)
+
+		// Repopulate the oversized cache, then switch to a series whose
+		// single-chunk fast path does not need the cache. The old cache and
+		// its key must both be released.
+		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(bigRef)}, false)
+		require.NoError(t, err)
+		require.Greater(t, cap(cr.cachedHeadChunks), headChunksBufMaxCap)
+		require.NotEqual(t, headChunkCacheKey{}, cr.cachedKey)
+
+		singleRef := chunks.NewHeadChunkRef(singleSeries.ref, singleSeries.firstChunkID)
+		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(singleRef)}, false)
+		require.NoError(t, err)
+		require.Nil(t, cr.cachedHeadChunks)
+		require.Equal(t, headChunkCacheKey{}, cr.cachedKey)
+
+		// Cache enablement is unchanged after releasing the oversized cache.
+		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(bigRef)}, false)
+		require.NoError(t, err)
+		require.Greater(t, cap(cr.cachedHeadChunks), headChunksBufMaxCap)
+
+		// The Head+OOO reader can return materialized OOO chunks without
+		// collecting in-order head chunks. It must still observe the series
+		// switch and release the oversized in-order cache.
+		wrappedCR := NewHeadAndOOOChunkReader(h, 0, 10000, cr, nil, 0)
+		materializedOOOChunk := chunkenc.NewXORChunk()
+		oooRef := chunks.NewHeadChunkRef(singleSeries.ref, oooChunkIDMask)
+		gotChunk, gotIterable, err := wrappedCR.ChunkOrIterable(chunks.Meta{
+			Ref:     chunks.ChunkRef(oooRef),
+			Chunk:   materializedOOOChunk,
+			MinTime: 0,
+			MaxTime: 0,
+		})
+		require.NoError(t, err)
+		require.Same(t, materializedOOOChunk, gotChunk)
+		require.Nil(t, gotIterable)
+		require.Nil(t, cr.cachedHeadChunks)
+		require.Equal(t, headChunkCacheKey{}, cr.cachedKey)
+
+		// Cache enablement is unchanged after release through the wrapper.
+		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(bigRef)}, false)
+		require.NoError(t, err)
+		require.Greater(t, cap(cr.cachedHeadChunks), headChunksBufMaxCap)
 	})
 
 	t.Run("released_on_close", func(t *testing.T) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -255,6 +255,9 @@ func (cr *HeadAndOOOChunkReader) chunkOrIterable(meta chunks.Meta, copyLastChunk
 
 	s.Lock()
 	defer s.Unlock()
+	if cr.cr != nil {
+		cr.cr.releaseOversizedCacheOnSeriesSwitch(storage.SeriesRef(s.ref))
+	}
 
 	if meta.Chunk == nil {
 		var headChunks []*memChunk


### PR DESCRIPTION
Range-query and compaction readers cache collected head chunks for sequential access. When a reader moved from a series with more than `headChunksBufMaxCap` head chunks to a different series with zero or one head chunk, the direct-lookup fast path returned before applying the capacity policy. The reader then retained the oversized backing array and its chunk pointers until it closed or visited another multi-chunk series.

Release the oversized cache on that series switch, resetting the fingerprint and slice together. Preserve the backing array for the same series so it can still be reused after mmap or truncation. The cache-cap regression now covers both multi-chunk and single-chunk destinations and verifies that caching can repopulate after the release.

<details>
<summary>Benchstat</summary>

Compared base `44d6a0e0b` with head `da183769b` using Go 1.26.6 on Darwin/ARM64 with an Apple M4 Pro. The temporary harness enabled the cache with `SelectHints.Step = 15s`; six samples per revision were interleaved and order-balanced.

| Cache-enabled benchmark | Base | Head | Result |
| --- | ---: | ---: | --- |
| `HeadChunkQuerier/multi_chunk` | 377.4µs | 379.5µs | No significant change (`p=0.310`) |
| `HeadChunkQuerier/single_chunk` | 36.36µs | 36.63µs | No significant change (`p=0.394`) |
| `HeadQuerier/multi_chunk` | 842.9µs | 861.0µs | +2.15% (`p=0.015`); not reproduced |
| `HeadQuerier/single_chunk` | 28.00µs | 28.39µs | No significant change (`p=0.394`) |

The initial `HeadQuerier/multi_chunk` result did not reproduce in a fresh six-sample confirmation (846.3µs base versus 845.5µs head, `p=0.310`); its cache-disabled control was also unchanged. Cache-enabled allocations/op were identical, and B/op showed no significant difference. No reproducible cache-enabled performance regression was found.

</details>

#### Which issue(s) does the PR fix:

Follow-up to #19136.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] TSDB: Avoid excess memory retention during range queries and head compaction after reading series with many in-memory chunks
```
