### PR TITLE
discovery/aws: don't panic on ECS clusters configured by name

### DIFF
--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -400,7 +400,7 @@ func (d *ECSDiscovery) describeClusters(ctx context.Context, clusters []string) 
 	return clusterMap, errg.Wait()
 }
 
-// listServiceARNs returns a map of cluster ARN to a slice of service ARNs.
+// listServiceARNs returns a map of the requested cluster identifier to a slice of service ARNs.
 // Uses concurrent requests limited by RequestConcurrency to respect AWS API throttling.
 // Services are listed in batches of 100 to respect AWS API limits (ListServices allows up to 100 services per call).
 func (d *ECSDiscovery) listServiceARNs(ctx context.Context, clusters []string) (map[string][]string, error) {
@@ -408,18 +408,18 @@ func (d *ECSDiscovery) listServiceARNs(ctx context.Context, clusters []string) (
 	services := make(map[string][]string)
 	errg, ectx := errgroup.WithContext(ctx)
 	errg.SetLimit(d.cfg.RequestConcurrency)
-	for _, clusterARN := range clusters {
+	for _, clusterIdentifier := range clusters {
 		errg.Go(func() error {
 			var nextToken *string
 			var serviceARNs []string
 			for {
 				resp, err := d.ecs.ListServices(ectx, &ecs.ListServicesInput{
-					Cluster:    aws.String(clusterARN),
+					Cluster:    aws.String(clusterIdentifier),
 					NextToken:  nextToken,
 					MaxResults: aws.Int32(100),
 				})
 				if err != nil {
-					return fmt.Errorf("could not list services for cluster %q: %w", clusterARN, err)
+					return fmt.Errorf("could not list services for cluster %q: %w", clusterIdentifier, err)
 				}
 
 				serviceARNs = append(serviceARNs, resp.ServiceArns...)
@@ -431,7 +431,7 @@ func (d *ECSDiscovery) listServiceARNs(ctx context.Context, clusters []string) (
 			}
 
 			mu.Lock()
-			services[clusterARN] = serviceARNs
+			services[clusterIdentifier] = serviceARNs
 			mu.Unlock()
 			return nil
 		})
@@ -474,16 +474,16 @@ func (d *ECSDiscovery) describeServices(ctx context.Context, clusterARN string, 
 	return services, errg.Wait()
 }
 
-// listTaskARNs returns a map of clustersARN to a slice of task ARNs.
+// listTaskARNs returns a map of the requested cluster identifier to a slice of task ARNs.
 // Uses concurrent requests limited by RequestConcurrency to respect AWS API throttling.
 // Tasks are listed in batches of 100 to respect AWS API limits (ListTasks allows up to 100 tasks per call).
 // This method also uses pagination to handle cases where there are more than 100 tasks in a cluster.
-func (d *ECSDiscovery) listTaskARNs(ctx context.Context, clusterARNs []string) (map[string][]string, error) {
+func (d *ECSDiscovery) listTaskARNs(ctx context.Context, clusters []string) (map[string][]string, error) {
 	mu := sync.Mutex{}
 	tasks := make(map[string][]string)
 	errg, ectx := errgroup.WithContext(ctx)
 	errg.SetLimit(d.cfg.RequestConcurrency)
-	for _, clusterARN := range clusterARNs {
+	for _, clusterIdentifier := range clusters {
 		errg.Go(func() error {
 			var (
 				nextToken *string
@@ -491,12 +491,12 @@ func (d *ECSDiscovery) listTaskARNs(ctx context.Context, clusterARNs []string) (
 			)
 			for {
 				resp, err := d.ecs.ListTasks(ectx, &ecs.ListTasksInput{
-					Cluster:    aws.String(clusterARN),
+					Cluster:    aws.String(clusterIdentifier),
 					NextToken:  nextToken,
 					MaxResults: aws.Int32(100),
 				})
 				if err != nil {
-					return fmt.Errorf("could not list tasks for cluster %q: %w", clusterARN, err)
+					return fmt.Errorf("could not list tasks for cluster %q: %w", clusterIdentifier, err)
 				}
 
 				taskARNs = append(taskARNs, resp.TaskArns...)
@@ -508,7 +508,7 @@ func (d *ECSDiscovery) listTaskARNs(ctx context.Context, clusterARNs []string) (
 			}
 
 			mu.Lock()
-			tasks[clusterARN] = taskARNs
+			tasks[clusterIdentifier] = taskARNs
 			mu.Unlock()
 			return nil
 		})
@@ -735,7 +735,9 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 		Source: d.region,
 	}
 
-	// Fetch cluster details, service ARNs, and task ARNs in parallel
+	// Fetch cluster details, service ARNs, and task ARNs in parallel.
+	// All three are keyed by the identifiers of the clusters slice, so they can
+	// be joined below whether those identifiers are cluster names or ARNs.
 	var (
 		clusterMap map[string]types.Cluster
 		serviceMap map[string][]string
@@ -770,17 +772,17 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 		clusterTargets []model.LabelSet
 	)
 
-	for clusterARN, taskARNs := range taskMap {
+	for clusterIdentifier, taskARNs := range taskMap {
 		if len(taskARNs) == 0 {
 			continue
 		}
 
-		cluster, ok := clusterMap[clusterARN]
+		cluster, ok := clusterMap[clusterIdentifier]
 		if !ok {
 			// The cluster has tasks but could not be described, for instance
 			// because it was deleted after its tasks were listed. Skip it
 			// rather than dereferencing the zero cluster below.
-			d.logger.Debug("Cluster not found in DescribeClusters response", "cluster", clusterARN)
+			d.logger.Debug("Cluster not found in DescribeClusters response", "cluster", clusterIdentifier)
 			continue
 		}
 
@@ -1087,7 +1089,7 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 			clusterMu.Lock()
 			clusterTargets = append(clusterTargets, taskTargets...)
 			clusterMu.Unlock()
-		}(cluster, serviceMap[clusterARN], taskARNs)
+		}(cluster, serviceMap[clusterIdentifier], taskARNs)
 	}
 
 	clusterWg.Wait()

--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -775,6 +775,15 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 			continue
 		}
 
+		cluster, ok := clusterMap[clusterARN]
+		if !ok {
+			// The cluster has tasks but could not be described, for instance
+			// because it was deleted after its tasks were listed. Skip it
+			// rather than dereferencing the zero cluster below.
+			d.logger.Debug("Cluster not found in DescribeClusters response", "cluster", clusterARN)
+			continue
+		}
+
 		clusterWg.Add(1)
 
 		go func(cluster types.Cluster, serviceARNs, taskARNs []string) {
@@ -1078,7 +1087,7 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 			clusterMu.Lock()
 			clusterTargets = append(clusterTargets, taskTargets...)
 			clusterMu.Unlock()
-		}(clusterMap[clusterARN], serviceMap[clusterARN], taskARNs)
+		}(cluster, serviceMap[clusterARN], taskARNs)
 	}
 
 	clusterWg.Wait()

--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -357,7 +357,7 @@ func (d *ECSDiscovery) listClusterARNs(ctx context.Context) ([]string, error) {
 	return clusterARNs, nil
 }
 
-// describeClusters returns a map of cluster ARN to a slice of clusters.
+// describeClusters returns a map of the requested cluster identifier to its cluster.
 // Uses concurrent requests limited by RequestConcurrency to respect AWS API throttling.
 // Clusters are described in batches of 100 to respect AWS API limits (DescribeClusters allows up to 100 clusters per call).
 func (d *ECSDiscovery) describeClusters(ctx context.Context, clusters []string) (map[string]types.Cluster, error) {
@@ -377,10 +377,20 @@ func (d *ECSDiscovery) describeClusters(ctx context.Context, clusters []string) 
 			}
 
 			for _, cluster := range resp.Clusters {
-				if cluster.ClusterArn != nil {
-					mu.Lock()
-					clusterMap[*cluster.ClusterArn] = cluster
-					mu.Unlock()
+				if cluster.ClusterArn == nil {
+					continue
+				}
+				// A cluster can be requested by its short name or by its ARN,
+				// but is always described with its ARN. Index it by the
+				// identifier it was requested with, as the rest of the
+				// discovery joins on the identifiers it was given.
+				for _, identifier := range batch {
+					if identifier == *cluster.ClusterArn || (cluster.ClusterName != nil && identifier == *cluster.ClusterName) {
+						mu.Lock()
+						clusterMap[identifier] = cluster
+						mu.Unlock()
+						break
+					}
 				}
 			}
 			return nil

--- a/discovery/aws/ecs_test.go
+++ b/discovery/aws/ecs_test.go
@@ -937,9 +937,12 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name     string
-		ecsData  *ecsDataStore
-		expected []*targetgroup.Group
+		name string
+		// configuredClusters is the value of the clusters option. An empty
+		// slice discovers every cluster in the region.
+		configuredClusters []string
+		ecsData            *ecsDataStore
+		expected           []*targetgroup.Group
 	}{
 		{
 			name: "SingleClusterWithTasks",
@@ -1164,6 +1167,70 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 							"__meta_ecs_network_mode":      model.LabelValue("awsvpc"),
 							"__meta_ecs_public_ip":         model.LabelValue("52.4.5.6"),
 							"__meta_ecs_tag_task_Role":     model.LabelValue("batch"),
+						},
+					},
+				},
+			},
+		},
+		{
+			// The ECS API accepts either the short name or the full ARN of a
+			// cluster, so both forms are valid values of the clusters option.
+			name:               "ClusterConfiguredByShortName",
+			configuredClusters: []string{"prod-cluster"},
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("prod-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				services: []ecsTypes.Service{},
+				tasks: []ecsTypes.Task{
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/prod-cluster/task-1"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/prod-task:1"),
+						Group:             strptr("batch-jobs"),
+						LaunchType:        ecsTypes.LaunchTypeFargate,
+						LastStatus:        strptr("RUNNING"),
+						DesiredStatus:     strptr("RUNNING"),
+						HealthStatus:      ecsTypes.HealthStatusHealthy,
+						AvailabilityZone:  strptr("us-west-2a"),
+						Attachments: []ecsTypes.Attachment{
+							{
+								Type: strptr("ElasticNetworkInterface"),
+								Details: []ecsTypes.KeyValuePair{
+									{Name: strptr("subnetId"), Value: strptr("subnet-prod-1")},
+									{Name: strptr("privateIPv4Address"), Value: strptr("10.0.1.100")},
+									{Name: strptr("networkInterfaceId"), Value: strptr("eni-prod-123")},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "us-west-2",
+					Targets: []model.LabelSet{
+						{
+							model.AddressLabel:             model.LabelValue("10.0.1.100:80"),
+							"__meta_ecs_cluster":           model.LabelValue("prod-cluster"),
+							"__meta_ecs_cluster_arn":       model.LabelValue("arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster"),
+							"__meta_ecs_task_group":        model.LabelValue("batch-jobs"),
+							"__meta_ecs_task_arn":          model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task/prod-cluster/task-1"),
+							"__meta_ecs_task_definition":   model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task-definition/prod-task:1"),
+							"__meta_ecs_region":            model.LabelValue("us-west-2"),
+							"__meta_ecs_availability_zone": model.LabelValue("us-west-2a"),
+							"__meta_ecs_subnet_id":         model.LabelValue("subnet-prod-1"),
+							"__meta_ecs_ip_address":        model.LabelValue("10.0.1.100"),
+							"__meta_ecs_launch_type":       model.LabelValue("FARGATE"),
+							"__meta_ecs_desired_status":    model.LabelValue("RUNNING"),
+							"__meta_ecs_last_status":       model.LabelValue("RUNNING"),
+							"__meta_ecs_health_status":     model.LabelValue("HEALTHY"),
+							"__meta_ecs_network_mode":      model.LabelValue("awsvpc"),
 						},
 					},
 				},
@@ -1571,6 +1638,7 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 				ec2: ec2Client,
 				cfg: &ECSSDConfig{
 					Region:             tt.ecsData.region,
+					Clusters:           tt.configuredClusters,
 					Port:               80,
 					RequestConcurrency: 1,
 				},
@@ -1618,9 +1686,21 @@ func (m *mockECSClient) ListClusters(_ context.Context, _ *ecs.ListClustersInput
 	}, nil
 }
 
+// resolveClusterARN mirrors the ECS API, which accepts either the short name or
+// the full ARN of a cluster everywhere a cluster is referenced.
+func (m *mockECSClient) resolveClusterARN(identifier string) string {
+	for _, cluster := range m.ecsData.clusters {
+		if cluster.ClusterName != nil && *cluster.ClusterName == identifier {
+			return *cluster.ClusterArn
+		}
+	}
+	return identifier
+}
+
 func (m *mockECSClient) DescribeClusters(_ context.Context, input *ecs.DescribeClustersInput, _ ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error) {
 	var clusters []ecsTypes.Cluster
-	for _, clusterArn := range input.Clusters {
+	for _, clusterIdentifier := range input.Clusters {
+		clusterArn := m.resolveClusterARN(clusterIdentifier)
 		for _, cluster := range m.ecsData.clusters {
 			if *cluster.ClusterArn == clusterArn {
 				clusters = append(clusters, cluster)
@@ -1636,8 +1716,9 @@ func (m *mockECSClient) DescribeClusters(_ context.Context, input *ecs.DescribeC
 
 func (m *mockECSClient) ListServices(_ context.Context, input *ecs.ListServicesInput, _ ...func(*ecs.Options)) (*ecs.ListServicesOutput, error) {
 	var serviceArns []string
+	clusterArn := m.resolveClusterARN(*input.Cluster)
 	for _, service := range m.ecsData.services {
-		if *service.ClusterArn == *input.Cluster {
+		if *service.ClusterArn == clusterArn {
 			serviceArns = append(serviceArns, *service.ServiceArn)
 		}
 	}
@@ -1649,9 +1730,10 @@ func (m *mockECSClient) ListServices(_ context.Context, input *ecs.ListServicesI
 
 func (m *mockECSClient) DescribeServices(_ context.Context, input *ecs.DescribeServicesInput, _ ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error) {
 	var services []ecsTypes.Service
+	clusterArn := m.resolveClusterARN(*input.Cluster)
 	for _, serviceArn := range input.Services {
 		for _, service := range m.ecsData.services {
-			if *service.ServiceArn == serviceArn && *service.ClusterArn == *input.Cluster {
+			if *service.ServiceArn == serviceArn && *service.ClusterArn == clusterArn {
 				services = append(services, service)
 				break
 			}
@@ -1665,8 +1747,9 @@ func (m *mockECSClient) DescribeServices(_ context.Context, input *ecs.DescribeS
 
 func (m *mockECSClient) ListTasks(_ context.Context, input *ecs.ListTasksInput, _ ...func(*ecs.Options)) (*ecs.ListTasksOutput, error) {
 	var taskArns []string
+	clusterArn := m.resolveClusterARN(*input.Cluster)
 	for _, task := range m.ecsData.tasks {
-		if *task.ClusterArn == *input.Cluster {
+		if *task.ClusterArn == clusterArn {
 			// If ServiceName is specified, filter by service
 			if input.ServiceName != nil {
 				expectedGroup := "service:" + *input.ServiceName
@@ -1686,9 +1769,10 @@ func (m *mockECSClient) ListTasks(_ context.Context, input *ecs.ListTasksInput, 
 
 func (m *mockECSClient) DescribeTasks(_ context.Context, input *ecs.DescribeTasksInput, _ ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
 	var tasks []ecsTypes.Task
+	clusterArn := m.resolveClusterARN(*input.Cluster)
 	for _, taskArn := range input.Tasks {
 		for _, task := range m.ecsData.tasks {
-			if *task.TaskArn == taskArn && *task.ClusterArn == *input.Cluster {
+			if *task.TaskArn == taskArn && *task.ClusterArn == clusterArn {
 				tasks = append(tasks, task)
 				break
 			}

--- a/discovery/aws/ecs_test.go
+++ b/discovery/aws/ecs_test.go
@@ -1237,6 +1237,95 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 			},
 		},
 		{
+			// A cluster deleted between ListTasks and DescribeClusters is
+			// reported as a failure by DescribeClusters, so it has tasks but no
+			// cluster to describe them with.
+			name: "ClusterMissingFromDescribeClusters",
+			configuredClusters: []string{
+				"arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster",
+				"arn:aws:ecs:us-west-2:123456789012:cluster/deleted-cluster",
+			},
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("prod-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				services: []ecsTypes.Service{},
+				tasks: []ecsTypes.Task{
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/prod-cluster/task-1"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/prod-task:1"),
+						Group:             strptr("batch-jobs"),
+						LaunchType:        ecsTypes.LaunchTypeFargate,
+						LastStatus:        strptr("RUNNING"),
+						DesiredStatus:     strptr("RUNNING"),
+						HealthStatus:      ecsTypes.HealthStatusHealthy,
+						AvailabilityZone:  strptr("us-west-2a"),
+						Attachments: []ecsTypes.Attachment{
+							{
+								Type: strptr("ElasticNetworkInterface"),
+								Details: []ecsTypes.KeyValuePair{
+									{Name: strptr("subnetId"), Value: strptr("subnet-prod-1")},
+									{Name: strptr("privateIPv4Address"), Value: strptr("10.0.1.100")},
+									{Name: strptr("networkInterfaceId"), Value: strptr("eni-prod-123")},
+								},
+							},
+						},
+					},
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/deleted-cluster/task-1"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/deleted-cluster"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/deleted-task:1"),
+						Group:             strptr("batch-jobs"),
+						LaunchType:        ecsTypes.LaunchTypeFargate,
+						LastStatus:        strptr("RUNNING"),
+						DesiredStatus:     strptr("RUNNING"),
+						HealthStatus:      ecsTypes.HealthStatusHealthy,
+						AvailabilityZone:  strptr("us-west-2a"),
+						Attachments: []ecsTypes.Attachment{
+							{
+								Type: strptr("ElasticNetworkInterface"),
+								Details: []ecsTypes.KeyValuePair{
+									{Name: strptr("subnetId"), Value: strptr("subnet-deleted-1")},
+									{Name: strptr("privateIPv4Address"), Value: strptr("10.0.2.100")},
+									{Name: strptr("networkInterfaceId"), Value: strptr("eni-deleted-123")},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "us-west-2",
+					Targets: []model.LabelSet{
+						{
+							model.AddressLabel:             model.LabelValue("10.0.1.100:80"),
+							"__meta_ecs_cluster":           model.LabelValue("prod-cluster"),
+							"__meta_ecs_cluster_arn":       model.LabelValue("arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster"),
+							"__meta_ecs_task_group":        model.LabelValue("batch-jobs"),
+							"__meta_ecs_task_arn":          model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task/prod-cluster/task-1"),
+							"__meta_ecs_task_definition":   model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task-definition/prod-task:1"),
+							"__meta_ecs_region":            model.LabelValue("us-west-2"),
+							"__meta_ecs_availability_zone": model.LabelValue("us-west-2a"),
+							"__meta_ecs_subnet_id":         model.LabelValue("subnet-prod-1"),
+							"__meta_ecs_ip_address":        model.LabelValue("10.0.1.100"),
+							"__meta_ecs_launch_type":       model.LabelValue("FARGATE"),
+							"__meta_ecs_desired_status":    model.LabelValue("RUNNING"),
+							"__meta_ecs_last_status":       model.LabelValue("RUNNING"),
+							"__meta_ecs_health_status":     model.LabelValue("HEALTHY"),
+							"__meta_ecs_network_mode":      model.LabelValue("awsvpc"),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "TaskWithBridgeNetworking",
 			ecsData: &ecsDataStore{
 				region: "us-west-2",

--- a/discovery/aws/ecs_test.go
+++ b/discovery/aws/ecs_test.go
@@ -1237,6 +1237,115 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 			},
 		},
 		{
+			// The two forms can be mixed within one clusters option.
+			name: "ClustersConfiguredByShortNameAndARN",
+			configuredClusters: []string{
+				"prod-cluster",
+				"arn:aws:ecs:us-west-2:123456789012:cluster/staging-cluster",
+			},
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("prod-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+					{
+						ClusterName: strptr("staging-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/staging-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				services: []ecsTypes.Service{},
+				tasks: []ecsTypes.Task{
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/prod-cluster/task-1"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/prod-task:1"),
+						Group:             strptr("batch-jobs"),
+						LaunchType:        ecsTypes.LaunchTypeFargate,
+						LastStatus:        strptr("RUNNING"),
+						DesiredStatus:     strptr("RUNNING"),
+						HealthStatus:      ecsTypes.HealthStatusHealthy,
+						AvailabilityZone:  strptr("us-west-2a"),
+						Attachments: []ecsTypes.Attachment{
+							{
+								Type: strptr("ElasticNetworkInterface"),
+								Details: []ecsTypes.KeyValuePair{
+									{Name: strptr("subnetId"), Value: strptr("subnet-prod-1")},
+									{Name: strptr("privateIPv4Address"), Value: strptr("10.0.1.100")},
+									{Name: strptr("networkInterfaceId"), Value: strptr("eni-prod-123")},
+								},
+							},
+						},
+					},
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/staging-cluster/task-1"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/staging-cluster"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/staging-task:1"),
+						Group:             strptr("batch-jobs"),
+						LaunchType:        ecsTypes.LaunchTypeFargate,
+						LastStatus:        strptr("RUNNING"),
+						DesiredStatus:     strptr("RUNNING"),
+						HealthStatus:      ecsTypes.HealthStatusHealthy,
+						AvailabilityZone:  strptr("us-west-2b"),
+						Attachments: []ecsTypes.Attachment{
+							{
+								Type: strptr("ElasticNetworkInterface"),
+								Details: []ecsTypes.KeyValuePair{
+									{Name: strptr("subnetId"), Value: strptr("subnet-staging-1")},
+									{Name: strptr("privateIPv4Address"), Value: strptr("10.0.3.100")},
+									{Name: strptr("networkInterfaceId"), Value: strptr("eni-staging-123")},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "us-west-2",
+					Targets: []model.LabelSet{
+						{
+							model.AddressLabel:             model.LabelValue("10.0.1.100:80"),
+							"__meta_ecs_cluster":           model.LabelValue("prod-cluster"),
+							"__meta_ecs_cluster_arn":       model.LabelValue("arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster"),
+							"__meta_ecs_task_group":        model.LabelValue("batch-jobs"),
+							"__meta_ecs_task_arn":          model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task/prod-cluster/task-1"),
+							"__meta_ecs_task_definition":   model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task-definition/prod-task:1"),
+							"__meta_ecs_region":            model.LabelValue("us-west-2"),
+							"__meta_ecs_availability_zone": model.LabelValue("us-west-2a"),
+							"__meta_ecs_subnet_id":         model.LabelValue("subnet-prod-1"),
+							"__meta_ecs_ip_address":        model.LabelValue("10.0.1.100"),
+							"__meta_ecs_launch_type":       model.LabelValue("FARGATE"),
+							"__meta_ecs_desired_status":    model.LabelValue("RUNNING"),
+							"__meta_ecs_last_status":       model.LabelValue("RUNNING"),
+							"__meta_ecs_health_status":     model.LabelValue("HEALTHY"),
+							"__meta_ecs_network_mode":      model.LabelValue("awsvpc"),
+						},
+						{
+							model.AddressLabel:             model.LabelValue("10.0.3.100:80"),
+							"__meta_ecs_cluster":           model.LabelValue("staging-cluster"),
+							"__meta_ecs_cluster_arn":       model.LabelValue("arn:aws:ecs:us-west-2:123456789012:cluster/staging-cluster"),
+							"__meta_ecs_task_group":        model.LabelValue("batch-jobs"),
+							"__meta_ecs_task_arn":          model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task/staging-cluster/task-1"),
+							"__meta_ecs_task_definition":   model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task-definition/staging-task:1"),
+							"__meta_ecs_region":            model.LabelValue("us-west-2"),
+							"__meta_ecs_availability_zone": model.LabelValue("us-west-2b"),
+							"__meta_ecs_subnet_id":         model.LabelValue("subnet-staging-1"),
+							"__meta_ecs_ip_address":        model.LabelValue("10.0.3.100"),
+							"__meta_ecs_launch_type":       model.LabelValue("FARGATE"),
+							"__meta_ecs_desired_status":    model.LabelValue("RUNNING"),
+							"__meta_ecs_last_status":       model.LabelValue("RUNNING"),
+							"__meta_ecs_health_status":     model.LabelValue("HEALTHY"),
+							"__meta_ecs_network_mode":      model.LabelValue("awsvpc"),
+						},
+					},
+				},
+			},
+		},
+		{
 			// A cluster deleted between ListTasks and DescribeClusters is
 			// reported as a failure by DescribeClusters, so it has tasks but no
 			// cluster to describe them with.
@@ -1740,13 +1849,12 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 
 			groups, err := d.refresh(ctx)
 			require.NoError(t, err)
-			if tt.name == "MixedNetworkingModes" {
-				// Use ElementsMatch for tests with multiple tasks as goroutines can affect order
-				require.Len(t, groups, len(tt.expected))
-				require.Equal(t, tt.expected[0].Source, groups[0].Source)
-				require.ElementsMatch(t, tt.expected[0].Targets, groups[0].Targets)
-			} else {
-				require.Equal(t, tt.expected, groups)
+			// Use ElementsMatch for the targets as a goroutine per cluster and
+			// per task can affect their order.
+			require.Len(t, groups, len(tt.expected))
+			for i, expected := range tt.expected {
+				require.Equal(t, expected.Source, groups[i].Source)
+				require.ElementsMatch(t, expected.Targets, groups[i].Targets)
 			}
 		})
 	}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1346,7 +1346,8 @@ filters:
       values: <string>, [...] ]
 
 # List of ECS, ElastiCache, MSK, or RDS cluster identifiers (ecs, elasticache, msk, and rds roles only) to discover.
-# A List of ARNs of clusters to discover. If empty, all clusters in the region are discovered.
+# A List of ARNs of clusters to discover. The ecs role also accepts cluster names.
+# If empty, all clusters in the region are discovered.
 # This can significantly improve performance when you only need to monitor specific clusters/caches.
 [ clusters: [<string>, ...] ]
 


### PR DESCRIPTION
The `clusters` option is documented as a list of cluster identifiers, and the ECS API accepts either the short name or the full ARN of a cluster wherever a cluster is referenced. Configuring an ECS cluster by name takes down the whole Prometheus process:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0]

goroutine 38 [running]:
aws.(*ECSDiscovery).refresh.func4.1()
	discovery/aws/ecs.go:782
golang.org/x/sync/errgroup.(*Group).Go.func1()
	errgroup.go:93
```

`listTaskARNs` and `listServiceARNs` key their results by the configured identifier, while `describeClusters` keyed its result by ARN. The lookup in `refresh` therefore missed, and the resulting zero `types.Cluster` was dereferenced. The dereference happens inside a goroutine, so it cannot be recovered from.

Each described cluster is now indexed by the identifier it was requested with, which works for both forms.

The same dereference is also reachable with an ARN: `DescribeClusters` reports a cluster that no longer exists as a failure rather than describing it, so a cluster deleted between listing its tasks and describing it has tasks but no cluster. Such a cluster is now skipped, leaving the rest of the clusters discovered.

Both bugs are exposed by a failing test first, then fixed, so the commits are best reviewed one by one.

```release-notes
[BUGFIX] discovery/aws: Do not panic when an ECS cluster is configured by name rather than by ARN, or when a configured cluster is missing from the DescribeClusters response.
```
