### PR TITLE
discovery/aws: describe each ElastiCache cluster only once

### DIFF
--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -435,53 +435,50 @@ func (d *ElasticacheDiscovery) describeCacheClusters(ctx context.Context, caches
 	mu := &sync.Mutex{}
 	errg, ectx := errgroup.WithContext(ctx)
 	errg.SetLimit(d.cfg.RequestConcurrency)
-	showCacheClustersNotInReplicationGroupsBools := []bool{false, true}
 	var cacheClusters []types.CacheCluster
+	// ShowCacheClustersNotInReplicationGroups is deliberately left unset:
+	// DescribeCacheClusters then returns every provisioned cluster, whereas
+	// setting it narrows the response to the subset that are not replication
+	// group members. Querying both ways returns each standalone cluster twice.
 	if len(caches) == 0 {
-		for _, showCacheClustersNotInReplicationGroupsBool := range showCacheClustersNotInReplicationGroupsBools {
-			errg.Go(func() error {
-				var nextToken *string
-				for {
-					output, err := d.elasticacheClient.DescribeCacheClusters(ectx, &elasticache.DescribeCacheClustersInput{
-						MaxRecords:                              aws.Int32(100),
-						Marker:                                  nextToken,
-						ShowCacheNodeInfo:                       aws.Bool(true),
-						ShowCacheClustersNotInReplicationGroups: aws.Bool(showCacheClustersNotInReplicationGroupsBool),
-					})
-					if err != nil {
-						return fmt.Errorf("failed to describe cache clusters: %w", err)
-					}
-					mu.Lock()
-					cacheClusters = append(cacheClusters, output.CacheClusters...)
-					mu.Unlock()
-					if output.Marker == nil {
-						break
-					}
-					nextToken = output.Marker
+		errg.Go(func() error {
+			var nextToken *string
+			for {
+				output, err := d.elasticacheClient.DescribeCacheClusters(ectx, &elasticache.DescribeCacheClustersInput{
+					MaxRecords:        aws.Int32(100),
+					Marker:            nextToken,
+					ShowCacheNodeInfo: aws.Bool(true),
+				})
+				if err != nil {
+					return fmt.Errorf("failed to describe cache clusters: %w", err)
 				}
-				return nil
-			})
-		}
+				mu.Lock()
+				cacheClusters = append(cacheClusters, output.CacheClusters...)
+				mu.Unlock()
+				if output.Marker == nil {
+					break
+				}
+				nextToken = output.Marker
+			}
+			return nil
+		})
 	} else {
 		for _, cacheID := range caches {
-			for _, showCacheClustersNotInReplicationGroupsBool := range showCacheClustersNotInReplicationGroupsBools {
-				errg.Go(func() error {
-					output, err := d.elasticacheClient.DescribeCacheClusters(ectx, &elasticache.DescribeCacheClustersInput{
-						MaxRecords:                              aws.Int32(100),
-						Marker:                                  nil,
-						ShowCacheNodeInfo:                       aws.Bool(true),
-						ShowCacheClustersNotInReplicationGroups: aws.Bool(showCacheClustersNotInReplicationGroupsBool),
-						CacheClusterId:                          aws.String(cacheID),
-					})
-					if err != nil {
-						return fmt.Errorf("failed to describe cache cluster %s: %w", cacheID, err)
-					}
-					mu.Lock()
-					cacheClusters = append(cacheClusters, output.CacheClusters...)
-					mu.Unlock()
-					return nil
+			errg.Go(func() error {
+				output, err := d.elasticacheClient.DescribeCacheClusters(ectx, &elasticache.DescribeCacheClustersInput{
+					MaxRecords:        aws.Int32(100),
+					Marker:            nil,
+					ShowCacheNodeInfo: aws.Bool(true),
+					CacheClusterId:    aws.String(cacheID),
 				})
-			}
+				if err != nil {
+					return fmt.Errorf("failed to describe cache cluster %s: %w", cacheID, err)
+				}
+				mu.Lock()
+				cacheClusters = append(cacheClusters, output.CacheClusters...)
+				mu.Unlock()
+				return nil
+			})
 		}
 	}
 

--- a/discovery/aws/elasticache_test.go
+++ b/discovery/aws/elasticache_test.go
@@ -502,23 +502,28 @@ func (m *mockElasticacheClient) DescribeServerlessCaches(_ context.Context, inpu
 	}, nil
 }
 
+// DescribeCacheClusters mirrors the ShowCacheClustersNotInReplicationGroups
+// filter: when it is set, only clusters that are not members of a replication
+// group are returned; when it is unset or false the API returns every cluster,
+// replication group members included.
 func (m *mockElasticacheClient) DescribeCacheClusters(_ context.Context, input *elasticache.DescribeCacheClustersInput, _ ...func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error) {
-	if input.CacheClusterId != nil {
-		// Single cluster lookup
-		for _, cluster := range m.data.cacheClusters {
-			if cluster.CacheClusterId != nil && *cluster.CacheClusterId == *input.CacheClusterId {
-				return &elasticache.DescribeCacheClustersOutput{
-					CacheClusters: []types.CacheCluster{cluster},
-				}, nil
-			}
+	notInReplicationGroupsOnly := aws.ToBool(input.ShowCacheClustersNotInReplicationGroups)
+
+	clusters := []types.CacheCluster{}
+	for _, cluster := range m.data.cacheClusters {
+		// Single cluster lookup.
+		if input.CacheClusterId != nil &&
+			(cluster.CacheClusterId == nil || *cluster.CacheClusterId != *input.CacheClusterId) {
+			continue
 		}
-		return &elasticache.DescribeCacheClustersOutput{
-			CacheClusters: []types.CacheCluster{},
-		}, nil
+		if notInReplicationGroupsOnly && cluster.ReplicationGroupId != nil {
+			continue
+		}
+		clusters = append(clusters, cluster)
 	}
 
 	return &elasticache.DescribeCacheClustersOutput{
-		CacheClusters: m.data.cacheClusters,
+		CacheClusters: clusters,
 	}, nil
 }
 
@@ -840,6 +845,71 @@ func TestElasticacheRefreshCacheClusterNilOptionalFields(t *testing.T) {
 					"label sourced from the absent field should be omitted")
 				require.Equal(t, model.LabelValue("my-cluster-001.abc123.0001.use1.cache.amazonaws.com:6379"), target[model.AddressLabel])
 			}
+		})
+	}
+}
+
+// TestElasticacheDescribeCacheClustersReturnsEachClusterOnce guards against
+// describing the same cluster twice. DescribeCacheClusters returns every
+// provisioned cluster unless ShowCacheClustersNotInReplicationGroups is set, in
+// which case it returns only the subset that are not replication group members,
+// so querying with and without the flag and concatenating both responses yields
+// every standalone cluster twice.
+func TestElasticacheDescribeCacheClustersReturnsEachClusterOnce(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		clusterIDs  []string
+		expectedIDs []string
+	}{
+		{
+			name:        "AllClusters",
+			clusterIDs:  nil,
+			expectedIDs: []string{"standalone-001", "member-001"},
+		},
+		{
+			name:        "StandaloneClusterByID",
+			clusterIDs:  []string{"standalone-001"},
+			expectedIDs: []string{"standalone-001"},
+		},
+		{
+			name:        "ReplicationGroupMemberByID",
+			clusterIDs:  []string{"member-001"},
+			expectedIDs: []string{"member-001"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := &ElasticacheDiscovery{
+				elasticacheClient: newMockElasticacheClient(&elasticacheDataStore{
+					region: "us-east-1",
+					cacheClusters: []types.CacheCluster{
+						// Memcached and single node clusters are not members of
+						// a replication group, so both API responses carry them.
+						{CacheClusterId: strptr("standalone-001")},
+						{
+							CacheClusterId:     strptr("member-001"),
+							ReplicationGroupId: strptr("my-replication-group"),
+						},
+					},
+				}),
+				cfg: &ElasticacheSDConfig{
+					Region:             "us-east-1",
+					RequestConcurrency: 10,
+				},
+			}
+
+			clusters, err := d.describeCacheClusters(context.Background(), tt.clusterIDs)
+			require.NoError(t, err)
+
+			ids := make([]string, 0, len(clusters))
+			for _, cluster := range clusters {
+				ids = append(ids, aws.ToString(cluster.CacheClusterId))
+			}
+			require.ElementsMatch(t, tt.expectedIDs, ids,
+				"each cluster must be described exactly once")
 		})
 	}
 }

--- a/discovery/aws/elasticache_test.go
+++ b/discovery/aws/elasticache_test.go
@@ -700,11 +700,8 @@ func TestElasticacheRefreshFullyPopulated(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, tgs, 1)
 
-	// describeCacheClusters queries the API twice, once with
-	// ShowCacheClustersNotInReplicationGroups set and once without, and
-	// concatenates both result sets. A cluster that is not a replication group
-	// member is returned by both calls, so the target count is not asserted
-	// here: that duplication predates this test and is out of its scope.
+	require.Len(t, tgs[0].Targets, 2, "one target per deployment option, and no duplicates")
+
 	targetsByOption := map[model.LabelValue]model.LabelSet{}
 	for _, target := range tgs[0].Targets {
 		targetsByOption[target[elasticacheLabelDeploymentOption]] = target
@@ -835,16 +832,13 @@ func TestElasticacheRefreshCacheClusterNilOptionalFields(t *testing.T) {
 			}).refresh(context.Background())
 			require.NoError(t, err)
 			require.Len(t, tgs, 1)
-			require.NotEmpty(t, tgs[0].Targets,
+			require.Len(t, tgs[0].Targets, 1,
 				"cluster node must still be discovered when an optional field is absent")
 
-			// See TestElasticacheRefreshFullyPopulated for why the target count
-			// is not asserted here.
-			for _, target := range tgs[0].Targets {
-				require.NotContains(t, target, tc.absent,
-					"label sourced from the absent field should be omitted")
-				require.Equal(t, model.LabelValue("my-cluster-001.abc123.0001.use1.cache.amazonaws.com:6379"), target[model.AddressLabel])
-			}
+			target := tgs[0].Targets[0]
+			require.NotContains(t, target, tc.absent,
+				"label sourced from the absent field should be omitted")
+			require.Equal(t, model.LabelValue("my-cluster-001.abc123.0001.use1.cache.amazonaws.com:6379"), target[model.AddressLabel])
 		})
 	}
 }


### PR DESCRIPTION
`describeCacheClusters` issues two `DescribeCacheClusters` queries for every page (and for every configured cluster ID), one with `ShowCacheClustersNotInReplicationGroups` set to `false` and one with it set to `true`, then concatenates both responses.

Per the [API reference](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_DescribeCacheClusters.html), those two responses overlap rather than partition:

> Returns information about all provisioned clusters if no cluster identifier is specified [...]
>
> **ShowCacheClustersNotInReplicationGroups** — An optional flag that can be included in the `DescribeCacheCluster` request to show only nodes (API/CLI: clusters) that are not members of a replication group. In practice, this means Memcached and single node Valkey or Redis OSS clusters.

The unfiltered response already lists every provisioned cluster, and the filtered one is a strict subset of it. Every cluster that is not a replication group member is therefore returned by both queries and described twice. Replication group members are unaffected, which is why the duplication is invisible to anyone running only those.

Consequences:

- Each standalone cluster produces two identical entries in the target group, doubling `prometheus_sd_discovered_targets` and listing the cluster twice on the `/service-discovery` page.
- The duplicated ARNs reach `listTagsForResource`, which starts one goroutine per slice entry, so `ListTagsForResource` is called twice for every standalone cluster.
- Half of the `DescribeCacheClusters` calls are redundant.

Scraping itself is unaffected: `scrapePool.sync` keys `uniqueLoops` by `Target.hash()`, so identical targets collapse into one scrape loop.

The fix leaves `ShowCacheClustersNotInReplicationGroups` unset and issues a single query per page or cluster ID.

The mock ignored the flag, which is why no existing test caught this; it now filters the way the API documents it. The first commit adds a test that fails without the fix.

I do not have an AWS account with a Memcached or single node cluster to confirm this end to end, so the change rests on the documented behaviour of the flag.

```release-notes
[BUGFIX] AWS SD: Describe each ElastiCache cluster once instead of twice for clusters that are not replication group members.
```
