### PR TITLE
tsdb: reserve disk space before block compaction

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -319,6 +319,10 @@ type DB struct {
 	compactor      Compactor
 	blocksToDelete BlocksToDeleteFunc
 
+	defaultDeletionPolicy bool
+	// compactionSize is only set while cmtx is held.
+	compactionSize int64
+
 	// mtx must be held when modifying the general block layout or lastGarbageCollectedMmapRef.
 	mtx    sync.RWMutex
 	blocks []*Block
@@ -1040,6 +1044,7 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 		blocksToDelete: opts.BlocksToDelete,
 		registerer:     r,
 	}
+	db.defaultDeletionPolicy = db.blocksToDelete == nil
 	defer func() {
 		// Close files if startup fails somewhere.
 		if returnedErr == nil {
@@ -2010,6 +2015,16 @@ func (db *DB) compactBlocks() (err error) {
 			break
 		}
 
+		deleted, err := db.reserveSpaceForCompaction(plan)
+		if err != nil {
+			return fmt.Errorf("reserve space for compaction: %w", err)
+		}
+		if deleted {
+			// Retention may have removed one of the planned blocks. Always plan
+			// again after changing the block layout.
+			continue
+		}
+
 		select {
 		case <-db.stopc:
 			return nil
@@ -2033,6 +2048,63 @@ func (db *DB) compactBlocks() (err error) {
 	}
 
 	return nil
+}
+
+// reserveSpaceForCompaction applies size retention before compaction so the
+// replacement block can be written without exceeding the configured limit.
+func (db *DB) reserveSpaceForCompaction(plan []string) (bool, error) {
+	if !db.defaultDeletionPolicy {
+		return false, nil
+	}
+	maxBytes, maxPercentage := db.getRetentionSettings()
+	if maxBytes <= 0 && maxPercentage <= 0 {
+		return false, nil
+	}
+
+	planned := make(map[string]struct{}, len(plan))
+	for _, dir := range plan {
+		planned[filepath.Clean(dir)] = struct{}{}
+	}
+
+	blocks := slices.Clone(db.Blocks())
+	var plannedSize int64
+	for _, block := range blocks {
+		if _, ok := planned[filepath.Clean(block.Dir())]; !ok {
+			continue
+		}
+		plannedSize += block.Size()
+		delete(planned, filepath.Clean(block.Dir()))
+	}
+	if len(planned) > 0 {
+		// A custom compactor may plan directories that are not loaded blocks.
+		return false, nil
+	}
+	if plannedSize == 0 {
+		return false, nil
+	}
+
+	// Size retention expects blocks ordered newest to oldest.
+	slices.SortFunc(blocks, func(a, b *Block) int {
+		switch {
+		case b.Meta().MaxTime < a.Meta().MaxTime:
+			return -1
+		case b.Meta().MaxTime > a.Meta().MaxTime:
+			return 1
+		default:
+			return 0
+		}
+	})
+	deletableULIDs := beyondSizeRetention(db, blocks, plannedSize)
+	if len(deletableULIDs) == 0 {
+		return false, nil
+	}
+
+	db.compactionSize = plannedSize
+	defer func() { db.compactionSize = 0 }()
+	if err := db.reloadBlocks(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // getBlock iterates a given block range to find a block by a given id.
@@ -2237,7 +2309,11 @@ func deletableBlocks(db *DB, blocks []*Block) map[ulid.ULID]struct{} {
 		deletable[ulid] = struct{}{}
 	}
 
-	for ulid := range BeyondSizeRetention(db, blocks) {
+	sizeDeletable := beyondSizeRetention(db, blocks, db.compactionSize)
+	if len(sizeDeletable) > 0 {
+		db.metrics.sizeRetentionCount.Inc()
+	}
+	for ulid := range sizeDeletable {
 		deletable[ulid] = struct{}{}
 	}
 
@@ -2271,6 +2347,14 @@ func BeyondTimeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 // BeyondSizeRetention returns those blocks which are beyond the size retention
 // set in the db options.
 func BeyondSizeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struct{}) {
+	deletable = beyondSizeRetention(db, blocks, 0)
+	if len(deletable) > 0 {
+		db.metrics.sizeRetentionCount.Inc()
+	}
+	return deletable
+}
+
+func beyondSizeRetention(db *DB, blocks []*Block, additionalBytes int64) (deletable map[ulid.ULID]struct{}) {
 	// No blocks to work with
 	if len(blocks) == 0 {
 		return deletable
@@ -2297,7 +2381,7 @@ func BeyondSizeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 
 	// Initializing size counter with WAL size and Head chunks
 	// written to disk, as that is part of the retention strategy.
-	blocksSize := db.Head().Size()
+	blocksSize := db.Head().Size() + additionalBytes
 	for i, block := range blocks {
 		blocksSize += block.Size()
 		if blocksSize > maxBytes {
@@ -2305,7 +2389,6 @@ func BeyondSizeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 			for _, b := range blocks[i:] {
 				deletable[b.meta.ULID] = struct{}{}
 			}
-			db.metrics.sizeRetentionCount.Inc()
 			break
 		}
 	}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9421,6 +9421,139 @@ func (c *mockCompactorFn) Write(string, BlockReader, int64, int64, *BlockMeta) (
 	return c.writeFn()
 }
 
+type observingCompactor struct {
+	Compactor
+	afterCompact func()
+}
+
+func (c *observingCompactor) Compact(dest string, dirs []string, open []*Block) ([]ulid.ULID, error) {
+	ulids, err := c.Compactor.Compact(dest, dirs, open)
+	if err == nil {
+		c.afterCompact()
+	}
+	return ulids, err
+}
+
+func TestCompactBlocksReservesSizeRetentionForCompaction(t *testing.T) {
+	testCases := map[string]func(*DB, int64){
+		"fixed size": func(db *DB, maxBytes int64) {
+			db.opts.MaxBytes = maxBytes
+		},
+		"percentage": func(db *DB, maxBytes int64) {
+			db.opts.MaxPercentage = 50
+			db.fsSizeFunc = func(string) uint64 { return uint64(maxBytes * 2) }
+		},
+	}
+
+	for name, setLimit := range testCases {
+		t.Run(name, func(t *testing.T) {
+			db := newTestDB(t, withRngs(100))
+
+			for i := range 8 {
+				mint := int64(i * 100)
+				createBlock(t, db.Dir(), genSeries(100, 10, mint, mint+100))
+			}
+			require.NoError(t, db.reloadBlocks())
+			require.Len(t, db.Blocks(), 8)
+
+			blocks := db.Blocks()
+			plan := []string{blocks[6].Dir(), blocks[7].Dir()}
+			plannedSize := blocks[6].Size() + blocks[7].Size()
+			maxBytes := db.Head().Size()
+			for _, block := range blocks {
+				maxBytes += block.Size()
+			}
+			setLimit(db, maxBytes)
+
+			compactCalled := false
+			db.compactor = &mockCompactorFn{
+				planFn: func() ([]string, error) {
+					if compactCalled {
+						return nil, nil
+					}
+					return plan, nil
+				},
+				compactFn: func() ([]ulid.ULID, error) {
+					compactCalled = true
+					retainedSize := db.Head().Size()
+					for _, block := range db.Blocks() {
+						retainedSize += block.Size()
+					}
+					require.LessOrEqual(t, retainedSize+plannedSize, maxBytes)
+					return nil, nil
+				},
+				writeFn: func() ([]ulid.ULID, error) { return nil, nil },
+			}
+
+			require.NoError(t, db.compactBlocks())
+			require.True(t, compactCalled)
+			require.Less(t, len(db.Blocks()), len(blocks))
+		})
+	}
+}
+
+func TestCompactBlocksDoesNotApplySizeRetentionWithCustomDeletionPolicy(t *testing.T) {
+	opts := DefaultOptions()
+	opts.BlocksToDelete = func([]*Block) map[ulid.ULID]struct{} { return nil }
+	db := newTestDB(t, withOpts(opts), withRngs(100))
+
+	for i := range 2 {
+		mint := int64(i * 100)
+		createBlock(t, db.Dir(), genSeries(10, 10, mint, mint+100))
+	}
+	require.NoError(t, db.reloadBlocks())
+	blocks := db.Blocks()
+	require.Len(t, blocks, 2)
+	db.opts.MaxBytes = 1
+
+	compactCalled := false
+	db.compactor = &mockCompactorFn{
+		planFn: func() ([]string, error) {
+			if compactCalled {
+				return nil, nil
+			}
+			return []string{blocks[0].Dir(), blocks[1].Dir()}, nil
+		},
+		compactFn: func() ([]ulid.ULID, error) {
+			compactCalled = true
+			return nil, nil
+		},
+		writeFn: func() ([]ulid.ULID, error) { return nil, nil },
+	}
+
+	require.NoError(t, db.compactBlocks())
+	require.True(t, compactCalled)
+	require.Len(t, db.Blocks(), len(blocks))
+}
+
+func TestCompactBlocksPeakDiskUsageStaysWithinSizeRetention(t *testing.T) {
+	db := newTestDB(t, withRngs(100, 300, 900))
+
+	for i := range 12 {
+		mint := int64(i * 100)
+		createBlock(t, db.Dir(), genSeries(100, 10, mint, mint+100))
+	}
+	require.NoError(t, db.reloadBlocks())
+
+	maxBytes, err := fileutil.DirSize(db.Dir())
+	require.NoError(t, err)
+	db.opts.MaxBytes = maxBytes
+
+	compactions := 0
+	db.compactor = &observingCompactor{
+		Compactor: db.compactor,
+		afterCompact: func() {
+			compactions++
+			size, err := fileutil.DirSize(db.Dir())
+			require.NoError(t, err)
+			require.LessOrEqual(t, size, maxBytes)
+		},
+	}
+
+	require.NoError(t, db.compactBlocks())
+	require.Positive(t, compactions)
+}
+
 // Regression test for https://github.com/prometheus/prometheus/pull/13754
 func TestAbortBlockCompactions(t *testing.T) {
 	// Create a test DB


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #11112

#### What does this PR do?

Size-based retention currently runs after a compacted block has been written, while both the source blocks and their replacement are still on disk. This allows compaction to temporarily exceed the configured retention limit.

Before compacting on-disk blocks, this change reserves space equal to the planned source blocks. If the retained data plus that reservation exceeds the configured fixed-size or percentage limit, the existing retention policy removes the oldest blocks through `reloadBlocks` and the compaction is replanned.

The reservation is only applied with the default block deletion policy. Downstream users that provide a custom `BlocksToDelete` callback retain the existing behavior.

No exported API or configuration surface is changed. When size-based retention is disabled, compaction follows the existing path without additional retention work.

Tests cover:

* Fixed-size and percentage retention reservations.
* Custom block deletion policy compatibility.
* Peak on-disk usage during a real leveled compaction.

Verification:

* Focused and adjacent TSDB tests.
* Focused regression tests with the race detector.
* Signed commit and clean diff checks.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] TSDB: Reserve disk space for replacement blocks before compaction when size-based retention is enabled.
```