### PR TITLE
discovery/kubernetes: fall back to status.loadBalancer.ingress for service loadbalancer IP

### DIFF
--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -234,7 +234,18 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
 		}
 
 		if svc.Spec.Type == apiv1.ServiceTypeLoadBalancer {
-			labelSet[serviceLoadBalancerIP] = lv(svc.Spec.LoadBalancerIP)
+			// spec.loadBalancerIP was deprecated in Kubernetes 1.24. Cloud providers
+			// now set status.loadBalancer.ingress instead. Fall back to the first
+			// ingress entry when the spec field is empty.
+			loadBalancerIP := svc.Spec.LoadBalancerIP
+			if loadBalancerIP == "" && len(svc.Status.LoadBalancer.Ingress) > 0 {
+				if ip := svc.Status.LoadBalancer.Ingress[0].IP; ip != "" {
+					loadBalancerIP = ip
+				} else {
+					loadBalancerIP = svc.Status.LoadBalancer.Ingress[0].Hostname
+				}
+			}
+			labelSet[serviceLoadBalancerIP] = lv(loadBalancerIP)
 		}
 
 		tg.Targets = append(tg.Targets, labelSet)

--- a/discovery/kubernetes/service_test.go
+++ b/discovery/kubernetes/service_test.go
@@ -113,6 +113,38 @@ func makeLoadBalancerService() *v1.Service {
 	}
 }
 
+// makeLoadBalancerServiceWithStatusIngressIP returns a LoadBalancer service
+// that has no spec.loadBalancerIP (deprecated since Kubernetes 1.24) but
+// has the assigned IP in status.loadBalancer.ingress, as set by modern cloud
+// providers.
+func makeLoadBalancerServiceWithStatusIngressIP() *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testservice-lb-status",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "testport",
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(31900),
+				},
+			},
+			Type:      v1.ServiceTypeLoadBalancer,
+			ClusterIP: "10.0.0.2",
+			// LoadBalancerIP intentionally left empty to simulate Kubernetes 1.24+
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{IP: "203.0.113.1"},
+				},
+			},
+		},
+	}
+}
+
 func TestServiceDiscoveryAdd(t *testing.T) {
 	t.Parallel()
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{})
@@ -180,6 +212,40 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 					"__meta_kubernetes_namespace":    "default",
 				},
 				Source: "svc/default/testservice-loadbalancer",
+			},
+		},
+	}.Run(t)
+}
+
+func TestServiceDiscoveryLoadBalancerIPFromStatusIngress(t *testing.T) {
+	t.Parallel()
+	n, c := makeDiscovery(RoleService, NamespaceDiscovery{})
+
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := makeLoadBalancerServiceWithStatusIngressIP()
+			c.CoreV1().Services(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			"svc/default/testservice-lb-status": {
+				Targets: []model.LabelSet{
+					{
+						"__meta_kubernetes_service_port_protocol":   "TCP",
+						"__address__":                               "testservice-lb-status.default.svc:31900",
+						"__meta_kubernetes_service_type":            "LoadBalancer",
+						"__meta_kubernetes_service_port_name":       "testport",
+						"__meta_kubernetes_service_port_number":     "31900",
+						"__meta_kubernetes_service_cluster_ip":      "10.0.0.2",
+						"__meta_kubernetes_service_loadbalancer_ip": "203.0.113.1",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_service_name": "testservice-lb-status",
+					"__meta_kubernetes_namespace":    "default",
+				},
+				Source: "svc/default/testservice-lb-status",
 			},
 		},
 	}.Run(t)


### PR DESCRIPTION
### Summary

`__meta_kubernetes_service_loadbalancer_ip` was always empty for LoadBalancer services on Kubernetes 1.24+ clusters because it read only `spec.loadBalancerIP`, which was deprecated in that release. Modern cloud providers (GKE, EKS, AKS, MetalLB, ...) now populate `status.loadBalancer.ingress` and leave `spec.loadBalancerIP` unset.

### Problem

In `discovery/kubernetes/service.go`:

```go
if svc.Spec.Type == apiv1.ServiceTypeLoadBalancer {
    labelSet[serviceLoadBalancerIP] = lv(svc.Spec.LoadBalancerIP)
}
```

`spec.loadBalancerIP` is always `""` on Kubernetes 1.24+ unless the user sets it explicitly, so `__meta_kubernetes_service_loadbalancer_ip` is always blank when using relabelling such as `__meta_kubernetes_service_loadbalancer_ip` as a `__param_target` for blackbox-style probes.

### Solution

When `spec.loadBalancerIP` is empty, fall back to the first entry in `status.loadBalancer.ingress` — first the `.IP` field, then `.Hostname` if no IP is available. The spec field is still checked first to keep backward compatibility for clusters that still set it.

```go
loadBalancerIP := svc.Spec.LoadBalancerIP
if loadBalancerIP == "" && len(svc.Status.LoadBalancer.Ingress) > 0 {
    if ip := svc.Status.LoadBalancer.Ingress[0].IP; ip != "" {
        loadBalancerIP = ip
    } else {
        loadBalancerIP = svc.Status.LoadBalancer.Ingress[0].Hostname
    }
}
labelSet[serviceLoadBalancerIP] = lv(loadBalancerIP)
```

### Testing

- Added `makeLoadBalancerServiceWithStatusIngressIP()` helper and `TestServiceDiscoveryLoadBalancerIPFromStatusIngress` test that verifies `__meta_kubernetes_service_loadbalancer_ip` is populated from `status.loadBalancer.ingress[0].IP` when `spec.loadBalancerIP` is empty.
- All existing tests unchanged and passing locally.

Fixes #14398