### PR TITLE
rules: fix nil logger panic in the default group loader

### DIFF
--- a/rules/fixtures/rules_multi_doc.yaml
+++ b/rules/fixtures/rules_multi_doc.yaml
@@ -1,0 +1,9 @@
+# A rule file with a second YAML document, which makes the group loader log a
+# warning that only the first document is processed.
+groups:
+  - name: multi_doc
+    rules:
+      - record: job:http_requests:rate1m
+        expr: sum by (job)(rate(http_requests_total[1m]))
+---
+groups: []

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -159,6 +159,12 @@ func NewManager(o *ManagerOptions) *Manager {
 		o.Context = context.Background()
 	}
 
+	// Default the logger first: the components built below capture it by value,
+	// so substituting it afterwards would leave them holding a nil logger.
+	if o.Logger == nil {
+		o.Logger = promslog.NewNopLogger()
+	}
+
 	if o.Metrics == nil {
 		o.Metrics = NewGroupMetrics(o.Registerer)
 	}
@@ -181,10 +187,6 @@ func NewManager(o *ManagerOptions) *Manager {
 
 	if o.RuleDependencyController == nil {
 		o.RuleDependencyController = ruleDependencyController{}
-	}
-
-	if o.Logger == nil {
-		o.Logger = promslog.NewNopLogger()
 	}
 
 	// Register rule manager features if a registry is provided.

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -1521,6 +1521,24 @@ func TestNativeHistogramsInRecordingRules(t *testing.T) {
 	require.Equal(t, chunkenc.ValNone, it.Next())
 }
 
+// TestManager_LoadGroups_WithoutLogger covers the nil pointer dereference in the
+// default GroupLoader. ManagerOptions.Logger is optional, but NewManager used to
+// build FileLoader before substituting a no-op logger for a nil one, so the loader
+// kept the nil and panicked on the first rule file it had to warn about.
+func TestManager_LoadGroups_WithoutLogger(t *testing.T) {
+	ruleManager := NewManager(&ManagerOptions{})
+
+	var (
+		groups map[string]*Group
+		errs   []error
+	)
+	require.NotPanics(t, func() {
+		groups, errs = ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, false, "fixtures/rules_multi_doc.yaml")
+	})
+	require.Empty(t, errs)
+	require.Len(t, groups, 1)
+}
+
 func TestManager_LoadGroups_ShouldCheckWhetherEachRuleHasDependentsAndDependencies(t *testing.T) {
 	storage := teststorage.New(t)
 


### PR DESCRIPTION
`ManagerOptions.Logger` is optional and `NewManager` substitutes a no-op logger when it is nil, but it only did so after building the default `FileLoader`, which captures the logger by value. A manager constructed without a logger therefore ends up with a perfectly valid `opts.Logger` and a nil one inside its group loader, which is why this stayed hidden for a while.

Nothing dereferenced it until #18114 added the multi-document warning to `rulefmt.Parse`, so today loading a rule file with a second YAML document panics. `promtool tsdb create-blocks-from rules` walks into it because its importer builds the manager without a logger, and so does any other caller that leaves the field unset. Details and a reproduction are in #19432.

The change moves the defaulting up, ahead of everything that captures the logger:

```go
	if o.Context == nil {
		o.Context = context.Background()
	}

	// Default the logger first: the components built below capture it by value,
	// so substituting it afterwards would leave them holding a nil logger.
	if o.Logger == nil {
		o.Logger = promslog.NewNopLogger()
	}
```

Nothing between the old and the new position reads `o.Logger`, so this is a reordering rather than a behaviour change: `FileLoader` is the only construction site that touches it.

## About the test

The regression test goes through exported API only, since that is the shortest path to the nil: a manager built from an empty `ManagerOptions` loading a fixture with a second YAML document.

```go
ruleManager := NewManager(&ManagerOptions{})

var (
	groups map[string]*Group
	errs   []error
)
require.NotPanics(t, func() {
	groups, errs = ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, false, "fixtures/rules_multi_doc.yaml")
})
```

On `main` it fails with the panic:

```text
--- FAIL: TestManager_LoadGroups_WithoutLogger (0.00s)
        Error:  func (assert.PanicTestFunc)(0x1145080) should not panic
                Panic value: runtime error: invalid memory address or nil pointer dereference
                log/slog.(*Logger).log(0x0, ...)
                github.com/prometheus/prometheus/model/rulefmt.Parse(...)
                github.com/prometheus/prometheus/rules.FileLoader.Load(...)
```

and passes with the change. `go test ./rules/...` is otherwise unaffected, and I also ran `./cmd/...` and `./web/...` since they build managers of their own.

## Why not guard the call in rulefmt

`rulefmt.Parse` could nil-check before `logger.Warn` instead, but then every future consumer of a `FileLoader` logger needs the same guard, and `NewManager` already promises a non-nil logger to everything it constructs. Repairing that promise seemed better than defending against it at each call site. I am happy to swap it round if you would rather have the check in `rulefmt`, or to add both.

#### Which issue(s) does the PR fix:

Fixes #19432

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] Rules: Fix a panic when a rule manager created without a logger loads a rule file containing multiple YAML documents.
```
