### PR TITLE
scrape: keep the FQDN lookup out of synctest bubbles

### DIFF
--- a/scrape/helpers_test.go
+++ b/scrape/helpers_test.go
@@ -307,6 +307,10 @@ func startFakeHTTPServer(t *testing.T) (*pipeListener, func()) {
 	return listener, srv.Close
 }
 
+// synctestFQDN replaces the FQDN lookup: resolving inside a bubble makes a
+// later lookup from outside abort the process.
+const synctestFQDN = "synctest.example.com"
+
 // setupSynctestManager abstracts the boilerplate of creating a mock network,
 // starting the fake HTTP server, and configuring the scrape manager for synctest.
 func setupSynctestManager(t *testing.T, opts *Options) (*Manager, *teststorage.Appendable, func()) {
@@ -319,6 +323,7 @@ func setupSynctestManager(t *testing.T, opts *Options) (*Manager, *teststorage.A
 		opts = &Options{}
 	}
 	opts.skipJitterOffsetting = true
+	opts.fqdn = synctestFQDN
 
 	// Ensure the scraper creates a new net.Pipe on every dial attempt
 	// and hands the server-side connection to the mock server's listener.

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -180,6 +180,9 @@ type Options struct {
 
 	// private option for testability.
 	skipJitterOffsetting bool
+
+	// private option for testability: replaces the FQDN lookup.
+	fqdn string
 }
 
 // Manager maintains a set of scrape pools and manages start/stop cycles
@@ -308,9 +311,13 @@ func (m *Manager) reload() {
 // setOffsetSeed calculates a global offsetSeed per server relying on extra label set.
 func (m *Manager) setOffsetSeed(labels labels.Labels) error {
 	h := fnv.New64a()
-	hostname, err := osutil.GetFQDN()
-	if err != nil {
-		return err
+	hostname := m.opts.fqdn
+	if hostname == "" {
+		var err error
+		hostname, err = osutil.GetFQDN()
+		if err != nil {
+			return err
+		}
 	}
 	if _, err := fmt.Fprintf(h, "%s%s", hostname, labels.String()); err != nil {
 		return err

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -821,6 +821,25 @@ global:
 	offsetSeed2 := scrapeManager.offsetSeed
 
 	require.NotEqual(t, offsetSeed1, offsetSeed2, "Offset seed should not be the same on different set of external labels.")
+
+	// The fqdn option replaces the name lookup, so the seed follows it.
+	seedFor := func(fqdn string) uint64 {
+		m, err := NewManager(&Options{fqdn: fqdn}, nil, nil, nil, teststorage.NewAppendable(), prometheus.NewRegistry())
+		require.NoError(t, err)
+		require.NoError(t, m.setOffsetSeed(cfg1.GlobalConfig.ExternalLabels))
+		return m.offsetSeed
+	}
+	seedA, seedB := seedFor("a.example.com"), seedFor("b.example.com")
+	require.NotEqual(t, seedA, seedB, "Offset seed should follow the fqdn option.")
+	require.Equal(t, seedA, seedFor("a.example.com"), "Offset seed should be stable for a fixed fqdn.")
+}
+
+func TestSetupSynctestManagerReplacesFQDNLookup(t *testing.T) {
+	scrapeManager, _, cleanup := setupSynctestManager(t, nil)
+	t.Cleanup(cleanup)
+
+	require.Equal(t, synctestFQDN, scrapeManager.opts.fqdn,
+		"synctest tests must not reach the resolver from inside a bubble")
 }
 
 func TestManagerScrapePools(t *testing.T) {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -7983,6 +7983,9 @@ func TestScrapeOffsetDistribution(t *testing.T) {
 					}
 				}),
 			},
+			// setupSynctestManager is unusable here: it also sets skipJitterOffsetting,
+			// which zeroes the offsets asserted below.
+			fqdn: synctestFQDN,
 		}
 		scrapeManager, err := NewManager(opts, promslog.NewNopLogger(), nil, app, nil, prometheus.NewRegistry())
 		scrapeManager.offsetSeed = 1 // Set a fixed offset seed for deterministic testing.


### PR DESCRIPTION
`go test -shuffle` can kill the `scrape` test run: the process aborts, no test is reported as failing, and CI never sees it because `-shuffle` is in no workflow. One in-bubble name lookup is enough to arm it — `TestScrapeOffsetDistribution` resolves the host's FQDN from inside a `synctest` bubble, and any later lookup from outside aborts the process. The root cause is in Go's `net`, which I reported as golang/go#80903 and sent a fix for as golang/go#80906 — and that upstream fix does not remove the need for this change.

`skipJitterOffsetting` would keep the lookup out, but it also zeroes each scrape loop's offset — exactly what this test asserts, which is why it cannot use the synctest helper. So the FQDN gets its own private option, in the same shape: the helper and that one test supply a fixed value, the offset seed stays real, and no lookup happens inside a bubble.

Verified against the twelve configurations that were fatal on `main` rather than a fresh set — four shuffle seeds of the whole package, and eight pairings of this test with another that resolves, each at its own fatal seed — and all twelve pass here. Instrumented, no `GetFQDN` call has `synctest` on the stack, against one on `main`. The new test fails if the helper stops setting the option; I checked by removing the line.

What it does not cover: the option is set directly in `TestScrapeOffsetDistribution`, so nothing catches its removal there, and the crash that would return is one CI cannot see.

Upstream covers two of the three channels `net` creates lazily; the third, `net.threadLimit`, takes its capacity from `rlim.Cur`, so it cannot be created eagerly — and with the other two fixed, the default resolver path here still aborts.

cc @krajorama

#### Which issue(s) does the PR fix:

Fixes #19439

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```
