### PR TITLE
storage/remote: migrate Remote Write 2.x receiver to AppenderV2

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -41,10 +41,9 @@ import (
 
 type writeHandler struct {
 	logger *slog.Logger
-	// appendable is used by the Remote Write 2.x path (writeV2). The Remote
-	// Write 1.0 path (write) uses appendableV2 as part of the migration to
-	// AppenderV2 (https://github.com/prometheus/prometheus/issues/17632).
-	appendable   storage.Appendable
+	// appendableV2 is used by both the Remote Write 1.0 and 2.x paths, which
+	// have been migrated to AppenderV2
+	// (https://github.com/prometheus/prometheus/issues/17632).
 	appendableV2 storage.AppendableV2
 
 	samplesWithInvalidLabelsTotal  prometheus.Counter
@@ -58,16 +57,14 @@ type writeHandler struct {
 const maxAheadTime = 10 * time.Minute
 
 // NewWriteHandler creates a http.Handler that accepts remote write requests with
-// the given message in acceptedMsgs and writes them to the provided appendables.
-// The Remote Write 1.0 path uses appendableV2 (storage.AppenderV2); the Remote
-// Write 2.x path still uses appendable (storage.Appender) until it is migrated.
+// the given message in acceptedMsgs and writes them to the provided appendable.
+// Both the Remote Write 1.0 and 2.x paths use appendableV2 (storage.AppenderV2).
 //
 // NOTE(bwplotka): When accepting v2 proto and spec, partial writes are possible
 // as per https://prometheus.io/docs/specs/remote_write_spec_2_0/#partial-write.
-func NewWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appendable storage.Appendable, appendableV2 storage.AppendableV2, acceptedMsgs remoteapi.MessageTypes, ingestSTZeroSample, enableTypeAndUnitLabels, appendMetadata bool) http.Handler {
+func NewWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appendableV2 storage.AppendableV2, acceptedMsgs remoteapi.MessageTypes, ingestSTZeroSample, enableTypeAndUnitLabels, appendMetadata bool) http.Handler {
 	h := &writeHandler{
 		logger:       logger,
-		appendable:   appendable,
 		appendableV2: appendableV2,
 		samplesWithInvalidLabelsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace: "prometheus",
@@ -285,9 +282,9 @@ func (h *writeHandler) appendV1Histograms(app storage.AppenderV2, hh []prompb.Hi
 // NOTE(bwplotka): TSDB storage is NOT idempotent, so we don't allow "partial retry-able" errors.
 // Once we have 5xx type of error, we immediately stop and rollback all appends.
 func (h *writeHandler) writeV2(ctx context.Context, req *writev2.Request) (_ remoteapi.WriteResponseStats, errHTTPCode int, _ error) {
-	app := &remoteWriteAppender{
-		Appender: h.appendable.Appender(ctx),
-		maxTime:  timestamp.FromTime(time.Now().Add(maxAheadTime)),
+	app := &remoteWriteAppenderV2{
+		AppenderV2: h.appendableV2.AppenderV2(ctx),
+		maxTime:    timestamp.FromTime(time.Now().Add(maxAheadTime)),
 	}
 
 	s := remoteapi.WriteResponseStats{}
@@ -321,12 +318,13 @@ func (h *writeHandler) writeV2(ctx context.Context, req *writev2.Request) (_ rem
 	return s, 0, nil
 }
 
-func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *remoteapi.WriteResponseStats) (samplesWithoutMetadata, errHTTPCode int, err error) {
+func (h *writeHandler) appendV2(app *remoteWriteAppenderV2, req *writev2.Request, rs *remoteapi.WriteResponseStats) (samplesWithoutMetadata, errHTTPCode int, err error) {
 	var (
 		badRequestErrs                                   []error
 		outOfOrderExemplarErrs, samplesWithInvalidLabels int
 
-		b = labels.NewScratchBuilder(0)
+		b         = labels.NewScratchBuilder(0)
+		exemplars = make([]exemplar.Exemplar, 0, 1)
 	)
 	for _, ts := range req.Timeseries {
 		ls, err := ts.ToLabels(&b, req.Symbols)
@@ -374,21 +372,23 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 			continue
 		}
 
-		allSamplesSoFar := rs.AllSamples()
 		var ref storage.SeriesRef
+		// Attach metadata to the first sample/histogram append of the series only; if that
+		// append is rejected, metadata is dropped with it, same as the exemplars below.
+		// Only attach metadata if the metadata-wal-records feature is enabled; without it,
+		// metadata is not persisted to WAL.
+		opts := storage.AOptions{}
+		if h.appendMetadata {
+			opts.Metadata = m
+		}
 		for _, s := range ts.Samples {
+			var st int64
 			if h.ingestSTZeroSample && s.StartTimestamp != 0 && s.Timestamp != 0 {
-				ref, err = app.AppendSTZeroSample(ref, ls, s.Timestamp, s.StartTimestamp)
-				// We treat OOO errors specially as it's a common scenario given:
-				// * We can't tell if ST was already ingested in a previous request.
-				// * We don't check if ST changed for stream of samples (we typically have one though),
-				// as it's checked in the AppendSTZeroSample reliably.
-				if err != nil && !errors.Is(err, storage.ErrOutOfOrderST) {
-					h.logger.Debug("Error when appending ST from remote write request", "err", err, "series", ls.String(), "start_timestamp", s.StartTimestamp, "timestamp", s.Timestamp)
-				}
+				st = s.StartTimestamp
 			}
 
-			ref, err = app.Append(ref, ls, s.GetTimestamp(), s.GetValue())
+			ref, err = app.Append(ref, ls, st, s.GetTimestamp(), s.GetValue(), nil, nil, opts)
+			opts = storage.AOptions{}
 			if err == nil {
 				rs.Samples++
 				continue
@@ -408,27 +408,22 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 
 		// Native Histograms.
 		for _, hp := range ts.Histograms {
+			var st int64
 			if h.ingestSTZeroSample && hp.StartTimestamp != 0 && hp.Timestamp != 0 {
-				ref, err = h.handleHistogramZeroSample(app, ref, ls, hp, hp.StartTimestamp)
-				// We treat OOO errors specially as it's a common scenario given:
-				// * We can't tell if ST was already ingested in a previous request.
-				// * We don't check if ST changed for stream of samples (we typically have one though),
-				// as it's checked in the ingestSTZeroSample reliably.
-				if err != nil && !errors.Is(err, storage.ErrOutOfOrderST) {
-					h.logger.Debug("Error when appending ST from remote write request", "err", err, "series", ls.String(), "start_timestamp", hp.StartTimestamp, "timestamp", hp.Timestamp)
-				}
+				st = hp.StartTimestamp
 			}
 			if hp.IsFloatHistogram() {
-				ref, err = app.AppendHistogram(ref, ls, hp.Timestamp, nil, hp.ToFloatHistogram())
+				ref, err = app.Append(ref, ls, st, hp.Timestamp, 0, nil, hp.ToFloatHistogram(), opts)
 			} else {
-				ref, err = app.AppendHistogram(ref, ls, hp.Timestamp, hp.ToIntHistogram(), nil)
+				ref, err = app.Append(ref, ls, st, hp.Timestamp, 0, hp.ToIntHistogram(), nil, opts)
 			}
+			opts = storage.AOptions{}
 			if err == nil {
 				rs.Histograms++
 				continue
 			}
 			// Handle append error.
-			// Although AppendHistogram does not currently return ErrDuplicateSampleForTimestamp there is
+			// Although Append does not currently return ErrDuplicateSampleForTimestamp for histograms there is
 			// a note indicating its inclusion in the future.
 			if errors.Is(err, storage.ErrOutOfOrderSample) ||
 				errors.Is(err, storage.ErrOutOfBounds) ||
@@ -448,38 +443,41 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 		}
 
 		// Exemplars.
-		for _, ep := range ts.Exemplars {
-			e, err := ep.ToExemplar(&b, req.Symbols)
-			if err != nil {
-				badRequestErrs = append(badRequestErrs, fmt.Errorf("parsing exemplar for series %v: %w", ls.String(), err))
-				continue
+		if len(ts.Exemplars) > 0 {
+			exemplars = exemplars[:0]
+			for _, ep := range ts.Exemplars {
+				e, err := ep.ToExemplar(&b, req.Symbols)
+				if err != nil {
+					badRequestErrs = append(badRequestErrs, fmt.Errorf("parsing exemplar for series %v: %w", ls.String(), err))
+					continue
+				}
+				exemplars = append(exemplars, e)
 			}
-			ref, err = app.AppendExemplar(ref, ls, e)
-			if err == nil {
-				rs.Exemplars++
-				continue
-			}
-			// Handle append error.
-			if errors.Is(err, storage.ErrOutOfOrderExemplar) {
-				outOfOrderExemplarErrs++ // Maintain old metrics, but technically not needed, given we fail here.
-				h.logger.Error("Out of order exemplar", "err", err.Error(), "series", ls.String(), "exemplar", fmt.Sprintf("%+v", e))
-				badRequestErrs = append(badRequestErrs, fmt.Errorf("%w for series %v", err, ls.String()))
-				continue
-			}
-			// TODO(bwplotka): Add strict mode which would trigger rollback of everything if needed.
-			// For now we keep the previously released flow (just error not debug level) of dropping them without rollback and 5xx.
-			h.logger.Error("failed to ingest exemplar, emitting error log, but no error for PRW caller", "err", err.Error(), "series", ls.String(), "exemplar", fmt.Sprintf("%+v", e))
-		}
+			// AppendExemplars requires exemplars sorted by timestamp.
+			slices.SortFunc(exemplars, exemplar.Compare)
 
-		// Only update metadata in WAL if the metadata-wal-records feature is enabled.
-		// Without this feature, metadata is not persisted to WAL.
-		if h.appendMetadata {
-			if _, err = app.UpdateMetadata(ref, ls, m); err != nil {
-				h.logger.Debug("error while updating metadata from remote write", "err", err)
-				// Metadata is attached to each series, so since Prometheus does not reject sample without metadata information,
-				// we don't report remote write error either. We increment metric instead.
-				samplesWithoutMetadata += rs.AllSamples() - allSamplesSoFar
+			appended := len(exemplars)
+			if _, err := app.AppendExemplars(ref, ls, exemplars); err != nil {
+				var pErr *storage.AppendPartialError
+				if errors.As(err, &pErr) {
+					appended -= len(pErr.ExemplarErrors)
+					for _, eErr := range pErr.ExemplarErrors {
+						if errors.Is(eErr, storage.ErrOutOfOrderExemplar) {
+							outOfOrderExemplarErrs++ // Maintain old metrics, but technically not needed, given we fail here.
+							h.logger.Error("Out of order exemplar", "err", eErr.Error(), "series", ls.String())
+							badRequestErrs = append(badRequestErrs, fmt.Errorf("%w for series %v", eErr, ls.String()))
+							continue
+						}
+						// TODO(bwplotka): Add strict mode which would trigger rollback of everything if needed.
+						// For now we keep the previously released flow (just error not debug level) of dropping them without rollback and 5xx.
+						h.logger.Error("failed to ingest exemplar, emitting error log, but no error for PRW caller", "err", eErr.Error(), "series", ls.String())
+					}
+				} else {
+					appended = 0
+					h.logger.Error("failed to ingest exemplars, emitting error log, but no error for PRW caller", "err", err.Error(), "series", ls.String())
+				}
 			}
+			rs.Exemplars += appended
 		}
 	}
 
@@ -495,73 +493,8 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 	return samplesWithoutMetadata, http.StatusBadRequest, errors.Join(badRequestErrs...)
 }
 
-// handleHistogramZeroSample appends ST as a zero-value sample with st value as the sample timestamp.
-// It doesn't return errors in case of out of order ST.
-func (*writeHandler) handleHistogramZeroSample(app storage.Appender, ref storage.SeriesRef, l labels.Labels, hist writev2.Histogram, st int64) (storage.SeriesRef, error) {
-	var err error
-	if hist.IsFloatHistogram() {
-		ref, err = app.AppendHistogramSTZeroSample(ref, l, hist.Timestamp, st, nil, hist.ToFloatHistogram())
-	} else {
-		ref, err = app.AppendHistogramSTZeroSample(ref, l, hist.Timestamp, st, hist.ToIntHistogram(), nil)
-	}
-	return ref, err
-}
-
 // TODO(bwplotka): Consider exposing timeLimitAppender and bucketLimitAppender appenders from scrape/target.go
 // to DRY, they do the same.
-type remoteWriteAppender struct {
-	storage.Appender
-
-	maxTime int64
-}
-
-func (app *remoteWriteAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
-	if t > app.maxTime {
-		return 0, fmt.Errorf("%w: timestamp is too far in the future", storage.ErrOutOfBounds)
-	}
-
-	ref, err := app.Appender.Append(ref, lset, t, v)
-	if err != nil {
-		return 0, err
-	}
-	return ref, nil
-}
-
-func (app *remoteWriteAppender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
-	var err error
-	if t > app.maxTime {
-		return 0, fmt.Errorf("%w: timestamp is too far in the future", storage.ErrOutOfBounds)
-	}
-
-	if h != nil && histogram.IsExponentialSchemaReserved(h.Schema) && h.Schema > histogram.ExponentialSchemaMax {
-		if err = h.ReduceResolution(histogram.ExponentialSchemaMax); err != nil {
-			return 0, err
-		}
-	}
-	if fh != nil && histogram.IsExponentialSchemaReserved(fh.Schema) && fh.Schema > histogram.ExponentialSchemaMax {
-		if err = fh.ReduceResolution(histogram.ExponentialSchemaMax); err != nil {
-			return 0, err
-		}
-	}
-
-	if ref, err = app.Appender.AppendHistogram(ref, l, t, h, fh); err != nil {
-		return 0, err
-	}
-	return ref, nil
-}
-
-func (app *remoteWriteAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
-	if e.Ts > app.maxTime {
-		return 0, fmt.Errorf("%w: timestamp is too far in the future", storage.ErrOutOfBounds)
-	}
-
-	ref, err := app.Appender.AppendExemplar(ref, l, e)
-	if err != nil {
-		return 0, err
-	}
-	return ref, nil
-}
-
 type remoteWriteAppenderV2 struct {
 	storage.AppenderV2
 

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -130,7 +130,7 @@ func TestRemoteWriteHandlerHeadersHandling_V1Message(t *testing.T) {
 			}
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -237,7 +237,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 			}
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -272,7 +272,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 		}
 
 		appendable := &mockAppendable{}
-		handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
+		handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
 
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, req)
@@ -301,7 +301,7 @@ func TestRemoteWriteHandler_V1Message(t *testing.T) {
 	// in Prometheus, so keeping like this to not break existing 1.0 clients.
 
 	appendable := &mockAppendable{}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -661,6 +661,37 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 			expectedLabels:          labels.FromStrings("__name__", "test_metric_wal", "instance", "localhost"),
 		},
 		{
+			desc: "Metadata-wal-records enabled - metadata stored via AppendV2Options",
+			input: func() []writev2.TimeSeries {
+				symbolTable := writev2.NewSymbolTable()
+				labelRefs := symbolTable.SymbolizeLabels(labels.FromStrings("__name__", "test_metric_wal", "instance", "localhost"), nil)
+				helpRef := symbolTable.Symbolize("Test metric for WAL verification")
+				unitRef := symbolTable.Symbolize("seconds")
+				return []writev2.TimeSeries{
+					{
+						LabelsRefs: labelRefs,
+						Metadata: writev2.Metadata{
+							Type:    writev2.Metadata_METRIC_TYPE_GAUGE,
+							HelpRef: helpRef,
+							UnitRef: unitRef,
+						},
+						Samples: []writev2.Sample{{Value: 42.0, Timestamp: 2000}},
+					},
+				}
+			}(),
+			symbols: func() []string {
+				symbolTable := writev2.NewSymbolTable()
+				symbolTable.SymbolizeLabels(labels.FromStrings("__name__", "test_metric_wal", "instance", "localhost"), nil)
+				symbolTable.Symbolize("Test metric for WAL verification")
+				symbolTable.Symbolize("seconds")
+				return symbolTable.Symbols()
+			}(),
+			expectedCode:            http.StatusNoContent,
+			enableTypeAndUnitLabels: false,
+			appendMetadata:          true,
+			expectedLabels:          labels.FromStrings("__name__", "test_metric_wal", "instance", "localhost"),
+		},
+		{
 			desc: "Type and unit labels enabled but no metadata",
 			input: func() []writev2.TimeSeries {
 				symbolTable := writev2.NewSymbolTable()
@@ -736,7 +767,7 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 				appendExemplarErr:     tc.appendExemplarErr,
 				updateMetadataErr:     tc.updateMetadataErr,
 			}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, tc.ingestSTZeroSample, tc.enableTypeAndUnitLabels, tc.appendMetadata)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, tc.ingestSTZeroSample, tc.enableTypeAndUnitLabels, tc.appendMetadata)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -911,7 +942,7 @@ func TestRemoteWriteHandler_V2Message_NoDuplicateTypeAndUnitLabels(t *testing.T)
 			req.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, true, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, true, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -960,7 +991,7 @@ func TestOutOfOrderSample_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -1002,7 +1033,7 @@ func TestOutOfOrderExemplar_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -1040,7 +1071,7 @@ func TestOutOfOrderHistogram_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -1090,7 +1121,7 @@ func BenchmarkRemoteWriteHandler(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{tc.protoFormat}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{tc.protoFormat}, false, false, false)
 			b.ResetTimer()
 			for b.Loop() {
 				b.StopTimer()
@@ -1115,7 +1146,7 @@ func TestCommitErr_V1Message(t *testing.T) {
 	require.NoError(t, err)
 
 	appendable := &mockAppendable{commitErr: errors.New("commit error")}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -1181,7 +1212,7 @@ func TestHistogramValidationErrorHandling(t *testing.T) {
 				require.NoError(t, err)
 				t.Cleanup(func() { require.NoError(t, db.Close()) })
 
-				handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), db.Head(), []remoteapi.WriteMessageType{protoMsg}, false, false, false)
+				handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []remoteapi.WriteMessageType{protoMsg}, false, false, false)
 				recorder := httptest.NewRecorder()
 
 				var buf []byte
@@ -1226,7 +1257,7 @@ func TestCommitErr_V2Message(t *testing.T) {
 	req.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
 
 	appendable := &mockAppendable{commitErr: errors.New("commit error")}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -1253,7 +1284,7 @@ func BenchmarkRemoteWriteOOOSamples(b *testing.B) {
 		require.NoError(b, db.Close())
 	})
 	// TODO: test with other proto format(s)
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), db.Head(), []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 	buf, _, _, err := buildWriteRequest(nil, genSeriesWithSample(1000, 200*time.Minute.Milliseconds()), nil, nil, nil, nil, "snappy")
 	require.NoError(b, err)
@@ -1386,11 +1417,32 @@ func (a *mockAppenderV2) asV1() *mockAppendable {
 	return (*mockAppendable)(a)
 }
 
-func (a *mockAppenderV2) Append(ref storage.SeriesRef, l labels.Labels, _, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, _ storage.AOptions) (storage.SeriesRef, error) {
-	if h != nil || fh != nil {
-		return a.asV1().AppendHistogram(ref, l, t, h, fh)
+func (a *mockAppenderV2) Append(ref storage.SeriesRef, l labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, opts storage.AOptions) (storage.SeriesRef, error) {
+	if st != 0 && t != 0 {
+		// Mirror a real AppenderV2 implementation, which owns ST zero-sample
+		// injection internally and does not surface its errors to the caller
+		// (e.g. TSDB head's bestEffortAppendSTZeroSample).
+		if h != nil || fh != nil {
+			_, _ = a.asV1().AppendHistogramSTZeroSample(ref, l, t, st, h, fh)
+		} else {
+			_, _ = a.asV1().AppendSTZeroSample(ref, l, t, st)
+		}
 	}
-	return a.asV1().Append(ref, l, t, v)
+
+	var err error
+	if h != nil || fh != nil {
+		ref, err = a.asV1().AppendHistogram(ref, l, t, h, fh)
+	} else {
+		ref, err = a.asV1().Append(ref, l, t, v)
+	}
+	if err != nil {
+		return ref, err
+	}
+	if !opts.Metadata.IsEmpty() {
+		// Metadata is best-effort within Append; errors are not surfaced to the caller.
+		_, _ = a.asV1().UpdateMetadata(ref, l, opts.Metadata)
+	}
+	return ref, nil
 }
 
 func (a *mockAppenderV2) AppendExemplars(ref storage.SeriesRef, l labels.Labels, exemplars []exemplar.Exemplar) (storage.SeriesRef, error) {
@@ -1632,7 +1684,7 @@ func TestHistogramsReduction(t *testing.T) {
 	for _, protoMsg := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
 		t.Run(string(protoMsg), func(t *testing.T) {
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{protoMsg}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{protoMsg}, false, false, false)
 
 			var (
 				err     error
@@ -1723,7 +1775,6 @@ func TestRemoteWriteHandler_ResponseStats(t *testing.T) {
 			handler := NewWriteHandler(
 				promslog.NewNopLogger(),
 				nil,
-				appendable,
 				appendable,
 				[]remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType},
 				false,

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -375,7 +375,7 @@ func NewAPI(
 	}
 
 	if rwEnabled {
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, apV2, acceptRemoteWriteProtoMsgs, stZeroIngestionEnabled, enableTypeAndUnitLabels, appendMetadata)
+		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, apV2, acceptRemoteWriteProtoMsgs, stZeroIngestionEnabled, enableTypeAndUnitLabels, appendMetadata)
 	}
 	if otlpEnabled {
 		a.otlpWriteHandler = remote.NewOTLPWriteHandler(logger, registerer, apV2, configFunc, remote.OTLPOptions{


### PR DESCRIPTION
Part of #17632. **Stacked on top of #19457** (RW 1.0 migration) — base branch is `krajo/rw1-receiver-appenderv2-v2`, so review only the top commit here.

## What

The Remote Write 2.x receiver path (`writeHandler.writeV2` / `appendV2`) is ported from V1 `storage.Appender` to `storage.AppenderV2`, matching the RW 1.0 path from #19457.

This folds together what #19251 and #19252 did separately, since the reason they were split (avoiding a per-exemplar interface call) no longer applies — `AppendExemplars` is mandatory and batched on this stack (#19455), so there's no standalone-vs-inline tradeoff to make for exemplars anymore:

- **Start timestamps** are now passed directly as the `AppenderV2.Append` `st` parameter; the appender owns ST zero-sample injection, so the explicit `AppendSTZeroSample` / `AppendHistogramSTZeroSample` calls (and the `handleHistogramZeroSample` helper) are removed. The receiver still gates on `ingestSTZeroSample`, preserving prior behaviour.
- **Metadata** is attached via `AppendV2Options.Metadata` on the first sample/histogram append of each series (same approach #19252 took) — if that append is rejected, metadata is dropped with it. It's best-effort: `Append` no longer reports metadata errors, so `samplesAppendedWithoutMetadata` is no longer incremented on this path (the metric stays registered and is still used by the RW 1.0 path).
- **Exemplars** are collected per series, sorted by timestamp (required by `AppendExemplars`'s contract), and appended in one batched `AppendExemplars` call instead of a per-exemplar loop. Out-of-order exemplars still map to a 400; other exemplar errors remain a no-op — preserving prior behaviour.

With both RW 1.0 and 2.x on `AppenderV2`, the V1 appendable is no longer used by the receiver: `NewWriteHandler` drops its `storage.Appendable` parameter and the now-dead `remoteWriteAppender` wrapper is removed.

## Tests

`mockAppenderV2.Append` now mirrors what a real `AppenderV2` implementation does internally: it injects the ST zero-sample (via the existing V1 mock methods) when `st != 0`, and records metadata via `opts.Metadata` when present — both best-effort, matching production semantics. Added a case exercising metadata stored via `AppendV2Options` (`appendMetadata: true`), which wasn't previously covered — the existing table only tested the disabled case.

```release-notes
NONE
```