### PR TITLE
Fix label mismatches in HA group alerts

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -407,7 +407,7 @@
             alert: 'PrometheusHAGroupNotIngestingSamples',
             expr: |||
               max by (%(prometheusHAGroupLabels)s) (
-                rate(prometheus_tsdb_head_samples_appended_total{%(prometheusSelector)s}[5m])
+                sum without(type) (rate(prometheus_tsdb_head_samples_appended_total{%(prometheusSelector)s}[5m]))
               and
                 (
                   sum without(scrape_job) (prometheus_target_metadata_cache_entries{%(prometheusSelector)s}) > 0
@@ -457,10 +457,10 @@
             alert: 'PrometheusHAGroupCrashlooping',
             expr: |||
               (
-                  prometheus_tsdb_clean_start{%(prometheusSelector)s} == 0
-                and
-                  (
-                    count by (%(prometheusHAGroupLabels)s) (
+                   (
+                      count by (%(prometheusHAGroupLabels)s) (
+                      prometheus_tsdb_clean_start{%(prometheusSelector)s} == 0
+                      and
                       changes(process_start_time_seconds{%(prometheusSelector)s}[1h]) > 1
                     )
                     /


### PR DESCRIPTION
Two bugs prevented the following alerts from working correctly:

1. **PrometheusHAGroupNotIngestingSamples**: The `rate()` of `prometheus_tsdb_head_samples_appended_total` needs `sum without(type)` to strip the `type` label (added in Prometheus 3.x), otherwise the `and` with metadata/rules metrics fails to match and the alert never fires. The non-HA version of this alert already strips the type label correctly.

2. **PrometheusHAGroupCrashlooping**: The unclean restart branch tried to and an instance-level `prometheus_tsdb_clean_start` metric with a group-level restart ratio. These have different label sets so the and was always empty. Fixed by aggregating the clean_start check by HA group labels first.

```release-notes
[BUGFIX] Mixins: Fix label mismatches that prevented PrometheusHAGroupNotIngestingSamples and PrometheusHAGroupCrashlooping from firing.
```