### PR TITLE
discovery/ionos: don't panic on absent response containers

### DIFF
--- a/discovery/ionos/server.go
+++ b/discovery/ionos/server.go
@@ -93,19 +93,33 @@ func (d *serverDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 		return nil, err
 	}
 
+	// Items is omitted from the response when the datacenter holds no servers.
+	var serverItems []ionoscloud.Server
+	if servers.Items != nil {
+		serverItems = *servers.Items
+	}
+
 	var targets []model.LabelSet
-	for _, server := range *servers.Items {
+	for _, server := range serverItems {
 		var ips []string
 		ipsByNICName := make(map[string][]string)
 
-		if server.Entities != nil && server.Entities.Nics != nil {
+		if server.Entities != nil && server.Entities.Nics != nil && server.Entities.Nics.Items != nil {
 			for _, nic := range *server.Entities.Nics.Items {
+				if nic.Properties == nil {
+					continue
+				}
+
 				nicName := nicDefaultName
 				if name := nic.Properties.Name; name != nil {
 					nicName = *name
 				}
 
-				nicIPs := *nic.Properties.Ips
+				// An absent Ips is equivalent to an empty one.
+				var nicIPs []string
+				if nic.Properties.Ips != nil {
+					nicIPs = *nic.Properties.Ips
+				}
 				ips = append(nicIPs, ips...)
 				ipsByNICName[nicName] = append(nicIPs, ipsByNICName[nicName]...)
 			}
@@ -122,11 +136,19 @@ func (d *serverDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 			serverIPLabel:      model.LabelValue(join(ips, metaLabelSeparator)),
 		}
 
-		if server.Properties.AvailabilityZone != nil {
-			labels[serverAvailabilityZoneLabel] = model.LabelValue(*server.Properties.AvailabilityZone)
+		// Properties is a pointer and is absent from the response for servers
+		// that expose none. Substituting the zero value keeps the per-field
+		// checks below as the single place where a label is omitted.
+		props := server.Properties
+		if props == nil {
+			props = &ionoscloud.ServerProperties{}
 		}
-		if server.Properties.CpuFamily != nil {
-			labels[serverCPUFamilyLabel] = model.LabelValue(*server.Properties.CpuFamily)
+
+		if props.AvailabilityZone != nil {
+			labels[serverAvailabilityZoneLabel] = model.LabelValue(*props.AvailabilityZone)
+		}
+		if props.CpuFamily != nil {
+			labels[serverCPUFamilyLabel] = model.LabelValue(*props.CpuFamily)
 		}
 		if servers.Id != nil {
 			labels[serverServersIDLabel] = model.LabelValue(*servers.Id)
@@ -137,14 +159,14 @@ func (d *serverDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 		if server.Metadata != nil && server.Metadata.State != nil {
 			labels[serverLifecycleLabel] = model.LabelValue(*server.Metadata.State)
 		}
-		if server.Properties.Name != nil {
-			labels[serverNameLabel] = model.LabelValue(*server.Properties.Name)
+		if props.Name != nil {
+			labels[serverNameLabel] = model.LabelValue(*props.Name)
 		}
-		if server.Properties.VmState != nil {
-			labels[serverStateLabel] = model.LabelValue(*server.Properties.VmState)
+		if props.VmState != nil {
+			labels[serverStateLabel] = model.LabelValue(*props.VmState)
 		}
-		if server.Properties.Type != nil {
-			labels[serverTypeLabel] = model.LabelValue(*server.Properties.Type)
+		if props.Type != nil {
+			labels[serverTypeLabel] = model.LabelValue(*props.Type)
 		}
 
 		for nicName, nicIPs := range ipsByNICName {
@@ -152,17 +174,17 @@ func (d *serverDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 			labels[model.LabelName(name)] = model.LabelValue(join(nicIPs, metaLabelSeparator))
 		}
 
-		if server.Properties.BootCdrom != nil {
-			labels[serverBootCDROMIDLabel] = model.LabelValue(*server.Properties.BootCdrom.Id)
+		if props.BootCdrom != nil && props.BootCdrom.Id != nil {
+			labels[serverBootCDROMIDLabel] = model.LabelValue(*props.BootCdrom.Id)
 		}
 
-		if server.Properties.BootVolume != nil {
-			labels[serverBootVolumeIDLabel] = model.LabelValue(*server.Properties.BootVolume.Id)
+		if props.BootVolume != nil && props.BootVolume.Id != nil {
+			labels[serverBootVolumeIDLabel] = model.LabelValue(*props.BootVolume.Id)
 		}
 
-		if server.Entities != nil && server.Entities.Volumes != nil {
+		if server.Entities != nil && server.Entities.Volumes != nil && server.Entities.Volumes.Items != nil {
 			volumes := *server.Entities.Volumes.Items
-			if len(volumes) > 0 {
+			if len(volumes) > 0 && volumes[0].Properties != nil {
 				image := volumes[0].Properties.Image
 				if image != nil {
 					labels[serverBootImageIDLabel] = model.LabelValue(*image)

--- a/discovery/ionos/server_test.go
+++ b/discovery/ionos/server_test.go
@@ -16,6 +16,7 @@ package ionos
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -97,6 +98,178 @@ func TestIONOSServerRefresh(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
 			require.Equal(t, lbls, tg.Targets[i])
+		})
+	}
+}
+
+// ionosTestDiscovery returns a discovery pointed at a mock serving body, so
+// refresh() runs the response through the real SDK decoder and the nil pointers
+// below are the ones a live API would produce.
+func ionosTestDiscovery(t *testing.T, body string) *serverDiscovery {
+	t.Helper()
+
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, body)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(mock.Close)
+
+	cfg := DefaultSDConfig
+	cfg.DatacenterID = ionosTestDatacenterID
+	cfg.HTTPClientConfig.BearerToken = ionosTestBearerToken
+	cfg.ionosEndpoint = mock.URL
+
+	d, err := newServerDiscovery(&cfg, nil)
+	require.NoError(t, err)
+
+	return d
+}
+
+// ionosServersBody wraps server objects in the collection the API returns.
+func ionosServersBody(items string) string {
+	return `{
+		"id": "` + ionosTestDatacenterID + `/servers",
+		"type": "collection",
+		"items": [` + items + `]
+	}`
+}
+
+// TestIONOSServerRefreshNilContainers covers responses where the API omitted a
+// container rather than a leaf field. Items, properties and ips are all
+// pointers carrying omitempty in the SDK, but refresh() walked into them with no
+// nil check, so a datacenter with no servers, a server with no properties or a
+// NIC with no IPs panicked the whole Prometheus process instead of degrading the
+// target.
+func TestIONOSServerRefreshNilContainers(t *testing.T) {
+	const serversID = "8feda53f-15f0-447f-badf-ebe32dad2fc0/servers"
+
+	for _, tc := range []struct {
+		name     string
+		body     string
+		expected []model.LabelSet
+	}{
+		{
+			name: "NoServerItems",
+			body: `{"id": "` + ionosTestDatacenterID + `/servers", "type": "collection"}`,
+		},
+		{
+			name: "NilServerProperties",
+			body: ionosServersBody(`{
+				"id": "srv-1",
+				"type": "server",
+				"properties": null,
+				"entities": {"nics": {"items": [
+					{"id": "nic-1", "type": "nic", "properties": {"ips": ["10.0.0.1"]}}
+				]}}
+			}`),
+			expected: []model.LabelSet{{
+				"__address__":                        "10.0.0.1:80",
+				"__meta_ionos_server_id":             "srv-1",
+				"__meta_ionos_server_ip":             ",10.0.0.1,",
+				"__meta_ionos_server_nic_ip_unnamed": ",10.0.0.1,",
+				"__meta_ionos_server_servers_id":     serversID,
+			}},
+		},
+		{
+			name: "NoNICItems",
+			body: ionosServersBody(`{
+				"id": "srv-2",
+				"type": "server",
+				"properties": {"name": "no-nics"},
+				"entities": {"nics": {"id": "srv-2/nics", "type": "collection"}}
+			}`),
+		},
+		{
+			name: "NilNICProperties",
+			body: ionosServersBody(`{
+				"id": "srv-3",
+				"type": "server",
+				"properties": {"name": "nic-without-properties"},
+				"entities": {"nics": {"items": [
+					{"id": "nic-3", "type": "nic", "properties": null}
+				]}}
+			}`),
+		},
+		{
+			name: "NilNICIps",
+			body: ionosServersBody(`{
+				"id": "srv-4",
+				"type": "server",
+				"properties": {"name": "nic-without-ips"},
+				"entities": {"nics": {"items": [
+					{"id": "nic-4", "type": "nic", "properties": {"name": "eth0"}}
+				]}}
+			}`),
+		},
+		{
+			name: "NilBootCdromAndBootVolumeID",
+			body: ionosServersBody(`{
+				"id": "srv-5",
+				"type": "server",
+				"properties": {"bootCdrom": {}, "bootVolume": {"id": null}},
+				"entities": {"nics": {"items": [
+					{"id": "nic-5", "type": "nic", "properties": {"ips": ["10.0.0.5"]}}
+				]}}
+			}`),
+			expected: []model.LabelSet{{
+				"__address__":                        "10.0.0.5:80",
+				"__meta_ionos_server_id":             "srv-5",
+				"__meta_ionos_server_ip":             ",10.0.0.5,",
+				"__meta_ionos_server_nic_ip_unnamed": ",10.0.0.5,",
+				"__meta_ionos_server_servers_id":     serversID,
+			}},
+		},
+		{
+			name: "NoVolumeItems",
+			body: ionosServersBody(`{
+				"id": "srv-6",
+				"type": "server",
+				"properties": {"name": "no-volume-items"},
+				"entities": {
+					"nics": {"items": [
+						{"id": "nic-6", "type": "nic", "properties": {"ips": ["10.0.0.6"]}}
+					]},
+					"volumes": {"id": "srv-6/volumes", "type": "collection"}
+				}
+			}`),
+			expected: []model.LabelSet{{
+				"__address__":                        "10.0.0.6:80",
+				"__meta_ionos_server_id":             "srv-6",
+				"__meta_ionos_server_ip":             ",10.0.0.6,",
+				"__meta_ionos_server_name":           "no-volume-items",
+				"__meta_ionos_server_nic_ip_unnamed": ",10.0.0.6,",
+				"__meta_ionos_server_servers_id":     serversID,
+			}},
+		},
+		{
+			name: "NilVolumeProperties",
+			body: ionosServersBody(`{
+				"id": "srv-7",
+				"type": "server",
+				"properties": {"name": "volume-without-properties"},
+				"entities": {
+					"nics": {"items": [
+						{"id": "nic-7", "type": "nic", "properties": {"ips": ["10.0.0.7"]}}
+					]},
+					"volumes": {"items": [{"id": "vol-7", "type": "volume", "properties": null}]}
+				}
+			}`),
+			expected: []model.LabelSet{{
+				"__address__":                        "10.0.0.7:80",
+				"__meta_ionos_server_id":             "srv-7",
+				"__meta_ionos_server_ip":             ",10.0.0.7,",
+				"__meta_ionos_server_name":           "volume-without-properties",
+				"__meta_ionos_server_nic_ip_unnamed": ",10.0.0.7,",
+				"__meta_ionos_server_servers_id":     serversID,
+			}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tgs, err := ionosTestDiscovery(t, tc.body).refresh(context.Background())
+			require.NoError(t, err)
+			require.Len(t, tgs, 1)
+			require.Equal(t, tc.expected, tgs[0].Targets)
 		})
 	}
 }


### PR DESCRIPTION
[PR 19418](https://redirect.github.com/prometheus/prometheus/pull/19418) guarded the leaf fields of the IONOS server discovery, but the pointers holding those leaves were left unchecked. `Items`, `properties` and `ips` are all pointers carrying `omitempty` in `ionos-cloud/sdk-go/v6`, so a response can legitimately omit any of them:

```go
for _, server := range *servers.Items {           // omitted when the datacenter has no servers
    ...
    if server.Properties.AvailabilityZone != nil  // Properties itself may be absent
```

Nothing under `discovery/` recovers, so each of these takes down the whole Prometheus process rather than degrading the target.

Guarded here, each covered by a subtest that panics without the fix:

- `servers.Items` — a datacenter holding no servers. This is the cheapest one to hit: an empty datacenter returns a collection with no `items` member at all.
- `server.Entities.Nics.Items` — a server whose NIC collection carries no items.
- `nic.Properties` and `nic.Properties.Ips` — a NIC with no properties, or with properties but no addresses.
- `server.Properties` — now read through a local that falls back to the zero value, which keeps the existing per-field checks as the single place where a label is omitted, rather than wrapping two separate blocks in a nil check.
- `BootCdrom.Id` and `BootVolume.Id` — the reference is present but carries no id. `ResourceReference.Id` is a pointer.
- `server.Entities.Volumes.Items` and `volumes[0].Properties`.

An absent `ips` is treated as an empty one, so a NIC without addresses behaves exactly as it already did for `"ips": []`.

The cases run through the real SDK decoder rather than constructing structs, so the nil pointers are the ones a live API would produce. They are separate responses instead of extra entries in `testdata/servers.json` because the first panic would otherwise mask the other seven.

I have no IONOS account to confirm this end to end, so the change rests on the field types and their `omitempty` tags in `ionos-cloud/sdk-go/v6 v6.3.11`.

```release-notes
[BUGFIX] IONOS SD: Do not panic when the API response omits the server, NIC or volume collections, or a server's properties.
```
