### PR TITLE
docs: fix broken range vector selector link in query examples

### DIFF
--- a/docs/querying/examples.md
+++ b/docs/querying/examples.md
@@ -16,7 +16,7 @@ Return all time series with the metric `http_requests_total` and the given
     http_requests_total{job="apiserver", handler="/api/comments"}
 
 Return a whole range of time (in this case 5 minutes up to the query time)
-for the same vector, making it a [range vector](../basics/#range-vector-selectors):
+for the same vector, making it a [range vector](./basics.md#range-vector-selectors):
 
     http_requests_total{job="apiserver", handler="/api/comments"}[5m]
 


### PR DESCRIPTION
Fix the relative link in `docs/querying/examples.md` so it points to `querying/basics.md` instead of the non-existent `../basics/` path.

```release-notes
NONE
```