### PR TITLE
promql: fix typo in preprocessExprHelper comment

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -4579,7 +4579,7 @@ func PreprocessExpr(expr parser.Expr, start, end time.Time, step time.Duration) 
 // Also resolves start() and end() on selector and subquery nodes.
 // Also remove superfluous parenthesis on parameters to functions and aggregations.
 // Return isStepInvariant is true when the whole subexpression is step invariant.
-// Return shoudlWrap is false for cases like MatrixSelector and StringLiteral that never need to be wrapped.
+// Return shouldWrap is false for cases like MatrixSelector and StringLiteral that never need to be wrapped.
 func preprocessExprHelper(expr parser.Expr, start, end time.Time) (isStepInvariant, shouldWrap bool) {
 	switch n := expr.(type) {
 	case *parser.VectorSelector:


### PR DESCRIPTION
The doc comment for `preprocessExprHelper` refers to `shoudlWrap`; the return value is actually named `shouldWrap`. Comment-only change, signed off per DCO.

```release-notes
NONE
```