### PR TITLE
ci: run the oldest Go tests on 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,9 @@ jobs:
       # Enforce the Go version.
       GOTOOLCHAIN: local
     container:
-      # The go version in this image should be N-1 wrt test_go.
-      image: quay.io/prometheus/golang-builder:1.25-base
+      # The go version in this image should be the oldest Go version upstream
+      # still supports, which scripts/check-go-mod-version.sh enforces.
+      image: quay.io/prometheus/golang-builder:1.26-base
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
`scripts/check-go-mod-version.sh` asks go.dev which Go versions are still supported upstream and requires the `test_go_oldest` job to run on the oldest of them. Go 1.27 was released today, so that is now 1.26 while the job still pins `golang-builder:1.25-base`:

```
Checking CI workflow test_go_oldest uses N-1 Go version
Error: test_go_oldest uses Go 1.25, but should use Go 1.26 (oldest supported version)
make: *** [Makefile:211: check-go-mod-version] Error 1
```

The check runs as part of `make test`, so `Go tests` and `Go tests with previous Go version` fail on every pull request and will fail on main on its next run. Nothing in the tree changed - the answer from go.dev did.

The remaining jobs stay on 1.26: `quay.io/prometheus/golang-builder:1.27-base` is not published yet, so bumping them has to wait. The comment above the image is updated to state the rule the script actually enforces, as the job now runs the same version as `test_go` until that image lands.

`go.mod` is untouched: the script only rejects a `go` directive newer than the oldest supported version, and 1.25.10 is older.

```release-notes
NONE
```
