### PR TITLE
Reduce allocations when parsing labels

### DIFF
--- a/cmd/promtool/backfill.go
+++ b/cmd/promtool/backfill.go
@@ -162,6 +162,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 
 				l := labels.Labels{}
 				p.Labels(&l)
+				l = l.Copy()
 
 				lb.Reset(l)
 				for name, value := range customLabels {

--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -68,6 +68,10 @@ type Parser interface {
 	// Labels writes the labels of the current sample into the passed labels.
 	// The values of the "le" labels of classic histograms and "quantile" labels
 	// of summaries should follow the OpenMetrics formatting rules.
+	// The underlying storage of l may be reused across calls to Next.
+	// If multiple labels.Labels instances share the same storage (slice or string)
+	// then this call will overwrite it for all instances, so the caller must make
+	// sure that no other labels.Labels points at the same storage.
 	Labels(l *labels.Labels)
 
 	// Exemplar writes the exemplar of the current sample into the passed

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -256,6 +256,7 @@ func testParse(t *testing.T, p Parser) (ret []parsedEntry) {
 			}
 			got.m = string(m)
 			p.Labels(&got.lset)
+			got.lset = got.lset.Copy()
 			got.st = p.StartTimestamp()
 
 			for e := (exemplar.Exemplar{}); p.Exemplar(&e); {

--- a/model/textparse/nhcbparse.go
+++ b/model/textparse/nhcbparse.go
@@ -148,7 +148,7 @@ func (p *NHCBParser) Labels(l *labels.Labels) {
 		*l = p.lsetNHCB
 		return
 	}
-	*l = p.lset
+	*l = p.lset.Copy()
 }
 
 func (p *NHCBParser) Exemplar(ex *exemplar.Exemplar) bool {

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -245,7 +245,7 @@ func (p *OpenMetricsParser) Labels(l *labels.Labels) {
 	}
 
 	p.builder.Sort()
-	*l = p.builder.Labels()
+	p.builder.Overwrite(l)
 }
 
 // Exemplar writes the exemplar of the current sample into the passed exemplar.

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -264,7 +264,7 @@ func (p *PromParser) Labels(l *labels.Labels) {
 	}
 
 	p.builder.Sort()
-	*l = p.builder.Labels()
+	p.builder.Overwrite(l)
 }
 
 // Exemplar implements the Parser interface. However, since the classic

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1758,6 +1758,7 @@ func (sl *scrapeLoopAppender) append(b []byte, contentType string, ts time.Time)
 		sampleLimitErr error
 		bucketLimitErr error
 		lset           labels.Labels     // Escapes to heap so hoisted out of loop.
+		lsetScratch    labels.Labels     // Reused by p.Labels via Overwrite; not retained.
 		e              exemplar.Exemplar // Escapes to heap so hoisted out of loop.
 		lastMeta       *metaEntry
 		lastMFName     []byte
@@ -1842,7 +1843,8 @@ loop:
 			lset = ce.lset
 			hash = ce.hash
 		} else {
-			p.Labels(&lset)
+			p.Labels(&lsetScratch)
+			lset = lsetScratch.Copy()
 			hash = lset.Hash()
 
 			// Hash label set as it is seen local to the target. Then add target labels

--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -128,6 +128,7 @@ func (sl *scrapeLoopAppenderV2) append(b []byte, contentType string, ts time.Tim
 		sampleLimitErr error
 		bucketLimitErr error
 		lset           labels.Labels     // Escapes to heap so hoisted out of loop.
+		lsetScratch    labels.Labels     // Reused by p.Labels via Overwrite; not retained.
 		e              exemplar.Exemplar // Escapes to heap so hoisted out of loop.
 		lastMeta       *metaEntry
 		lastMFName     []byte
@@ -215,7 +216,8 @@ loop:
 			lset = ce.lset
 			hash = ce.hash
 		} else {
-			p.Labels(&lset)
+			p.Labels(&lsetScratch)
+			lset = lsetScratch.Copy()
 			hash = lset.Hash()
 
 			// Hash label set as it is seen local to the target. Then add target labels

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -3352,6 +3352,7 @@ func testScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T, appV2 bool) {
 	_, err := p.Next()
 	require.NoError(t, err)
 	p.Labels(&lset)
+	lset = lset.Copy()
 	hash := lset.Hash()
 
 	// Create a fake entry in the cache


### PR DESCRIPTION
OpenMetricsParser.Labels() and PromParser.Labels() allocate a new buffer on every call.
This is because both call Labels() that ends up being a ScratchBuilder.Labels().
NHCBParser.Next() calls Labels() for every sample and overwrites the result on the next sample, so these allocations end up wasted.

We can avoid this waste if we switch to ScratchBuilder.Overwrite(), which writes into the caller's existing buffer.
NHCBParser.Next() reuses p.lset across samples, so the buffer grows once and all subsequent calls are allocation-free.
But this changes the behaviour if Labels() calls so we need to document this and ensure that all callers that keep labels
across calls now copy them first, since the buffer is shared and reused.

If callers don't make a copy then we might end up with multiple labels.Labels instances pointing at the same slice of string with actual
labels (depending if we're dealing with slicelabels or stringlabels) and calling Labels(lset) on one of them would
trigger Overwrite() that would replace data in the slice of string that stores the actual label data, which is often not what the
caller wants if the resulting labels instance is suppose to be kept for longer (for example in scrape cache).

This trade off yields decent savings in parsing, benchmarks:

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/textparse
cpu: 13th Gen Intel(R) Core(TM) i7-13800H
                                                  │  before.txt  │              after.txt              │
                                                  │    sec/op    │   sec/op     vs base                │
ParsePromText/parser=promtext-4                     1176.9µ ± 5%   989.0µ ± 3%  -15.97% (p=0.001 n=10)
ParsePromText/parser=omtext-4                        70.86m ± 0%   67.30m ± 1%   -5.03% (p=0.000 n=10)
ParsePromText/parser=expfmt-promtext-4               5.013m ± 7%   4.559m ± 5%   -9.05% (p=0.002 n=10)
ParsePromText_NoMeta/parser=promtext-4               909.7µ ± 6%   723.4µ ± 2%  -20.48% (p=0.000 n=10)
ParsePromText_NoMeta/parser=expfmt-promtext-4        3.575m ± 8%   3.173m ± 2%  -11.24% (p=0.000 n=10)
ParseOMText-4                                        44.36µ ± 5%   41.40µ ± 1%   -6.67% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext-4                 273.2µ ± 1%   257.6µ ± 2%   -5.70% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-4       43.42µ ± 6%   38.50µ ± 2%  -11.35% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-4    67.58µ ± 4%   60.69µ ± 1%  -10.19% (p=0.000 n=10)
geomean                                              714.2µ        637.4µ       -10.76%

                                                  │  before.txt  │               after.txt               │
                                                  │     B/s      │      B/s       vs base                │
ParsePromText/parser=promtext-4                     154.1Mi ± 6%    183.4Mi ± 3%  +18.98% (p=0.001 n=10)
ParsePromText/parser=omtext-4                       2.561Mi ± 1%    2.694Mi ± 1%   +5.21% (p=0.000 n=10)
ParsePromText/parser=expfmt-promtext-4              36.19Mi ± 8%    39.79Mi ± 5%   +9.95% (p=0.002 n=10)
ParsePromText_NoMeta/parser=promtext-4              155.3Mi ± 5%    195.3Mi ± 2%  +25.75% (p=0.000 n=10)
ParsePromText_NoMeta/parser=expfmt-promtext-4       39.52Mi ± 7%    44.53Mi ± 2%  +12.67% (p=0.000 n=10)
ParseOMText-4                                       96.25Mi ± 5%   103.12Mi ± 1%   +7.14% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext-4                14.63Mi ± 1%    15.52Mi ± 2%   +6.06% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-4      92.04Mi ± 6%   103.82Mi ± 2%  +12.80% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-4   59.15Mi ± 5%    65.86Mi ± 1%  +11.35% (p=0.000 n=10)
geomean                                             44.41Mi         49.76Mi       +12.05%

                                                  │  before.txt   │              after.txt               │
                                                  │     B/op      │     B/op      vs base                │
ParsePromText/parser=promtext-4                      310.8Ki ± 0%   153.1Ki ± 0%  -50.74% (p=0.000 n=10)
ParsePromText/parser=omtext-4                        580.0Ki ± 0%   422.3Ki ± 0%  -27.19% (p=0.000 n=10)
ParsePromText/parser=expfmt-promtext-4               2.342Mi ± 0%   2.342Mi ± 0%        ~ (p=0.781 n=10)
ParsePromText_NoMeta/parser=promtext-4               303.8Ki ± 0%   147.3Ki ± 0%  -51.52% (p=0.000 n=10)
ParsePromText_NoMeta/parser=expfmt-promtext-4        1.705Mi ± 0%   1.705Mi ± 0%        ~ (p=0.162 n=10)
ParseOMText-4                                       10.877Ki ± 0%   8.173Ki ± 0%  -24.86% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext-4                 22.40Ki ± 0%   18.47Ki ± 0%  -17.52% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-4       13.99Ki ± 0%   10.06Ki ± 0%  -28.05% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-4    14.89Ki ± 0%   10.97Ki ± 0%  -26.34% (p=0.000 n=10)
geomean                                              131.3Ki        95.56Ki       -27.24%

                                                  │  before.txt  │               after.txt               │
                                                  │  allocs/op   │  allocs/op   vs base                  │
ParsePromText/parser=promtext-4                      4.655k ± 0%   2.806k ± 0%  -39.72% (p=0.000 n=10)
ParsePromText/parser=omtext-4                       10.821k ± 0%   8.971k ± 0%  -17.10% (p=0.000 n=10)
ParsePromText/parser=expfmt-promtext-4               54.83k ± 0%   54.83k ± 0%        ~ (p=1.000 n=10) ¹
ParsePromText_NoMeta/parser=promtext-4               3.722k ± 0%   1.873k ± 0%  -49.68% (p=0.000 n=10)
ParsePromText_NoMeta/parser=expfmt-promtext-4        45.71k ± 0%   45.71k ± 0%        ~ (p=1.000 n=10) ¹
ParseOMText-4                                         231.0 ± 0%    191.0 ± 0%  -17.32% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext-4                  375.0 ± 0%    334.0 ± 0%  -10.93% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-4        163.0 ± 0%    122.0 ± 0%  -25.15% (p=0.000 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-4     181.0 ± 0%    140.0 ± 0%  -22.65% (p=0.000 n=10)
geomean                                              2.199k        1.716k       -21.97%
¹ all samples are equal

pkg: github.com/prometheus/prometheus/scrape
                                                                                                              │ before.txt  │              after.txt               │
                                                                                                              │   sec/op    │    sec/op     vs base                │
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4     468.3µ ± 1%   474.9µ ±  1%   +1.42% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4       466.2µ ± 0%   454.7µ ±  1%   -2.48% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4    583.7µ ± 2%   579.0µ ±  1%        ~ (p=0.353 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4    827.1µ ± 0%   817.1µ ±  0%   -1.21% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4      813.2µ ± 0%   792.3µ ±  4%   -2.56% (p=0.023 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4   734.0µ ± 1%   740.6µ ±  1%   +0.89% (p=0.015 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4      471.3µ ± 1%   472.9µ ±  1%        ~ (p=0.123 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4        466.4µ ± 0%   456.7µ ±  0%   -2.08% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4     588.2µ ± 2%   569.4µ ±  3%   -3.20% (p=0.002 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4     825.7µ ± 0%   818.0µ ±  0%   -0.94% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4       812.3µ ± 1%   792.6µ ±  1%   -2.43% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4    740.6µ ± 1%   741.2µ ±  1%        ~ (p=0.579 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4      501.8µ ± 1%   498.0µ ±  0%   -0.75% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4        495.4µ ± 1%   487.6µ ±  0%   -1.58% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4     626.0µ ± 2%   604.5µ ±  2%   -3.44% (p=0.002 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4     842.7µ ± 1%   840.0µ ±  0%   -0.32% (p=0.011 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4       69.69m ± 0%   66.90m ±  0%   -4.00% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4    768.4µ ± 1%   773.3µ ±  1%        ~ (p=0.089 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4       525.8µ ± 1%   528.7µ ±  0%        ~ (p=0.089 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4         521.9µ ± 0%   523.8µ ±  0%   +0.36% (p=0.005 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4      643.0µ ± 1%   671.5µ ±  1%   +4.42% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4      898.9µ ± 1%   898.7µ ±  1%        ~ (p=0.739 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4        69.75m ± 0%   67.13m ±  0%   -3.75% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4     829.6µ ± 1%   827.5µ ±  1%        ~ (p=0.853 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4      536.9µ ± 1%   537.3µ ±  1%        ~ (p=0.529 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4        531.8µ ± 1%   522.1µ ±  1%   -1.83% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4     625.8µ ± 1%   621.9µ ±  1%        ~ (p=0.063 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4     868.2µ ± 1%   865.4µ ±  0%        ~ (p=0.105 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4       845.5µ ± 2%   839.1µ ±  0%   -0.76% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4    749.8µ ± 1%   755.3µ ±  0%        ~ (p=0.063 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4       538.4µ ± 1%   535.2µ ±  1%        ~ (p=0.436 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4         531.9µ ± 6%   526.6µ ±  1%   -0.99% (p=0.003 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4      626.1µ ± 1%   624.9µ ±  1%        ~ (p=0.315 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4      868.2µ ± 1%   869.2µ ±  0%        ~ (p=0.529 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4        855.1µ ± 1%   841.9µ ±  0%   -1.55% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4     749.7µ ± 1%   756.5µ ±  0%   +0.90% (p=0.004 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4       574.4µ ± 1%   572.8µ ±  0%        ~ (p=0.218 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4         571.5µ ± 1%   566.4µ ±  0%   -0.89% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4      663.9µ ± 1%   679.9µ ±  1%   +2.41% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4      899.1µ ± 1%   894.9µ ±  0%   -0.47% (p=0.004 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4        69.78m ± 0%   66.83m ±  1%   -4.22% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4     790.2µ ± 1%   793.3µ ±  0%        ~ (p=0.684 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4        647.4µ ± 1%   649.5µ ±  1%        ~ (p=0.089 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4          646.2µ ± 1%   649.7µ ±  1%        ~ (p=0.631 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4       751.8µ ± 1%   763.2µ ±  1%   +1.51% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4       976.1µ ± 1%   982.8µ ±  0%   +0.68% (p=0.035 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4         69.95m ± 0%   66.82m ±  1%   -4.47% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4      878.3µ ± 0%   883.4µ ±  1%        ~ (p=0.075 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Counters-4                            693.0µ ± 0%   681.0µ ±  1%   -1.74% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Histograms-4                          2.008m ± 1%   1.991m ±  1%   -0.85% (p=0.005 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100IntHistograms-4                       2.960m ± 3%   2.737m ±  1%   -7.53% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100FloatHistograms-4                     60.13µ ± 7%   55.81µ ±  2%   -7.19% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=237FamsAllTypes-4                        9.276m ± 1%   8.857m ±  1%   -4.51% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Counters-4                             695.7µ ± 0%   683.1µ ±  1%   -1.81% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Histograms-4                           2.013m ± 2%   2.001m ±  1%        ~ (p=0.063 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100IntHistograms-4                        2.966m ± 6%   2.720m ±  1%   -8.30% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100FloatHistograms-4                      97.54µ ± 8%   84.18µ ± 11%  -13.69% (p=0.002 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=237FamsAllTypes-4                         9.408m ± 1%   9.000m ±  0%   -4.34% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Counters-4                             705.1µ ± 1%   692.4µ ±  1%   -1.79% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Histograms-4                           2.186m ± 1%   2.149m ±  0%   -1.69% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100IntHistograms-4                        2.834m ± 1%   2.744m ±  1%   -3.17% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100FloatHistograms-4                      58.81µ ± 1%   58.69µ ±  1%        ~ (p=0.393 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=237FamsAllTypes-4                         9.280m ± 1%   8.982m ±  1%   -3.21% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Counters-4                              703.7µ ± 1%   689.2µ ±  1%   -2.06% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Histograms-4                            2.175m ± 1%   2.154m ±  1%   -0.96% (p=0.002 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100IntHistograms-4                         2.815m ± 0%   2.724m ±  1%   -3.20% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100FloatHistograms-4                       81.68µ ± 1%   80.96µ ±  0%   -0.89% (p=0.003 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=237FamsAllTypes-4                          9.380m ± 1%   8.960m ±  0%   -4.48% (p=0.000 n=10)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=false-4                                                          1.389m ± 1%   1.388m ±  1%        ~ (p=0.631 n=10)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=true-4                                                           2.178m ± 1%   2.129m ± 16%   -2.28% (p=0.023 n=10)
ScrapeLoopScrapeAndReport/appV2=false-4                                                                         946.1µ ± 2%   929.1µ ±  1%   -1.80% (p=0.000 n=10)
ScrapeLoopScrapeAndReport/appV2=true-4                                                                          70.23m ± 1%   67.44m ±  0%   -3.97% (p=0.000 n=10)
ScrapePoolRestartLoops-4                                                                                        2.472m ± 2%   2.912m ±  8%  +17.80% (p=0.000 n=10)
geomean                                                                                                         1.144m        1.128m         -1.33%

                                                                                                              │  before.txt  │               after.txt                │
                                                                                                              │     B/op     │     B/op      vs base                  │
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4     1.561Ki ± 1%   1.572Ki ± 1%        ~ (p=0.084 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4       1.697Ki ± 0%   1.693Ki ± 1%        ~ (p=0.065 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4    110.1Ki ± 0%   110.2Ki ± 0%   +0.05% (p=0.001 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4    2.252Ki ± 1%   2.241Ki ± 1%        ~ (p=0.065 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4      2.378Ki ± 0%   2.361Ki ± 0%   -0.72% (p=0.014 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4   73.72Ki ± 0%   73.83Ki ± 0%   +0.14% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4      1.566Ki ± 1%   1.561Ki ± 1%        ~ (p=0.305 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4        1.699Ki ± 0%   1.703Ki ± 1%        ~ (p=0.697 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4     110.1Ki ± 0%   110.2Ki ± 0%   +0.04% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4     2.254Ki ± 0%   2.243Ki ± 0%   -0.50% (p=0.001 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4       2.380Ki ± 1%   2.366Ki ± 0%   -0.59% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4    73.72Ki ± 0%   73.84Ki ± 0%   +0.16% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4      1.630Ki ± 0%   1.634Ki ± 1%        ~ (p=0.698 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4        1.766Ki ± 0%   1.764Ki ± 1%        ~ (p=0.378 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4     110.2Ki ± 0%   110.2Ki ± 0%        ~ (p=0.060 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4     2.313Ki ± 1%   2.311Ki ± 0%        ~ (p=0.403 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4       338.3Ki ± 1%   338.4Ki ± 1%        ~ (p=0.895 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4    73.80Ki ± 0%   73.89Ki ± 0%   +0.13% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4       1.647Ki ± 1%   1.647Ki ± 0%        ~ (p=0.838 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4         1.787Ki ± 0%   1.786Ki ± 0%        ~ (p=0.808 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4      110.2Ki ± 0%   110.3Ki ± 0%   +0.05% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4      2.367Ki ± 1%   2.361Ki ± 0%        ~ (p=0.117 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4        338.3Ki ± 1%   338.4Ki ± 0%        ~ (p=0.457 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4     73.84Ki ± 0%   73.95Ki ± 0%   +0.15% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4      3.371Ki ± 3%   3.361Ki ± 1%        ~ (p=0.698 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4        3.499Ki ± 5%   3.424Ki ± 1%        ~ (p=0.139 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4     112.5Ki ± 0%   112.5Ki ± 0%        ~ (p=0.529 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4     4.492Ki ± 4%   4.452Ki ± 5%        ~ (p=0.529 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4       4.487Ki ± 6%   4.477Ki ± 1%        ~ (p=0.684 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4    75.78Ki ± 0%   75.83Ki ± 0%        ~ (p=0.271 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4       3.450Ki ± 1%   3.452Ki ± 0%        ~ (p=0.565 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4         3.613Ki ± 4%   3.523Ki ± 4%        ~ (p=0.066 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4      112.6Ki ± 0%   112.7Ki ± 0%        ~ (p=0.393 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4      4.618Ki ± 3%   4.626Ki ± 1%        ~ (p=0.725 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4        4.705Ki ± 4%   4.644Ki ± 1%   -1.30% (p=0.007 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4     75.84Ki ± 0%   75.94Ki ± 0%   +0.12% (p=0.014 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4       3.514Ki ± 4%   3.476Ki ± 2%        ~ (p=0.280 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4         3.665Ki ± 2%   3.602Ki ± 1%   -1.71% (p=0.029 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4      112.5Ki ± 0%   112.7Ki ± 0%   +0.18% (p=0.002 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4      4.645Ki ± 3%   4.518Ki ± 1%   -2.72% (p=0.004 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4        498.6Ki ± 4%   484.4Ki ± 3%        ~ (p=1.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4     75.85Ki ± 0%   75.89Ki ± 0%        ~ (p=0.481 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4        3.977Ki ± 3%   3.921Ki ± 2%        ~ (p=0.256 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4          4.023Ki ± 3%   4.061Ki ± 1%        ~ (p=0.447 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4       113.1Ki ± 0%   113.3Ki ± 0%        ~ (p=0.315 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4       5.016Ki ± 2%   5.063Ki ± 1%        ~ (p=0.190 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4         518.7Ki ± 3%   503.2Ki ± 3%        ~ (p=0.781 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4      76.33Ki ± 0%   76.39Ki ± 0%        ~ (p=0.190 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Counters-4                            13.12Ki ± 0%   13.12Ki ± 0%        ~ (p=0.474 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Histograms-4                          243.5Ki ± 0%   243.5Ki ± 0%   -0.01% (p=0.019 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100IntHistograms-4                       617.4Ki ± 0%   447.5Ki ± 0%  -27.53% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100FloatHistograms-4                     22.17Ki ± 0%   22.17Ki ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=237FamsAllTypes-4                        498.5Ki ± 0%   341.5Ki ± 0%  -31.49% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Counters-4                             13.12Ki ± 0%   13.12Ki ± 0%   -0.00% (p=0.033 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Histograms-4                           243.5Ki ± 0%   243.5Ki ± 0%        ~ (p=0.158 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100IntHistograms-4                        617.5Ki ± 0%   447.5Ki ± 0%  -27.53% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100FloatHistograms-4                      40.13Ki ± 0%   40.13Ki ± 0%        ~ (p=0.303 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=237FamsAllTypes-4                         564.0Ki ± 0%   407.0Ki ± 0%  -27.83% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Counters-4                             13.61Ki ± 0%   13.63Ki ± 0%        ~ (p=0.541 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Histograms-4                           249.9Ki ± 0%   249.6Ki ± 0%   -0.15% (p=0.009 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100IntHistograms-4                        618.9Ki ± 0%   448.8Ki ± 0%  -27.49% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100FloatHistograms-4                      22.54Ki ± 0%   22.53Ki ± 0%        ~ (p=0.224 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=237FamsAllTypes-4                         506.8Ki ± 0%   349.5Ki ± 0%  -31.04% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Counters-4                              13.61Ki ± 0%   13.61Ki ± 0%        ~ (p=0.897 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Histograms-4                            249.7Ki ± 0%   249.8Ki ± 0%        ~ (p=0.971 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100IntHistograms-4                         618.8Ki ± 0%   448.7Ki ± 0%  -27.48% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100FloatHistograms-4                       40.52Ki ± 0%   40.54Ki ± 0%   +0.05% (p=0.006 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=237FamsAllTypes-4                          571.1Ki ± 0%   413.8Ki ± 0%  -27.55% (p=0.000 n=10)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=false-4                                                          136.6Ki ± 0%   136.5Ki ± 0%        ~ (p=0.529 n=10)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=true-4                                                           249.8Ki ± 0%   249.5Ki ± 0%        ~ (p=0.393 n=10)
ScrapeLoopScrapeAndReport/appV2=false-4                                                                         12.40Ki ± 4%   12.19Ki ± 2%   -1.65% (p=0.043 n=10)
ScrapeLoopScrapeAndReport/appV2=true-4                                                                          565.5Ki ± 3%   565.8Ki ± 3%        ~ (p=0.616 n=10)
ScrapePoolRestartLoops-4                                                                                        2.191Mi ± 0%   2.191Mi ± 0%        ~ (p=0.470 n=10)
geomean                                                                                                         30.25Ki        29.07Ki        -3.88%
¹ all samples are equal

                                                                                                              │  before.txt  │               after.txt               │
                                                                                                              │  allocs/op   │  allocs/op   vs base                  │
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4       16.00 ± 0%    16.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4         17.00 ± 0%    17.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4      32.00 ± 3%    33.00 ± 3%   +3.12% (p=0.001 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4      20.00 ± 0%    20.00 ± 0%        ~ (p=1.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4        21.00 ± 0%    21.00 ± 0%        ~ (p=1.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4    2.236k ± 0%   2.237k ± 0%   +0.04% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4        16.00 ± 0%    16.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4          17.00 ± 0%    17.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4       32.00 ± 0%    32.00 ± 3%        ~ (p=0.124 n=10)
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4       20.00 ± 0%    20.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4         21.00 ± 0%    21.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=false/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4     2.236k ± 0%   2.237k ± 0%   +0.04% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4        17.00 ± 0%    17.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4          18.00 ± 0%    18.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4       33.00 ± 0%    34.00 ± 0%   +3.03% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4       21.00 ± 0%    21.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4        6.753k ± 1%   6.754k ± 0%        ~ (p=0.067 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4     2.237k ± 0%   2.238k ± 0%   +0.04% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4         17.00 ± 0%    17.00 ± 0%        ~ (p=1.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4           18.00 ± 0%    18.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4        33.00 ± 0%    34.00 ± 0%   +3.03% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4        22.00 ± 5%    21.00 ± 5%        ~ (p=0.370 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4         6.753k ± 1%   6.754k ± 0%        ~ (p=0.352 n=10)
ScrapeLoopAppend/withStorage=false/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4      2.237k ± 0%   2.238k ± 0%   +0.04% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4        25.00 ± 4%    25.00 ± 0%        ~ (p=0.303 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4          26.00 ± 4%    26.00 ± 0%        ~ (p=1.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4       42.00 ± 0%    43.00 ± 2%   +2.38% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4       30.50 ± 5%    30.00 ± 3%        ~ (p=0.341 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4         31.00 ± 3%    31.00 ± 3%        ~ (p=0.070 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4     2.245k ± 0%   2.246k ± 0%   +0.04% (p=0.002 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4         25.00 ± 0%    25.00 ± 0%        ~ (p=1.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4           26.00 ± 4%    26.00 ± 4%        ~ (p=0.505 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4        42.00 ± 0%    43.00 ± 2%   +2.38% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4        30.00 ± 3%    30.00 ± 0%        ~ (p=0.474 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4          31.00 ± 3%    31.00 ± 0%        ~ (p=0.211 n=10)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4      2.245k ± 0%   2.246k ± 0%   +0.04% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-4         27.00 ± 4%    27.00 ± 0%        ~ (p=0.474 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=OMText-4           28.00 ± 0%    28.00 ± 0%        ~ (p=0.526 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromProto-4        44.00 ± 2%    45.00 ± 2%   +2.27% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-4        32.00 ± 3%    31.00 ± 3%        ~ (p=0.052 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-4         7.379k ± 1%   7.306k ± 1%        ~ (p=0.819 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-4      2.246k ± 0%   2.247k ± 0%   +0.04% (p=0.002 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromText-4          28.00 ± 4%    28.00 ± 4%        ~ (p=1.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=OMText-4            29.00 ± 3%    29.00 ± 0%        ~ (p=0.582 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=1Fam2000Gauges/fmt=PromProto-4         45.00 ± 0%    46.00 ± 2%   +2.22% (p=0.000 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromText-4         33.00 ± 0%    33.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=OMText-4          7.380k ± 1%   7.306k ± 1%        ~ (p=0.878 n=10)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=true/data=237FamsAllTypes/fmt=PromProto-4       2.247k ± 0%   2.249k ± 0%   +0.09% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Counters-4                              414.0 ± 0%    414.0 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100Histograms-4                           4.835k ± 0%   4.835k ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100IntHistograms-4                       10.032k ± 0%   7.735k ± 0%  -22.90% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=100FloatHistograms-4                       326.0 ± 0%    326.0 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=false/data=237FamsAllTypes-4                         7.759k ± 0%   5.919k ± 0%  -23.71% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Counters-4                               414.0 ± 0%    414.0 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100Histograms-4                            4.835k ± 0%   4.835k ± 0%        ~ (p=0.721 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100IntHistograms-4                        10.032k ± 0%   7.735k ± 0%  -22.90% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=100FloatHistograms-4                        626.0 ± 0%    626.0 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend_STSynthesis/withStorage=false/synthesizeST=true/data=237FamsAllTypes-4                          8.695k ± 0%   6.855k ± 0%  -21.16% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Counters-4                               417.0 ± 0%    417.0 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100Histograms-4                            4.860k ± 0%   4.859k ± 0%   -0.02% (p=0.004 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100IntHistograms-4                        10.036k ± 0%   7.739k ± 0%  -22.89% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=100FloatHistograms-4                        329.0 ± 0%    329.0 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=false/data=237FamsAllTypes-4                          7.794k ± 0%   5.954k ± 0%  -23.61% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Counters-4                                417.0 ± 0%    417.0 ± 0%        ~ (p=1.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100Histograms-4                             4.859k ± 0%   4.859k ± 0%        ~ (p=0.892 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100IntHistograms-4                         10.036k ± 0%   7.739k ± 0%  -22.89% (p=0.000 n=10)
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=100FloatHistograms-4                         629.0 ± 0%    629.0 ± 0%        ~ (p=1.000 n=10) ¹
ScrapeLoopAppend_STSynthesis/withStorage=true/synthesizeST=true/data=237FamsAllTypes-4                           8.730k ± 0%   6.888k ± 0%  -21.10% (p=0.000 n=10)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=false-4                                                           2.445k ± 0%   2.445k ± 0%        ~ (p=0.511 n=10)
ScrapeLoopAppend_HistogramsWithExemplars/appV2=true-4                                                            4.859k ± 0%   4.858k ± 0%   -0.03% (p=0.026 n=10)
ScrapeLoopScrapeAndReport/appV2=false-4                                                                           137.5 ± 3%    136.0 ± 1%        ~ (p=0.358 n=10)
ScrapeLoopScrapeAndReport/appV2=true-4                                                                           8.043k ± 1%   8.044k ± 1%        ~ (p=0.750 n=10)
ScrapePoolRestartLoops-4                                                                                         34.01k ± 0%   34.01k ± 0%        ~ (p=0.628 n=10)
geomean                                                                                                           275.1         267.7        -2.69%
¹ all samples are equal
```


<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[PERF] textparse: reduce allocations when parsing labels
```
