### PR TITLE
promql: fix sort_by_label tie-break for natural-equal labels

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1072,11 +1072,9 @@ func funcSortByLabel(vectorVals []Vector, _ Matrix, args parser.Expressions, _ *
 				continue
 			}
 
-			if natsort.Compare(lv1, lv2) {
-				return -1
+			if cmp := compareNaturalLabelValues(lv1, lv2); cmp != 0 {
+				return cmp
 			}
-
-			return +1
 		}
 
 		// If all labels provided as arguments were equal, sort by the full label set. This ensures a consistent ordering.
@@ -1098,11 +1096,9 @@ func funcSortByLabelDesc(vectorVals []Vector, _ Matrix, args parser.Expressions,
 				continue
 			}
 
-			if natsort.Compare(lv1, lv2) {
-				return +1
+			if cmp := compareNaturalLabelValues(lv1, lv2); cmp != 0 {
+				return -cmp
 			}
-
-			return -1
 		}
 
 		// If all labels provided as arguments were equal, sort by the full label set. This ensures a consistent ordering.
@@ -1110,6 +1106,28 @@ func funcSortByLabelDesc(vectorVals []Vector, _ Matrix, args parser.Expressions,
 	})
 
 	return vectorVals[0], nil
+}
+
+func compareNaturalLabelValues(a, b string) int {
+	if a == b {
+		return 0
+	}
+
+	aBeforeB := natsort.Compare(a, b)
+	bBeforeA := natsort.Compare(b, a)
+
+	switch {
+	case aBeforeB && !bBeforeA:
+		return -1
+	case bBeforeA && !aBeforeB:
+		return 1
+	case aBeforeB && bBeforeA:
+		// Natsort's Compare is a less predicate and can return true both ways
+		// for equal numeric chunks such as "1" and "01".
+		return 0
+	default:
+		return strings.Compare(a, b)
+	}
 }
 
 func clamp(vec Vector, minVal, maxVal float64, enh *EvalNodeHelper) (Vector, annotations.Annotations) {

--- a/promql/sort_by_label_test.go
+++ b/promql/sort_by_label_test.go
@@ -1,0 +1,116 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+func TestSortByLabelNaturallyEqualValuesUseFullLabelSetTieBreak(t *testing.T) {
+	samples := Vector{
+		{
+			Metric: labels.FromStrings("__name__", "leading_zero_cpu", "cpu", "001", "shard", "a"),
+			F:      1,
+		},
+		{
+			Metric: labels.FromStrings("__name__", "leading_zero_cpu", "cpu", "01", "shard", "b"),
+			F:      2,
+		},
+		{
+			Metric: labels.FromStrings("__name__", "leading_zero_cpu", "cpu", "1", "shard", "c"),
+			F:      3,
+		},
+	}
+	expectedAscending := []string{"001", "01", "1"}
+	expectedDescending := []string{"1", "01", "001"}
+
+	for _, vec := range samplePermutations(samples) {
+		args := parser.Expressions{nil, &parser.StringLiteral{Val: "cpu"}}
+
+		ascending, _ := funcSortByLabel([]Vector{append(Vector(nil), vec...)}, nil, args, nil)
+		require.Equal(t, expectedAscending, cpuLabelValues(ascending))
+
+		descending, _ := funcSortByLabelDesc([]Vector{append(Vector(nil), vec...)}, nil, args, nil)
+		require.Equal(t, expectedDescending, cpuLabelValues(descending))
+	}
+}
+
+func TestSortByLabelMissingAndEmptyValuesSortBeforePopulatedValues(t *testing.T) {
+	samples := Vector{
+		{
+			Metric: labels.FromStrings("__name__", "cpu_usage", "id", "missing"),
+			F:      1,
+		},
+		{
+			Metric: labels.FromStrings("__name__", "cpu_usage", "cpu", "1", "id", "present"),
+			F:      2,
+		},
+		{
+			Metric: labels.FromStrings("__name__", "cpu_usage", "cpu", "", "id", "empty"),
+			F:      3,
+		},
+	}
+	expectedAscending := []string{"empty", "missing", "present"}
+	expectedDescending := []string{"present", "missing", "empty"}
+
+	for _, vec := range samplePermutations(samples) {
+		args := parser.Expressions{nil, &parser.StringLiteral{Val: "cpu"}}
+
+		ascending, _ := funcSortByLabel([]Vector{append(Vector(nil), vec...)}, nil, args, nil)
+		require.Equal(t, expectedAscending, idLabelValues(ascending))
+
+		descending, _ := funcSortByLabelDesc([]Vector{append(Vector(nil), vec...)}, nil, args, nil)
+		require.Equal(t, expectedDescending, idLabelValues(descending))
+	}
+}
+
+func samplePermutations(samples Vector) []Vector {
+	var result []Vector
+	var permute func(Vector, int)
+	permute = func(vec Vector, index int) {
+		if index == len(vec) {
+			result = append(result, append(Vector(nil), vec...))
+			return
+		}
+		for i := index; i < len(vec); i++ {
+			vec[index], vec[i] = vec[i], vec[index]
+			permute(vec, index+1)
+			vec[index], vec[i] = vec[i], vec[index]
+		}
+	}
+	permute(slices.Clone(samples), 0)
+	return result
+}
+
+func cpuLabelValues(vec Vector) []string {
+	values := make([]string, 0, len(vec))
+	for _, sample := range vec {
+		values = append(values, sample.Metric.Get("cpu"))
+	}
+	return values
+}
+
+func idLabelValues(vec Vector) []string {
+	values := make([]string, 0, len(vec))
+	for _, sample := range vec {
+		values = append(values, sample.Metric.Get("id"))
+	}
+	return values
+}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None. Related to #17799/#18676, but this covers a separate natural-sort tie case.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] PromQL: Make sort_by_label and sort_by_label_desc use the documented full label-set tie-break for naturally equal selected label values.
```

`natsort.Compare` is a less predicate, not a three-way comparator. For label values such as `1`, `01`, and `001`, it can report both directions as less, so the existing `slices.SortFunc` comparator could make the order depend on the incoming vector order instead of reaching the full-label-set tie-break.

This change turns only that two-way natural-sort case into a tie, keeps lexical ordering when natural sort cannot order either direction, and applies the same comparison to descending order.

Tests:
- `go test ./promql -run 'TestSortByLabel(NaturallyEqualValuesUseFullLabelSetTieBreak|MissingAndEmptyValuesSortBeforePopulatedValues)' -count=1`
- `go test ./promql -run TestEvaluations -count=1`
- `go test ./promql/... -count=1`
- `go test ./model/labels -count=1`
- `go test -race ./promql -run 'TestSortByLabel(NaturallyEqualValuesUseFullLabelSetTieBreak|MissingAndEmptyValuesSortBeforePopulatedValues)' -count=10`
- `go build ./cmd/prometheus`
- `go test ./... -run '^$'`
- `golangci-lint run --timeout=5m ./promql`