### PR TITLE
tsdb: validate labels are sorted lexicographically on append

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -553,6 +553,12 @@ func (a *headAppenderBase) getOrCreate(lset labels.Labels) (s *memSeries, create
 	if l, dup := lset.HasDuplicateLabelNames(); dup {
 		return nil, false, fmt.Errorf(`label name "%s" is not unique: %w`, l, ErrInvalidSample)
 	}
+	// Ensure labels are sorted lexicographically by name.
+	for i := 1; i < len(lset); i++ {
+		if lset[i].Name < lset[i-1].Name {
+			return nil, false, fmt.Errorf("labels %q are not sorted, found %q before %q: %w", lset, lset[i-1].Name, lset[i].Name, ErrInvalidSample)
+		}
+	}
 	s, created, err = a.head.getOrCreate(lset.Hash(), lset, true)
 	if err != nil {
 		return nil, false, err

--- a/tsdb/head_label_sort_test.go
+++ b/tsdb/head_label_sort_test.go
@@ -1,0 +1,45 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/util/compression"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddUnsortedLabels(t *testing.T) {
+	h, _ := newTestHead(t, 1000, compression.None, false)
+
+	add := func(lbls labels.Labels, expectErr string) {
+		app := h.Appender(context.Background())
+		_, err := app.Append(0, lbls, 0, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), expectErr)
+	}
+
+	// Labels not sorted: "b" comes before "a".
+	add(labels.FromStrings("b", "1", "a", "2"), "labels are not sorted")
+	// Labels not sorted: "z" comes before "m".
+	add(labels.FromStrings("z", "1", "m", "2", "a", "3"), "labels are not sorted")
+	// Already sorted labels should succeed.
+	app := h.Appender(context.Background())
+	_, err := app.Append(0, labels.FromStrings("a", "1", "b", "2"), 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds a validation check to ensure labels are sorted lexicographically by name when samples are appended to the TSDB head.

## Why is this change needed?

Fixes #11505

The Prometheus codebase assumes labels are lexicographically sorted (e.g., HasDuplicateLabelNames assumes sorted labels, the New function sorts labels, etc.). However, this requirement is not enforced when samples are ingested (appended to head), unlike other similar requirements like no empty labels and no duplicate labels.

This can lead to subtle bugs when unsorted labels are ingested, as the codebase relies on this ordering assumption in various places.

## Changes

- Added label sort validation in getOrCreate function in 	sdb/head_append.go
- Added test TestAddUnsortedLabels to verify the validation works

## Testing

The new test verifies:
1. Labels not sorted (e.g.,  before ) are rejected with an appropriate error
2. Already sorted labels continue to work correctly

This follows the existing pattern used for empty label and duplicate label validation.