### PR TITLE
discovery/aws: don't panic on ElastiCache resources with absent optional fields

### DIFF
--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -528,6 +528,11 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 			return fmt.Errorf("failed to describe serverless caches: %w", err)
 		}
 		for _, cache := range caches {
+			// ARN is optional in the ElastiCache API and is only used to look
+			// up tags, so a cache without one is still discovered below.
+			if cache.ARN == nil {
+				continue
+			}
 			clustersMu.Lock()
 			clusters = append(clusters, *cache.ARN)
 			clustersMu.Unlock()
@@ -541,6 +546,9 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 			return fmt.Errorf("failed to describe cache clusters: %w", err)
 		}
 		for _, cluster := range cacheClusters {
+			if cluster.ARN == nil {
+				continue
+			}
 			clustersMu.Lock()
 			clusters = append(clusters, *cluster.ARN)
 			clustersMu.Unlock()
@@ -572,7 +580,7 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 		}
 		for _, cache := range caches {
 			targetsMu.Lock()
-			addServerlessCacheTargets(tg, &cache, tagsByResourceARN[*cache.ARN])
+			addServerlessCacheTargets(tg, &cache, tagsByResourceARN[aws.ToString(cache.ARN)])
 			targetsMu.Unlock()
 		}
 		return nil
@@ -585,7 +593,7 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 		}
 		for _, cluster := range cacheClusters {
 			targetsMu.Lock()
-			addCacheClusterTargets(tg, &cluster, tagsByResourceARN[*cluster.ARN])
+			addCacheClusterTargets(tg, &cluster, tagsByResourceARN[aws.ToString(cluster.ARN)])
 			targetsMu.Unlock()
 		}
 		return nil
@@ -627,14 +635,35 @@ func splitCacheDeploymentOptions(caches []string, logger *slog.Logger) (serverle
 
 // addServerlessCacheTargets adds targets for a serverless cache to the target group.
 func addServerlessCacheTargets(tg *targetgroup.Group, cache *types.ServerlessCache, tags []types.Tag) {
+	// Every field below is optional in the ElastiCache API. Omit the label when
+	// the field is absent rather than dereferencing a nil pointer, which would
+	// panic and take down the whole Prometheus process.
 	labels := model.LabelSet{
-		elasticacheLabelDeploymentOption:                  model.LabelValue("serverless"),
-		elasticacheLabelServerlessCacheARN:                model.LabelValue(*cache.ARN),
-		elasticacheLabelServerlessCacheName:               model.LabelValue(*cache.ServerlessCacheName),
-		elasticacheLabelServerlessCacheStatus:             model.LabelValue(*cache.Status),
-		elasticacheLabelServerlessCacheEngine:             model.LabelValue(*cache.Engine),
-		elasticacheLabelServerlessCacheFullEngineVersion:  model.LabelValue(*cache.FullEngineVersion),
-		elasticacheLabelServerlessCacheMajorEngineVersion: model.LabelValue(*cache.MajorEngineVersion),
+		elasticacheLabelDeploymentOption: model.LabelValue("serverless"),
+	}
+
+	if cache.ARN != nil {
+		labels[elasticacheLabelServerlessCacheARN] = model.LabelValue(*cache.ARN)
+	}
+
+	if cache.ServerlessCacheName != nil {
+		labels[elasticacheLabelServerlessCacheName] = model.LabelValue(*cache.ServerlessCacheName)
+	}
+
+	if cache.Status != nil {
+		labels[elasticacheLabelServerlessCacheStatus] = model.LabelValue(*cache.Status)
+	}
+
+	if cache.Engine != nil {
+		labels[elasticacheLabelServerlessCacheEngine] = model.LabelValue(*cache.Engine)
+	}
+
+	if cache.FullEngineVersion != nil {
+		labels[elasticacheLabelServerlessCacheFullEngineVersion] = model.LabelValue(*cache.FullEngineVersion)
+	}
+
+	if cache.MajorEngineVersion != nil {
+		labels[elasticacheLabelServerlessCacheMajorEngineVersion] = model.LabelValue(*cache.MajorEngineVersion)
 	}
 
 	if cache.Description != nil {
@@ -724,12 +753,24 @@ func addServerlessCacheTargets(tg *targetgroup.Group, cache *types.ServerlessCac
 // addCacheClusterTargets adds targets for a cache cluster to the target group.
 // Creates one target per cache node for individual scraping.
 func addCacheClusterTargets(tg *targetgroup.Group, cluster *types.CacheCluster, tags []types.Tag) {
-	// Build common labels that apply to all nodes in this cluster
+	// Build common labels that apply to all nodes in this cluster. Every field
+	// below is optional in the ElastiCache API, so the label is omitted when the
+	// field is absent rather than dereferencing a nil pointer, which would panic
+	// and take down the whole Prometheus process.
 	commonLabels := model.LabelSet{
-		elasticacheLabelDeploymentOption:   model.LabelValue("node"),
-		elasticacheLabelCacheClusterARN:    model.LabelValue(*cluster.ARN),
-		elasticacheLabelCacheClusterID:     model.LabelValue(*cluster.CacheClusterId),
-		elasticacheLabelCacheClusterStatus: model.LabelValue(*cluster.CacheClusterStatus),
+		elasticacheLabelDeploymentOption: model.LabelValue("node"),
+	}
+
+	if cluster.ARN != nil {
+		commonLabels[elasticacheLabelCacheClusterARN] = model.LabelValue(*cluster.ARN)
+	}
+
+	if cluster.CacheClusterId != nil {
+		commonLabels[elasticacheLabelCacheClusterID] = model.LabelValue(*cluster.CacheClusterId)
+	}
+
+	if cluster.CacheClusterStatus != nil {
+		commonLabels[elasticacheLabelCacheClusterStatus] = model.LabelValue(*cluster.CacheClusterStatus)
 	}
 
 	if cluster.AtRestEncryptionEnabled != nil {

--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -560,6 +560,9 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 	tg := &targetgroup.Group{
 		Source: d.region,
 	}
+	// Both goroutines below append to tg.Targets, so the append must be
+	// serialised.
+	targetsMu := sync.Mutex{}
 
 	errg, ectx := errgroup.WithContext(ctx)
 	errg.Go(func() error {
@@ -568,7 +571,9 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 			return fmt.Errorf("failed to describe serverless caches: %w", err)
 		}
 		for _, cache := range caches {
+			targetsMu.Lock()
 			addServerlessCacheTargets(tg, &cache, tagsByResourceARN[*cache.ARN])
+			targetsMu.Unlock()
 		}
 		return nil
 	})
@@ -579,7 +584,9 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 			return fmt.Errorf("failed to describe cache clusters: %w", err)
 		}
 		for _, cluster := range cacheClusters {
+			targetsMu.Lock()
 			addCacheClusterTargets(tg, &cluster, tagsByResourceARN[*cluster.ARN])
+			targetsMu.Unlock()
 		}
 		return nil
 	})

--- a/discovery/aws/elasticache_test.go
+++ b/discovery/aws/elasticache_test.go
@@ -620,3 +620,226 @@ func TestSplitCacheDeploymentOptions(t *testing.T) {
 		})
 	}
 }
+
+// elasticacheTestDiscovery returns a discovery backed by the mock client, so
+// refresh() can be exercised without reaching AWS. initElasticacheClient returns
+// early when elasticacheClient is already set, which also leaves region unset,
+// so it is populated here.
+func elasticacheTestDiscovery(data *elasticacheDataStore) *ElasticacheDiscovery {
+	return &ElasticacheDiscovery{
+		logger:            promslog.NewNopLogger(),
+		elasticacheClient: newMockElasticacheClient(data),
+		cfg: &ElasticacheSDConfig{
+			Region:             data.region,
+			RequestConcurrency: 10,
+		},
+		region: data.region,
+	}
+}
+
+// fullyPopulatedServerlessCache is the shape the AWS API returns when every
+// optional field happens to be set. Each subtest below blanks exactly one of
+// them.
+func fullyPopulatedServerlessCache() types.ServerlessCache {
+	return types.ServerlessCache{
+		ARN:                 strptr("arn:aws:elasticache:us-east-1:123456789012:serverlesscache:my-cache"),
+		ServerlessCacheName: strptr("my-cache"),
+		Status:              strptr("available"),
+		Engine:              strptr("redis"),
+		FullEngineVersion:   strptr("7.1"),
+		MajorEngineVersion:  strptr("7"),
+		Endpoint: &types.Endpoint{
+			Address: strptr("my-cache.serverless.use1.cache.amazonaws.com"),
+			Port:    aws.Int32(6379),
+		},
+	}
+}
+
+// fullyPopulatedCacheCluster mirrors fullyPopulatedServerlessCache for the
+// node-based deployment option.
+func fullyPopulatedCacheCluster() types.CacheCluster {
+	return types.CacheCluster{
+		ARN:                strptr("arn:aws:elasticache:us-east-1:123456789012:cluster:my-cluster-001"),
+		CacheClusterId:     strptr("my-cluster-001"),
+		CacheClusterStatus: strptr("available"),
+		CacheNodes: []types.CacheNode{
+			{
+				CacheNodeId: strptr("0001"),
+				Endpoint: &types.Endpoint{
+					Address: strptr("my-cluster-001.abc123.0001.use1.cache.amazonaws.com"),
+					Port:    aws.Int32(6379),
+				},
+			},
+		},
+	}
+}
+
+// TestElasticacheRefreshFullyPopulated pins the happy path so the nil handling
+// added for the cases below cannot silently drop labels that used to be set.
+func TestElasticacheRefreshFullyPopulated(t *testing.T) {
+	t.Parallel()
+
+	tgs, err := elasticacheTestDiscovery(&elasticacheDataStore{
+		region:           "us-east-1",
+		serverlessCaches: []types.ServerlessCache{fullyPopulatedServerlessCache()},
+		cacheClusters:    []types.CacheCluster{fullyPopulatedCacheCluster()},
+		tags: map[string][]types.Tag{
+			"arn:aws:elasticache:us-east-1:123456789012:serverlesscache:my-cache": {
+				{Key: strptr("Environment"), Value: strptr("test")},
+			},
+			"arn:aws:elasticache:us-east-1:123456789012:cluster:my-cluster-001": {
+				{Key: strptr("Environment"), Value: strptr("prod")},
+			},
+		},
+	}).refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+
+	// describeCacheClusters queries the API twice, once with
+	// ShowCacheClustersNotInReplicationGroups set and once without, and
+	// concatenates both result sets. A cluster that is not a replication group
+	// member is returned by both calls, so the target count is not asserted
+	// here: that duplication predates this test and is out of its scope.
+	targetsByOption := map[model.LabelValue]model.LabelSet{}
+	for _, target := range tgs[0].Targets {
+		targetsByOption[target[elasticacheLabelDeploymentOption]] = target
+	}
+	require.Len(t, targetsByOption, 2, "both deployment options must be discovered")
+
+	serverless := targetsByOption["serverless"]
+	require.Equal(t, model.LabelValue("my-cache.serverless.use1.cache.amazonaws.com:6379"), serverless[model.AddressLabel])
+	require.Equal(t, model.LabelValue("arn:aws:elasticache:us-east-1:123456789012:serverlesscache:my-cache"), serverless[elasticacheLabelServerlessCacheARN])
+	require.Equal(t, model.LabelValue("my-cache"), serverless[elasticacheLabelServerlessCacheName])
+	require.Equal(t, model.LabelValue("available"), serverless[elasticacheLabelServerlessCacheStatus])
+	require.Equal(t, model.LabelValue("redis"), serverless[elasticacheLabelServerlessCacheEngine])
+	require.Equal(t, model.LabelValue("7.1"), serverless[elasticacheLabelServerlessCacheFullEngineVersion])
+	require.Equal(t, model.LabelValue("7"), serverless[elasticacheLabelServerlessCacheMajorEngineVersion])
+	require.Equal(t, model.LabelValue("test"), serverless[elasticacheLabelServerlessCacheTag+"Environment"])
+
+	node := targetsByOption["node"]
+	require.Equal(t, model.LabelValue("my-cluster-001.abc123.0001.use1.cache.amazonaws.com:6379"), node[model.AddressLabel])
+	require.Equal(t, model.LabelValue("arn:aws:elasticache:us-east-1:123456789012:cluster:my-cluster-001"), node[elasticacheLabelCacheClusterARN])
+	require.Equal(t, model.LabelValue("my-cluster-001"), node[elasticacheLabelCacheClusterID])
+	require.Equal(t, model.LabelValue("available"), node[elasticacheLabelCacheClusterStatus])
+	require.Equal(t, model.LabelValue("prod"), node[elasticacheLabelCacheClusterTag+"Environment"])
+}
+
+// TestElasticacheRefreshServerlessCacheNilOptionalFields covers serverless
+// caches where the AWS API omitted an optional field. None of the members of
+// ServerlessCache are marked required by the SDK, yet refresh() dereferenced
+// these without a nil check, so a single missing field panicked the whole
+// Prometheus process during service discovery rather than degrading the target.
+func TestElasticacheRefreshServerlessCacheNilOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*types.ServerlessCache)
+		absent model.LabelName
+	}{
+		{
+			name:   "NilARN",
+			mutate: func(c *types.ServerlessCache) { c.ARN = nil },
+			absent: elasticacheLabelServerlessCacheARN,
+		},
+		{
+			name:   "NilServerlessCacheName",
+			mutate: func(c *types.ServerlessCache) { c.ServerlessCacheName = nil },
+			absent: elasticacheLabelServerlessCacheName,
+		},
+		{
+			name:   "NilStatus",
+			mutate: func(c *types.ServerlessCache) { c.Status = nil },
+			absent: elasticacheLabelServerlessCacheStatus,
+		},
+		{
+			name:   "NilEngine",
+			mutate: func(c *types.ServerlessCache) { c.Engine = nil },
+			absent: elasticacheLabelServerlessCacheEngine,
+		},
+		{
+			name:   "NilFullEngineVersion",
+			mutate: func(c *types.ServerlessCache) { c.FullEngineVersion = nil },
+			absent: elasticacheLabelServerlessCacheFullEngineVersion,
+		},
+		{
+			name:   "NilMajorEngineVersion",
+			mutate: func(c *types.ServerlessCache) { c.MajorEngineVersion = nil },
+			absent: elasticacheLabelServerlessCacheMajorEngineVersion,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cache := fullyPopulatedServerlessCache()
+			tc.mutate(&cache)
+
+			tgs, err := elasticacheTestDiscovery(&elasticacheDataStore{
+				region:           "us-east-1",
+				serverlessCaches: []types.ServerlessCache{cache},
+			}).refresh(context.Background())
+			require.NoError(t, err)
+			require.Len(t, tgs, 1)
+			require.Len(t, tgs[0].Targets, 1,
+				"cache must still be discovered when an optional field is absent")
+
+			target := tgs[0].Targets[0]
+			require.NotContains(t, target, tc.absent,
+				"label sourced from the absent field should be omitted")
+			// The cache is still usable: the address is what makes it a target.
+			require.Equal(t, model.LabelValue("my-cache.serverless.use1.cache.amazonaws.com:6379"), target[model.AddressLabel])
+		})
+	}
+}
+
+// TestElasticacheRefreshCacheClusterNilOptionalFields is the node deployment
+// counterpart of TestElasticacheRefreshServerlessCacheNilOptionalFields.
+func TestElasticacheRefreshCacheClusterNilOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*types.CacheCluster)
+		absent model.LabelName
+	}{
+		{
+			name:   "NilARN",
+			mutate: func(c *types.CacheCluster) { c.ARN = nil },
+			absent: elasticacheLabelCacheClusterARN,
+		},
+		{
+			name:   "NilCacheClusterId",
+			mutate: func(c *types.CacheCluster) { c.CacheClusterId = nil },
+			absent: elasticacheLabelCacheClusterID,
+		},
+		{
+			name:   "NilCacheClusterStatus",
+			mutate: func(c *types.CacheCluster) { c.CacheClusterStatus = nil },
+			absent: elasticacheLabelCacheClusterStatus,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cluster := fullyPopulatedCacheCluster()
+			tc.mutate(&cluster)
+
+			tgs, err := elasticacheTestDiscovery(&elasticacheDataStore{
+				region:        "us-east-1",
+				cacheClusters: []types.CacheCluster{cluster},
+			}).refresh(context.Background())
+			require.NoError(t, err)
+			require.Len(t, tgs, 1)
+			require.NotEmpty(t, tgs[0].Targets,
+				"cluster node must still be discovered when an optional field is absent")
+
+			// See TestElasticacheRefreshFullyPopulated for why the target count
+			// is not asserted here.
+			for _, target := range tgs[0].Targets {
+				require.NotContains(t, target, tc.absent,
+					"label sourced from the absent field should be omitted")
+				require.Equal(t, model.LabelValue("my-cluster-001.abc123.0001.use1.cache.amazonaws.com:6379"), target[model.AddressLabel])
+			}
+		})
+	}
+}


### PR DESCRIPTION
None of the members of the SDK's `ServerlessCache` and `CacheCluster` types are marked required - `elasticache v1.56.4` carries zero `This member is required` annotations on either - but the ElastiCache discovery dereferences nine of them with no nil check, all inside the `model.LabelSet` literals:

```go
labels := model.LabelSet{
	elasticacheLabelDeploymentOption:      model.LabelValue("serverless"),
	elasticacheLabelServerlessCacheARN:    model.LabelValue(*cache.ARN),
	elasticacheLabelServerlessCacheName:   model.LabelValue(*cache.ServerlessCacheName),
	...
}
```

A cache returned without one of them panics, and since nothing under `discovery/` recovers, that takes down the whole Prometheus process. The fields further down in the same two functions are already guarded, so this reads as an oversight in the literals rather than a deliberate assumption.

Guarded here, following the pattern the surrounding code already uses:

- `ServerlessCache`: `ARN`, `ServerlessCacheName`, `Status`, `Engine`, `FullEngineVersion`, `MajorEngineVersion`
- `CacheCluster`: `ARN`, `CacheClusterId`, `CacheClusterStatus`

`ARN` additionally keys the tag lookup. Resources without one are skipped when collecting the ARNs to describe tags for, and the lookup goes through `aws.ToString`, so a missing ARN yields no tags instead of a panic.

**On the first commit.** Writing a test that drives `refresh()` with both deployment options populated exposed a data race: the two errgroup goroutines each append to the same `targetgroup.Group` with no synchronisation. No existing test covered that combination, which is why it went unnoticed. CI runs the suite with `-race`, so this had to be fixed before the test could land, and it is separated into its own commit.

The second commit adds the test and fails; the third adds the guards.

```release-notes
[BUGFIX] AWS SD: Do not panic when the ElastiCache API omits optional fields of a serverless cache or cache cluster.
```
