### PR TITLE
PromQL: Do not register start timestamp reset if ST hasn't changed

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -758,8 +758,8 @@ func histogramRate(
 
 // isStartTimestampReset tells whether there was a counter reset by checking the start timestamp value.
 func isStartTimestampReset(prevStartTimestamp, prevTimestamp, currStartTimestamp, currTimestamp int64) bool {
-	if currStartTimestamp == 0 || currStartTimestamp >= currTimestamp {
-		// No reset if start timestamp is not set (value is 0), if it is clearly invalid
+	if prevStartTimestamp == currStartTimestamp || currStartTimestamp == 0 || currStartTimestamp >= currTimestamp {
+		// No reset if start timestamp hasn't changed, if it is not set (value is 0), if it is clearly invalid
 		// (ST > T), or if it is OTel's unknown start time (ST == T).
 		return false
 	}

--- a/promql/promqltest/testdata/start_timestamps.test
+++ b/promql/promqltest/testdata/start_timestamps.test
@@ -146,17 +146,17 @@ eval instant at 6m increase(series[5m])
     {type="st_outside_range"}                         5
     {type="st_inside_range"}                          5
     {type="st_at_t"}                                  5
-    {type="st_after_t"}                               6
+    {type="st_after_t"}                               5
     {type="no_st_extrapolate_both"}                   5
     {type="st_outside_extrapolate_both"}              5
     {type="st_inside_extrapolate_right"}              5.142857142857143
     {type="st_at_t_extrapolate_right"}                5
-    {type="st_after_t_extrapolate_both"}              6.333333333333333
+    {type="st_after_t_extrapolate_both"}              5
     {type="no_st_extrapolate_both_limit_range"}       2
     {type="st_outside_extrapolate_both_limit_range"}  2
     {type="st_inside_extrapolate_right_limit_range"}  3.6
     {type="st_at_t_extrapolate_right_limit_range"}    2
-    {type="st_after_t_extrapolate_both_limit_range"}  6
+    {type="st_after_t_extrapolate_both_limit_range"}  2
     {type="st_inside_single_datapoint"}               3
 
 clear


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Making a small adjustment to start timestamp reset detection, which would not register a reset if ST value hasn't changed since the previous sample. This aligns with OTel description of matching STs, prevents likely false positive counter resets for cumulative counters if ST values erroneously get shifted into the future (see the adjusted tests in this PR), and might also be a small efficiency gain for cumulative counters (since more often than not, two subsequent cumulative samples should have matching STs).

According to OTel:

> In an unbroken sequence of observations, the StartTimeUnixNano always matches either the TimeUnixNano or the StartTimeUnixNano of other points in the same sequence.
> https://opentelemetry.io/docs/specs/otel/metrics/data-model/#resets-and-gaps

Thus matching STs hint about samples belonging to the same unbroken cumulative sequence. And if the sequence is unbroken, it makes little sense to detect a counter reset inside it.

It's important to note that the statement above from OTel doesn't guarantee that if two samples have matching STs, they must belong to the same unbroken sequence. In theory, multiple sequences could end up with matching STs, but I can't think of any cases where this wouldn't be a mistake (e.g. two cumulative sequences collapsed into one due to matching labels, and they happen to have started at the same time). 

There is currently one case where subsequent samples have matching STs and we detect a reset in-between them. This case is when the earlier sample of the two has ST > T (see the tests adjusted in this PR). Such situation is invalid, and detecting a reset in such case isn't more correct than not detecting it. Even contrary, it might be better to be conservative and not detect a reset in such ambiguous cases. This should give more confidence for users that once ST handling in PromQL enabled, bad ST values would be less likely to negatively affect existing queries (i.e. when in doubt, we do not change anything and keep the results that the user is already used to).  

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[CHANGE] PromQL: Do not register a start timestamp reset if the start timestamp hasn't changed between subsequent samples.
```
