### PR TITLE
prw2-receive: accept PRW2 series that carry only exemplars

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -351,9 +351,8 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 			continue
 		}
 
-		// Validate that the TimeSeries has at least one sample or histogram.
-		if len(ts.Samples) == 0 && len(ts.Histograms) == 0 {
-			badRequestErrs = append(badRequestErrs, fmt.Errorf("TimeSeries must contain at least one sample or histogram for series %v", ls.String()))
+		if len(ts.Samples) == 0 && len(ts.Histograms) == 0 && len(ts.Exemplars) == 0 {
+			badRequestErrs = append(badRequestErrs, fmt.Errorf("TimeSeries must contain at least one sample, histogram or exemplar for series %v", ls.String()))
 			continue
 		}
 

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -350,11 +350,12 @@ func expectHeaderValue(t testing.TB, expected int, got string) {
 func TestRemoteWriteHandler_V2Message(t *testing.T) {
 	// V2 supports partial writes for non-retriable errors, so test them.
 	for _, tc := range []struct {
-		desc             string
-		input            []writev2.TimeSeries
-		symbols          []string // Custom symbol table for tests that need it
-		expectedCode     int
-		expectedRespBody string
+		desc                          string
+		input                         []writev2.TimeSeries
+		symbols                       []string // Custom symbol table for tests that need it
+		expectedCode                  int
+		expectedRespBody              string
+		expectedExtraExemplarsWritten int
 
 		commitErr             error
 		appendSampleErr       error
@@ -453,20 +454,28 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 			expectedRespBody: "parsing metadata for series [1 2]: metadata help_ref 999 outside of symbols table (size 18)\n",
 		},
 		{
-			desc: "Partial write; TimeSeries with only exemplars (no samples or histograms)",
+			desc: "TimeSeries with only exemplars (no samples or histograms) accepted",
 			input: append(
+				append([]writev2.TimeSeries{}, writeV2RequestFixture.Timeseries...),
 				// Series with only exemplars, no samples or histograms.
-				[]writev2.TimeSeries{{
+				writev2.TimeSeries{
 					LabelsRefs: []uint32{1, 2},
 					Exemplars: []writev2.Exemplar{{
 						LabelsRefs: []uint32{},
 						Value:      1.0,
-						Timestamp:  1,
+						Timestamp:  30,
 					}},
-				}},
+				}),
+			expectedCode:                  http.StatusNoContent,
+			expectedExtraExemplarsWritten: 1,
+		},
+		{
+			desc: "Partial write; first series with no samples, histograms or exemplars",
+			input: append(
+				[]writev2.TimeSeries{{LabelsRefs: []uint32{1, 2}}},
 				writeV2RequestFixture.Timeseries...),
 			expectedCode:     http.StatusBadRequest,
-			expectedRespBody: "TimeSeries must contain at least one sample or histogram for series {__name__=\"test_metric1\"}\n",
+			expectedRespBody: "TimeSeries must contain at least one sample, histogram or exemplar for series {__name__=\"test_metric1\"}\n",
 		},
 		{
 			desc: "Partial write; first series with one OOO sample",
@@ -773,7 +782,7 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 			if tc.appendExemplarErr != nil {
 				expectHeaderValue(t, 0, resp.Header.Get(rw20WrittenExemplarsHeader))
 			} else {
-				expectHeaderValue(t, 2, resp.Header.Get(rw20WrittenExemplarsHeader))
+				expectHeaderValue(t, 2+tc.expectedExtraExemplarsWritten, resp.Header.Get(rw20WrittenExemplarsHeader))
 			}
 
 			// Double check what was actually appended.


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

The PRW2 receiver drops series that carry only exemplars, so exemplars in those series are dropped.
Prometheus senders send exemplars in exactly this shape, so their exemplars are lost.
Fixed by rejecting a `TimeSeries` only when it carries no samples, no histograms and no exemplars.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Remote-write: No longer skip PRW2 series that carry only exemplars, as Prometheus senders emit them. Those exemplars were dropped and the request answered with a 400 partial write.
```
