### PR TITLE
promql: fix panic in extendFloats on a series with an empty window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 - [BUGFIX] Discovery/AWS: Defer region resolution in EC2, ECS, RDS, MSK, ElastiCache, and Lightsail service discovery configs from YAML unmarshaling to SD init time. `promtool check config` and other config-only operations no longer make network calls to the EC2 instance metadata service (IMDS) when the region is omitted, which is supported by the documented configuration. Region resolution errors now surface at the discovery's first refresh instead of failing config validation. #19037
-- [BUGFIX] PromQL: Fix a panic in range selectors using the experimental `anchored` or `smoothed` modifier when the selected series has no samples inside the query window, for example a query evaluated inside a scrape gap. The query failed with `unexpected error: runtime error: index out of range [-1]`; it now returns an empty result, as it does without the modifier. #19431
 
 ## 3.13.2 / 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [BUGFIX] Discovery/AWS: Defer region resolution in EC2, ECS, RDS, MSK, ElastiCache, and Lightsail service discovery configs from YAML unmarshaling to SD init time. `promtool check config` and other config-only operations no longer make network calls to the EC2 instance metadata service (IMDS) when the region is omitted, which is supported by the documented configuration. Region resolution errors now surface at the discovery's first refresh instead of failing config validation. #19037
+- [BUGFIX] PromQL: Fix a panic in range selectors using the experimental `anchored` or `smoothed` modifier when the selected series has no samples inside the query window, for example a query evaluated inside a scrape gap. The query failed with `unexpected error: runtime error: index out of range [-1]`; it now returns an empty result, as it does without the modifier. #19431
 
 ## 3.13.2 / 2026-07-29
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -4878,9 +4878,8 @@ func (ev *evaluator) gatherVector(ts int64, input Matrix, output Vector, bufHelp
 // extendFloats extends the floats to the given mint and maxt.
 // This function is used with matrix selectors that are smoothed or anchored.
 func extendFloats(floats []FPoint, mint, maxt int64, smoothed bool) []FPoint {
-	// A series can be selected on chunk granularity and then trimmed to no
-	// samples at all, so floats may be empty here. Return it as-is rather than
-	// a fresh slice, so the caller can still hand it back to the pool.
+	// Nothing to extend. Return floats as-is so the caller can still hand it
+	// back to the pool.
 	if len(floats) == 0 {
 		return floats
 	}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -4878,6 +4878,13 @@ func (ev *evaluator) gatherVector(ts int64, input Matrix, output Vector, bufHelp
 // extendFloats extends the floats to the given mint and maxt.
 // This function is used with matrix selectors that are smoothed or anchored.
 func extendFloats(floats []FPoint, mint, maxt int64, smoothed bool) []FPoint {
+	// A series can be selected on chunk granularity and then trimmed to no
+	// samples at all, so floats may be empty here. Return it as-is rather than
+	// a fresh slice, so the caller can still hand it back to the pool.
+	if len(floats) == 0 {
+		return floats
+	}
+
 	lastSampleIndex := len(floats) - 1
 
 	firstSampleIndex := max(0, sort.Search(lastSampleIndex, func(i int) bool { return floats[i].T > mint })-1)

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -777,3 +777,39 @@ eval instant at 3m changes(honlywithreset[1m] anchored)
 
 eval instant at 3m changes(hhffmixed[1m] anchored)
     {} 1
+
+clear
+
+# A series can be selected on chunk granularity and then trimmed to no samples
+# at all: the chunk below spans 0s..1000s, so it overlaps the 2m window
+# evaluated at 500s while neither sample falls inside it. extendFloats used to
+# index into that empty slice and panic, with "index out of range [-1]" for
+# anchored and "index out of range [0] with length 0" for smoothed.
+load 1000s
+  emptyrange 1 2
+
+# Control: without a modifier this has always been an empty result.
+eval instant at 500s emptyrange[2m]
+  expect range vector from 380s to 500s step 60s
+
+eval instant at 500s emptyrange[2m] anchored
+  expect range vector from 380s to 500s step 60s
+
+eval instant at 500s emptyrange[2m] smoothed
+  expect range vector from 380s to 500s step 60s
+
+clear
+
+# The extension itself still works when the window does contain samples. The
+# samples on both boundaries are replaced by the extension's own endpoints, so
+# the result is the 200s sample framed by mint and maxt.
+load 100s
+  posrange 1 2 3 4
+
+eval instant at 300s posrange[200s] anchored
+  expect range vector from 100s to 300s step 100s
+  posrange 2 3 4
+
+eval instant at 300s posrange[200s] smoothed
+  expect range vector from 100s to 300s step 100s
+  posrange 2 3 4

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -780,36 +780,38 @@ eval instant at 3m changes(hhffmixed[1m] anchored)
 
 clear
 
-# A series can be selected on chunk granularity and then trimmed to no samples
-# at all: the chunk below spans 0s..1000s, so it overlaps the 2m window
-# evaluated at 500s while neither sample falls inside it. extendFloats used to
-# index into that empty slice and panic, with "index out of range [-1]" for
-# anchored and "index out of range [0] with length 0" for smoothed.
-load 1000s
+# A series is selected on chunk granularity but trimmed per sample, so it can be
+# selected and then trimmed to no samples at all. The chunk below spans 0m..20m,
+# so it overlaps the 8m..10m window evaluated at 10m; the modifiers widen the
+# sample window to 3m..10m (anchored) and 3m..15m (smoothed), and neither the 0m
+# nor the 20m sample falls inside it. extendFloats used to index into that empty
+# slice and panic, with "index out of range [-1]" for anchored and
+# "index out of range [0] with length 0" for smoothed.
+load 20m
   emptyrange 1 2
 
 # Control: without a modifier this has always been an empty result.
-eval instant at 500s emptyrange[2m]
-  expect range vector from 380s to 500s step 60s
+eval instant at 10m emptyrange[2m]
+  expect range vector from 8m to 10m step 1m
 
-eval instant at 500s emptyrange[2m] anchored
-  expect range vector from 380s to 500s step 60s
+eval instant at 10m emptyrange[2m] anchored
+  expect range vector from 8m to 10m step 1m
 
-eval instant at 500s emptyrange[2m] smoothed
-  expect range vector from 380s to 500s step 60s
+eval instant at 10m emptyrange[2m] smoothed
+  expect range vector from 8m to 10m step 1m
 
 clear
 
 # The extension itself still works when the window does contain samples. The
 # samples on both boundaries are replaced by the extension's own endpoints, so
-# the result is the 200s sample framed by mint and maxt.
-load 100s
+# the result is the 2m sample framed by mint and maxt.
+load 1m
   posrange 1 2 3 4
 
-eval instant at 300s posrange[200s] anchored
-  expect range vector from 100s to 300s step 100s
+eval instant at 3m posrange[2m] anchored
+  expect range vector from 1m to 3m step 1m
   posrange 2 3 4
 
-eval instant at 300s posrange[200s] smoothed
-  expect range vector from 100s to 300s step 100s
+eval instant at 3m posrange[2m] smoothed
+  expect range vector from 1m to 3m step 1m
   posrange 2 3 4


### PR DESCRIPTION
`extendFloats` dereferences `floats[len(floats)-1]` with no emptiness check, and
`matrixSelector` calls it for every series the querier returned. A series can be returned and
then trimmed to nothing — selection is per chunk, trimming is per sample — so a chunk that
*spans* the query window without holding a sample inside it yields an empty slice:

```
demo_metric[10s]            -> 200, matrix, 0 series
demo_metric[10s] anchored   -> 422 unexpected error: runtime error: index out of range [-1]
demo_metric[10s] smoothed   -> 422 unexpected error: runtime error: index out of range [0] with length 0
```

Two messages from one hole: `anchored` leaves the index at `len-1` == -1 (Go omits the length
suffix for a negative index), `smoothed` recomputes it as `sort.Search(-1, …)` == 0. Any
scrape gap longer than `range + lookbackDelta` reaches this when queried inside the gap, since
the modifiers widen the sample window by `lookbackDelta`; reproduced against the released
`prom/prometheus:v3.13.2` image by killing a real target for 40s. The panic is recovered, so
this is a 422 and a logged stack trace per attempt, not a crash.

**The fix** returns the empty slice before indexing, as-is rather than a fresh `[]FPoint{}` so
the caller can still pool it. That matches #17479, which fixed `resets`/`changes` to return
empty for anchored selectors when the samples are outside the range. `extendFloats` has
exactly two callers, both in `matrixSelector`, so this is the whole reachable surface —
`rate(foo[2m] anchored)` goes through `extendedRate` and was already correct. Whether such a
series should reach `matrixSelector` at all is a larger question this PR does not touch.

**Tests:** five `promqltest` cases in `extended_vectors.test` — the two panicking queries, the
no-modifier control, and two asserting extension still produces the right values when the
window does contain samples. The two panic cases were confirmed to fail on an unpatched tree.

#### Which issue(s) does the PR fix:

<!-- No issue filed; reported directly as this PR. -->

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] PromQL: Fix a panic in range selectors using the experimental `anchored` or `smoothed` modifier when the selected series has no samples inside the query window, for example a query evaluated inside a scrape gap.
```
