### PR TITLE
tsdb: fix ABBA lock-ordering deadlock in gc/gcSeries check callbacks

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2321,6 +2321,18 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 
 	// For one series, truncate old chunks and check if any chunks left. If not, mark as deleted and collect the ID.
 	check := func(hashShard int, hash uint64, series *memSeries, deletedForCallback map[chunks.HeadSeriesRef]labels.Labels) {
+		// Acquire the ref-stripe lock before the series lock to enforce a consistent
+		// global lock order: stripe-lock → series-lock. This matches the order used
+		// by mmapHeadChunksInStripe (locks[i].RLock → series.Lock) and prevents an
+		// ABBA deadlock when gcSeries runs concurrently with mmapHeadChunks (e.g.
+		// when CompactSelectedSeries is called from an external goroutine). See
+		// https://github.com/prometheus/prometheus/issues/19445
+		stripe := s.refStripe(series.ref)
+		if hashShard != stripe {
+			s.locks[stripe].Lock()
+			defer s.locks[stripe].Unlock()
+		}
+
 		series.Lock()
 		defer series.Unlock()
 
@@ -2360,16 +2372,8 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 			}
 			return
 		}
-		// The series is gone entirely. We need to keep the series lock
-		// and make sure we have acquired the stripe locks for hash and ID of the
-		// series alike.
-		// If we don't hold them all, there's a very small chance that a series receives
-		// samples again while we are half-way into deleting it.
-		stripe := s.refStripe(series.ref)
-		if hashShard != stripe {
-			s.locks[stripe].Lock()
-			defer s.locks[stripe].Unlock()
-		}
+		// The series is gone entirely. The ref-stripe lock (stripe) was already
+		// acquired above before the series lock, so we hold both now.
 
 		stale, isHist, buckets := series.sampleState()
 		if stale {
@@ -2384,7 +2388,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 		s.hashes[hashShard].del(hash, series.ref)
 		delete(s.series[stripe], series.ref)
-		deletedForCallback[series.ref] = series.lset // OK to access lset; series is locked at the top of this function.
+		deletedForCallback[series.ref] = series.lset // OK to access lset; series is locked above.
 	}
 
 	s.iterForDeletion(check)
@@ -2549,6 +2553,18 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 			return
 		}
 
+		// Acquire the ref-stripe lock before the series lock to enforce a consistent
+		// global lock order: stripe-lock → series-lock. This matches the order used
+		// by mmapHeadChunksInStripe (locks[i].RLock → series.Lock) and prevents an
+		// ABBA deadlock when gcSeries runs concurrently with mmapHeadChunks (e.g.
+		// when CompactSelectedSeries is called from an external goroutine). See
+		// https://github.com/prometheus/prometheus/issues/19445
+		stripe := s.refStripe(series.ref)
+		if hashShard != stripe {
+			s.locks[stripe].Lock()
+			defer s.locks[stripe].Unlock()
+		}
+
 		series.Lock()
 		defer series.Unlock()
 
@@ -2569,13 +2585,9 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 		// series alike.
 		// If we don't hold them all, there's a very small chance that a series receives
 		// samples again while we are half-way into deleting it.
-		stripe := s.refStripe(series.ref)
+		// Note: stripe lock was already acquired above before the series lock.
 		if headChunkCount >= 2 {
 			s.decMmapReady(series.ref)
-		}
-		if hashShard != stripe {
-			s.locks[stripe].Lock()
-			defer s.locks[stripe].Unlock()
 		}
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
@@ -2590,7 +2602,7 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 		s.hashes[hashShard].del(hash, series.ref)
 		delete(s.series[stripe], series.ref)
-		deletedForCallback[series.ref] = series.lset // OK to access lset; series is locked at the top of this function.
+		deletedForCallback[series.ref] = series.lset // OK to access lset; series is locked above.
 	}
 
 	s.iterForDeletion(check)

--- a/tsdb/head_deadlock_test.go
+++ b/tsdb/head_deadlock_test.go
@@ -1,0 +1,208 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+// Regression tests for https://github.com/prometheus/prometheus/issues/19445
+//
+// ABBA lock-ordering deadlock between:
+//   - mmapHeadChunksInStripe: holds stripe[i].RLock  → waits for series.Lock()
+//   - gcSeries check callback: holds series.Lock()   → waits for stripe[j].Lock() (write)
+//
+// With the un-fixed code the tests hang permanently; with the fix they
+// complete within the deadline.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/compression"
+)
+
+// TestDeadlockGCSeriesAndMmapChunks exercises the concurrent path that Mimir
+// hits when it calls CompactSelectedSeries from a goroutine while the background
+// DB.run() loop is running mmapHeadChunks.
+//
+// Before the fix the test hangs within the first few iterations.
+// After the fix it completes well within the 30-second deadline.
+func TestDeadlockGCSeriesAndMmapChunks(t *testing.T) {
+	// Use a tiny stripe size so hash-shard ≠ ref-stripe is very common,
+	// maximising the chance that gcSeries must acquire a second stripe lock.
+	opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
+	opts.StripeSize = 2
+
+	head, wal := newTestHeadWithOptions(t, compression.None, opts)
+	t.Cleanup(func() { _ = wal.Close() })
+	require.NoError(t, head.Init(0))
+
+	// Append enough samples so every series has headChunkCount >= 2 (mmap-eligible).
+	const numSeries = 50
+	const samplesPerSeries = DefaultSamplesPerChunk + 5
+
+	refs := make([]storage.SeriesRef, 0, numSeries)
+	for i := range numSeries {
+		lset := labels.FromStrings("__name__", "deadlock_test", "id", string(rune('a'+i)))
+		app := head.Appender(context.Background())
+		var ref storage.SeriesRef
+		for j := range samplesPerSeries {
+			r, err := app.Append(ref, lset, int64(j)*1000, float64(j))
+			require.NoError(t, err)
+			ref = r
+		}
+		require.NoError(t, app.Commit())
+		refs = append(refs, ref)
+	}
+
+	const rounds = 300
+	deadline := time.After(30 * time.Second)
+	done := make(chan struct{})
+
+	// Goroutine A: mmapHeadChunks — stripe RLock → series.Lock
+	// Goroutine B: gcSeries      — (before fix) series.Lock → stripe write Lock
+	//
+	// Running them concurrently without synchronisation maximises interleaving
+	// and makes the deadlock deterministic on any scheduler.
+	go func() {
+		defer close(done)
+
+		var wg sync.WaitGroup
+		for range rounds {
+			wg.Add(2)
+
+			go func() {
+				defer wg.Done()
+				head.mmapHeadChunks()
+			}()
+
+			go func() {
+				defer wg.Done()
+				// maxt=-1 means nothing is evicted, but all lock paths are taken.
+				_ = head.gcSeries(refs, -1, func(*memSeries) bool { return false })
+			}()
+
+			wg.Wait()
+		}
+	}()
+
+	select {
+	case <-done:
+		// No deadlock.
+	case <-deadline:
+		t.Fatal("deadlock detected: mmapHeadChunks and gcSeries are permanently blocked; " +
+			"regression for https://github.com/prometheus/prometheus/issues/19445")
+	}
+}
+
+// TestDeadlockGCAndMmapChunks_CrossStripe is the same scenario with StripeSize=4
+// to cover series whose ref-stripe ≠ hash-stripe (the cross-stripe case that
+// requires two stripe locks in the GC callback).
+func TestDeadlockGCAndMmapChunks_CrossStripe(t *testing.T) {
+	opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
+	opts.StripeSize = 4
+
+	head, wal := newTestHeadWithOptions(t, compression.None, opts)
+	t.Cleanup(func() { _ = wal.Close() })
+	require.NoError(t, head.Init(0))
+
+	const numSeries = 100
+	const samplesPerSeries = DefaultSamplesPerChunk + 1
+
+	refs := make([]storage.SeriesRef, 0, numSeries)
+	for i := range numSeries {
+		lset := labels.FromStrings("pod", string(rune('a'+i%26)), "idx", string(rune('0'+i/26)))
+		app := head.Appender(context.Background())
+		var ref storage.SeriesRef
+		for j := range samplesPerSeries {
+			r, err := app.Append(ref, lset, int64(j)*1000, float64(j))
+			require.NoError(t, err)
+			ref = r
+		}
+		require.NoError(t, app.Commit())
+		refs = append(refs, ref)
+	}
+
+	deadline := time.After(30 * time.Second)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+		for range 200 {
+			wg.Add(2)
+			go func() { defer wg.Done(); head.mmapHeadChunks() }()
+			go func() {
+				defer wg.Done()
+				_ = head.gcSeries(refs, -1, func(*memSeries) bool { return false })
+			}()
+			wg.Wait()
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-deadline:
+		t.Fatal("deadlock detected (cross-stripe): " +
+			"regression for https://github.com/prometheus/prometheus/issues/19445")
+	}
+}
+
+// TestDeadlockStripeSeries_GC covers the gc() → stripeSeries.gc() path whose
+// check callback had the identical ABBA pattern.
+func TestDeadlockStripeSeries_GC(t *testing.T) {
+	opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
+	opts.StripeSize = 2
+
+	head, wal := newTestHeadWithOptions(t, compression.None, opts)
+	t.Cleanup(func() { _ = wal.Close() })
+	require.NoError(t, head.Init(0))
+
+	const numSeries = 40
+	const samplesPerSeries = DefaultSamplesPerChunk + 2
+
+	app := head.Appender(context.Background())
+	for i := range numSeries {
+		lset := labels.FromStrings("gc_test", string(rune('a'+i)))
+		for j := range samplesPerSeries {
+			_, err := app.Append(0, lset, int64(j)*1000, float64(j))
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, app.Commit())
+
+	deadline := time.After(30 * time.Second)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+		for range 200 {
+			wg.Add(2)
+			go func() { defer wg.Done(); head.mmapHeadChunks() }()
+			go func() { defer wg.Done(); head.gc() }()
+			wg.Wait()
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-deadline:
+		t.Fatal("deadlock detected (stripeSeries.gc path): " +
+			"regression for https://github.com/prometheus/prometheus/issues/19445")
+	}
+}


### PR DESCRIPTION
Fixes #19445

## What this does

`iterForDeletion()` holds `locks[hashShard].Lock()` (stripe write lock) and then calls the `check` callback. Both `(*stripeSeries).gc()` and `(*stripeSeries).gcSeries()` check callbacks were acquiring locks in the wrong order:

1. `series.Lock()` — inside the callback
2. `s.locks[stripe].Lock()` — only when `hashShard != stripe` (cross-stripe series)

Meanwhile `mmapHeadChunksInStripe()` — running on the background `(*DB).run()` goroutine — always acquires:

1. `stripe[i].RLock()`
2. `series.Lock()` (via `mmapSeriesChunks`)

When `CompactSelectedSeries` (or any external caller of `truncateSeries`/`gcSeries`) runs from a separate goroutine concurrently with the background mmap loop, these two orderings interleave into a classic **ABBA deadlock**:

```
Goroutine A (mmapHeadChunksInStripe):
  holds stripe[i].RLock()  →  waits for series.Lock()

Goroutine B (gcSeries.check):
  holds series.Lock()       →  waits for stripe[i].Lock() (write)
```

`sync.RWMutex` in Go blocks new readers once a writer is pending, so goroutine A cannot even release its `RLock` — the deadlock is permanent.

## Fix

Pre-acquire the ref-stripe write lock **before** `series.Lock()` in both `check` callbacks, establishing the consistent global order **stripe-lock → series-lock** already used by every other path in the package (`mmapHeadChunksInStripe`, `getOrCreate`, `deleteSeriesByID`).

## Testing

Three new concurrent regression tests added in `tsdb/head_deadlock_test.go` — each runs `mmapHeadChunks` and `gcSeries`/`gc` in parallel goroutines and must complete in <30 s (they hang permanently without the fix):

- `TestDeadlockGCSeriesAndMmapChunks` — `gcSeries` path, StripeSize=2
- `TestDeadlockGCAndMmapChunks_CrossStripe` — same, StripeSize=4
- `TestDeadlockStripeSeries_GC` — `gc()` path, StripeSize=2

Full existing test suite passes: `ok github.com/prometheus/prometheus/tsdb 98.560s`

```release-notes
[BUGFIX] tsdb: Fix permanent deadlock between mmapHeadChunks and gc/gcSeries when CompactSelectedSeries is called concurrently from an external goroutine (e.g. from Mimir's ingester).
```
