### PR TITLE
Only call StartTimestamp() in NH conversion if needed

### DIFF
--- a/model/textparse/benchmark_test.go
+++ b/model/textparse/benchmark_test.go
@@ -129,8 +129,9 @@ func BenchmarkParseOpenMetricsNHCB(b *testing.B) {
 	data := readTestdataFile(b, "1histogram.om.txt")
 
 	for _, parser := range []string{
-		"omtext",           // Measure OM parser baseline for histograms.
-		"omtext_with_nhcb", // Measure NHCB over OM parser.
+		"omtext",              // Measure OM parser baseline for histograms.
+		"omtext_with_nhcb",    // Measure NHCB over OM parser without ST parsing.
+		"omtext_with_nhcb_st", // Measure NHCB over OM parser with ST parsing enabled.
 	} {
 		b.Run(fmt.Sprintf("parser=%v", parser), func(b *testing.B) {
 			benchParse(b, data, parser)
@@ -158,6 +159,15 @@ func benchParse(b *testing.B, data []byte, parser string) {
 	case "omtext_with_nhcb":
 		newParserFn = func(buf []byte, st *labels.SymbolTable) Parser {
 			p, err := New(buf, "application/openmetrics-text", st, ParserOptions{ConvertClassicHistogramsToNHCB: true})
+			require.NoError(b, err)
+			return p
+		}
+	case "omtext_with_nhcb_st":
+		newParserFn = func(buf []byte, st *labels.SymbolTable) Parser {
+			p, err := New(buf, "application/openmetrics-text", st, ParserOptions{
+				ConvertClassicHistogramsToNHCB: true,
+				OpenMetricsSkipSTSeries:        true,
+			})
 			require.NoError(b, err)
 			return p
 		}

--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -194,7 +194,10 @@ func New(b []byte, contentType string, st *labels.SymbolTable, opts ParserOption
 	}
 
 	if baseParser != nil && opts.ConvertClassicHistogramsToNHCB {
-		baseParser = NewNHCBParser(baseParser, st, opts.KeepClassicOnClassicAndNativeHistograms)
+		// OpenMetricsSkipSTSeries is set to true when the scrape loop
+		// wants start timestamps. NHCBParser uses it to decide if
+		// StartTimestamp calls are necessary.
+		baseParser = NewNHCBParser(baseParser, st, opts.KeepClassicOnClassicAndNativeHistograms, opts.OpenMetricsSkipSTSeries)
 	}
 
 	return baseParser, err

--- a/model/textparse/nhcbparse.go
+++ b/model/textparse/nhcbparse.go
@@ -52,6 +52,9 @@ type NHCBParser struct {
 	parser Parser
 	// Option to keep classic histograms along with converted histograms.
 	keepClassicHistograms bool
+	// parseST tells if the caller needs start timestamps. When false,
+	// StartTimestamp calls are skipped because they are expensive.
+	parseST bool
 
 	// Labels builder.
 	builder labels.ScratchBuilder
@@ -103,10 +106,11 @@ type NHCBParser struct {
 	hBuffer []byte
 }
 
-func NewNHCBParser(p Parser, st *labels.SymbolTable, keepClassicHistograms bool) Parser {
+func NewNHCBParser(p Parser, st *labels.SymbolTable, keepClassicHistograms, parseST bool) Parser {
 	return &NHCBParser{
 		parser:                p,
 		keepClassicHistograms: keepClassicHistograms,
+		parseST:               parseST,
 		builder:               labels.NewScratchBuilderWithSymbolTable(st, 16),
 		tempNHCB:              convertnhcb.NewTempHistogram(),
 	}
@@ -319,7 +323,11 @@ func (p *NHCBParser) handleClassicHistogramSeries(lset labels.Labels) bool {
 func (p *NHCBParser) processClassicHistogramSeries(lset labels.Labels, name string, updateHist func(*convertnhcb.TempHistogram)) {
 	if p.state != stateCollecting {
 		p.storeClassicLabels(name)
-		p.tempST = p.parser.StartTimestamp()
+		if p.parseST {
+			p.tempST = p.parser.StartTimestamp()
+		} else {
+			p.tempST = 0
+		}
 		p.state = stateCollecting
 		p.tempLsetNHCB = convertnhcb.GetHistogramMetricBase(lset, name)
 	}

--- a/model/textparse/nhcbparse_test.go
+++ b/model/textparse/nhcbparse_test.go
@@ -443,7 +443,10 @@ foobar{quantile="0.99"} 150.1`
 		},
 	}
 
-	p, err := New([]byte(input), "application/openmetrics-text", labels.NewSymbolTable(), ParserOptions{ConvertClassicHistogramsToNHCB: true})
+	p, err := New([]byte(input), "application/openmetrics-text", labels.NewSymbolTable(), ParserOptions{
+		ConvertClassicHistogramsToNHCB: true,
+		OpenMetricsSkipSTSeries:        true,
+	})
 	require.NoError(t, err)
 	require.NotNil(t, p)
 	got := testParse(t, p)
@@ -603,7 +606,11 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 		func() (string, parserFactory, []int, parserOptions) {
 			factory := func(keepClassic, nhcb bool) (Parser, error) {
 				input := createTestOpenMetricsHistogram()
-				return New([]byte(input), "application/openmetrics-text", labels.NewSymbolTable(), ParserOptions{KeepClassicOnClassicAndNativeHistograms: keepClassic, ConvertClassicHistogramsToNHCB: nhcb})
+				return New([]byte(input), "application/openmetrics-text", labels.NewSymbolTable(), ParserOptions{
+					KeepClassicOnClassicAndNativeHistograms: keepClassic,
+					ConvertClassicHistogramsToNHCB:          nhcb,
+					OpenMetricsSkipSTSeries:                 true,
+				})
 			}
 			return "OpenMetrics", factory, []int{1}, parserOptions{hasStartTimestamp: true}
 		},
@@ -956,7 +963,10 @@ something_bucket{a="b",le="+Inf"} 9
 		},
 	}
 
-	p, err := New([]byte(input), "application/openmetrics-text", labels.NewSymbolTable(), ParserOptions{ConvertClassicHistogramsToNHCB: true})
+	p, err := New([]byte(input), "application/openmetrics-text", labels.NewSymbolTable(), ParserOptions{
+		ConvertClassicHistogramsToNHCB: true,
+		OpenMetricsSkipSTSeries:        true,
+	})
 	require.NoError(t, err)
 	require.NotNil(t, p)
 	got := testParse(t, p)
@@ -1087,7 +1097,10 @@ metric: <
 		},
 	}
 
-	p, err := New(buf.Bytes(), "application/vnd.google.protobuf", labels.NewSymbolTable(), ParserOptions{ConvertClassicHistogramsToNHCB: true})
+	p, err := New(buf.Bytes(), "application/vnd.google.protobuf", labels.NewSymbolTable(), ParserOptions{
+		ConvertClassicHistogramsToNHCB: true,
+		OpenMetricsSkipSTSeries:        true,
+	})
 	require.NoError(t, err)
 	require.NotNil(t, p)
 	got := testParse(t, p)


### PR DESCRIPTION
Start timestamps are a new feature behind a flag, but when conversion of classic to native histograms is enabled for a scrape job they are parsed unconditionally. Fix it by making NH conversion aware if start timestamps should be parsed or not. This improves conversion when start timestamps are not enabled by ~25%:

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/textparse
cpu: 13th Gen Intel(R) Core(TM) i7-13800H
BenchmarkParseOpenMetricsNHCB/parser=omtext-20         	    4564	    263001 ns/op	  15.94 MB/s	   22953 B/op	     375 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext-20         	    4725	    267516 ns/op	  15.67 MB/s	   22953 B/op	     375 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext-20         	    4494	    266138 ns/op	  15.75 MB/s	   22953 B/op	     375 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext-20         	    4339	    274864 ns/op	  15.25 MB/s	   22954 B/op	     375 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext-20         	    4555	    271449 ns/op	  15.44 MB/s	   22953 B/op	     375 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext-20         	    4557	    265099 ns/op	  15.81 MB/s	   22953 B/op	     375 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb-20         	   17178	     68069 ns/op	  61.57 MB/s	   19582 B/op	     335 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb-20         	   16897	     70082 ns/op	  59.80 MB/s	   19583 B/op	     335 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb-20         	   17547	     67433 ns/op	  62.15 MB/s	   19583 B/op	     335 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb-20         	   19473	     64224 ns/op	  65.26 MB/s	   19583 B/op	     335 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb-20         	   21372	     62047 ns/op	  67.55 MB/s	   19583 B/op	     335 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb-20         	   17398	     69037 ns/op	  60.71 MB/s	   19583 B/op	     335 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-20      	   12673	     92909 ns/op	  45.11 MB/s	   20520 B/op	     353 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-20      	   13558	     92818 ns/op	  45.15 MB/s	   20520 B/op	     353 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-20      	   13099	     91639 ns/op	  45.73 MB/s	   20520 B/op	     353 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-20      	   13731	     88575 ns/op	  47.32 MB/s	   20520 B/op	     353 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-20      	   12201	     96279 ns/op	  43.53 MB/s	   20520 B/op	     353 allocs/op
BenchmarkParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-20      	   12896	     94736 ns/op	  44.24 MB/s	   20520 B/op	     353 allocs/op
PASS
ok  	github.com/prometheus/prometheus/model/textparse	22.386s
```

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[PERF] scrape: conversion from classic to native histograms should only parse start times when enabled
```
