### PR TITLE
ci: set --platform on the per-arch docker builds

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -247,6 +247,7 @@ common-docker-repo-name:
 
 .PHONY: common-docker $(BUILD_DOCKER_ARCHS)
 common-docker: $(BUILD_DOCKER_ARCHS)
+# DOCKER_ARCHS holds promu architecture names, which are not OCI platform strings.
 $(BUILD_DOCKER_ARCHS): common-docker-%:
 	@for variant in $(DOCKERFILE_VARIANTS_WITH_NAMES); do \
 		dockerfile=$${variant#*:}; \
@@ -255,10 +256,16 @@ $(BUILD_DOCKER_ARCHS): common-docker-%:
 		if [ "$*" = "armv7" ]; then \
 			distroless_arch="arm"; \
 		fi; \
+		arch="$*"; \
+		case "$$arch" in \
+			armv*) docker_platform="linux/arm/v$${arch#armv}";; \
+			*)     docker_platform="linux/$$arch";; \
+		esac; \
 		if [ "$$dockerfile" = "Dockerfile" ]; then \
 			echo "Building default variant ($$variant_name) for linux-$* using $$dockerfile"; \
 			docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)" \
 				-f $$dockerfile \
+				--platform "$$docker_platform" \
 				--build-arg ARCH="$*" \
 				--build-arg OS="linux" \
 				--build-arg DISTROLESS_ARCH="$$distroless_arch" \
@@ -272,6 +279,7 @@ $(BUILD_DOCKER_ARCHS): common-docker-%:
 			echo "Building $$variant_name variant for linux-$* using $$dockerfile"; \
 			docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name" \
 				-f $$dockerfile \
+				--platform "$$docker_platform" \
 				--build-arg ARCH="$*" \
 				--build-arg OS="linux" \
 				--build-arg DISTROLESS_ARCH="$$distroless_arch" \


### PR DESCRIPTION
Fixes a purely cosmetic issue (more details in commit message):

```
  InvalidBaseImagePlatform: Base image quay.io/prometheus/busybox-linux-arm64
  was pulled with platform "linux/arm64", expected "linux/amd64"
```

Found this in Alertmanager, but there are examples in Prometheus as well:
https://github.com/prometheus/prometheus/actions/runs/31891208019/job/95030145850

A more structural fix would be nice, but I'm not sure how to accomplish that, given all the repos this file syncs to.

Important: I don't think CI actually checks this part of the Makefile.

#### Which issue(s) does the PR fix:

No open issue as far as I'm aware.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```
