### PR TITLE
perf(scrape): optimize series cache lookups

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -874,10 +874,11 @@ type loop interface {
 }
 
 type cacheEntry struct {
-	ref      storage.SeriesRef
-	lastIter uint64
-	hash     uint64
-	lset     labels.Labels
+	ref  storage.SeriesRef
+	hash uint64
+	lset labels.Labels
+
+	met string
 
 	// st is an optional state for ST synthesis.
 	st *stCache
@@ -954,27 +955,57 @@ type scrapeLoop struct {
 	disabledEndOfRunStalenessMarkers atomic.Bool
 }
 
-// scrapeCache tracks mappings of exposed metric strings to label sets and
-// storage references. Additionally, it tracks staleness of series between
-// scrapes.
-// Cache is meant to be used per a single target.
+// cacheSlot identifies a cached metric. Its high bit marks dropped series.
+type cacheSlot uint64
+
+const droppedSlotMask cacheSlot = 1 << 63
+
+func droppedSlot(index uint64) cacheSlot {
+	return cacheSlot(index) | droppedSlotMask
+}
+
+func (s cacheSlot) dropped() bool {
+	return s&droppedSlotMask != 0
+}
+
+func (s cacheSlot) index() uint64 {
+	return uint64(s &^ droppedSlotMask)
+}
+
+// scrapeCache maps metric strings to label sets and storage references for one
+// target. It also tracks staleness between scrapes.
+//
+// Cached data uses slices because targets usually preserve series order. This
+// allows lookup by the next expected index without maintaining a map. A map
+// index is built only when the order changes.
+//
+// iterDone must be called once per scrape.
 type scrapeCache struct {
 	iter uint64 // Current scrape iteration.
 
 	// How many series and metadata entries there were at the last success.
 	successfulCount int
 
-	// Parsed string to an entry with information about the actual label set
-	// and its storage reference.
-	series map[string]*cacheEntry
+	slots []cacheSlot // Metric order from the last successful scrape
+	pos   int         // Is the next expected slot.
 
-	// Cache of dropped metric strings and their iteration. The iteration must
-	// be a pointer so we can update it.
-	droppedSeries map[string]*uint64
+	nextSlots    []cacheSlot // Records the current order after a mismatch
+	orderChanged bool        // Marks nextSlots for adoption after a successful scrape.
+
+	lookup    map[string]cacheSlot // Maps metric strings to slots after order-based lookup fails
+	orderRuns int                  // Counts ordered scrapes until lookup is released.
+
+	entries     []cacheEntry // Holds cached series.
+	freeEntries []uint64     // Holds reusable entry indexes.
+	seenEntries []bool       // Marks entries seen this scrape.
+
+	dropped     []string // Holds relabel-dropped metric strings.
+	freeDropped []uint64 // Holds reusable dropped indexes.
+	seenDropped []bool   // Marks dropped entries seen this scrape.
 
 	// Series that were seen in the current and previous scrape, for staleness detection.
-	seriesCur  map[storage.SeriesRef]*cacheEntry
-	seriesPrev map[storage.SeriesRef]*cacheEntry
+	seriesCur  map[storage.SeriesRef]cacheSlot
+	seriesPrev map[storage.SeriesRef]cacheSlot
 
 	// TODO(bwplotka): Consider moving metadata caching to head. See
 	// https://github.com/prometheus/prometheus/issues/17619.
@@ -997,21 +1028,32 @@ func (m *metaEntry) size() int {
 	return len(m.Help) + len(m.Unit) + len(m.Type)
 }
 
+// orderedRunsBeforeRelease controls when a stable target drops its map index.
+const orderedRunsBeforeRelease = 3
+
+// compactSlack delays compaction until allocated storage exceeds twice the
+// live slot count by this amount.
+const compactSlack = 128
+
 func newScrapeCache(metrics *scrapeMetrics) *scrapeCache {
 	return &scrapeCache{
-		series:        map[string]*cacheEntry{},
-		droppedSeries: map[string]*uint64{},
-		seriesCur:     map[storage.SeriesRef]*cacheEntry{},
-		seriesPrev:    map[storage.SeriesRef]*cacheEntry{},
-		metadata:      map[string]*metaEntry{},
-		metrics:       metrics,
+		seriesCur:  map[storage.SeriesRef]cacheSlot{},
+		seriesPrev: map[storage.SeriesRef]cacheSlot{},
+		metadata:   map[string]*metaEntry{},
+		metrics:    metrics,
 	}
 }
 
 func (c *scrapeCache) iterDone(flushCache bool) {
 	c.metaMtx.Lock()
-	count := len(c.series) + len(c.droppedSeries) + len(c.metadata)
+	count := len(c.slots) + len(c.metadata)
 	c.metaMtx.Unlock()
+
+	// Save whether the scrape completed; flushCache may be forced below.
+	completeScrape := flushCache
+
+	// Adopt order only from a successful scrape.
+	publishOrder := flushCache && c.orderChanged
 
 	switch {
 	case flushCache:
@@ -1030,16 +1072,27 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 		// All caches may grow over time through series churn
 		// or multiple string representations of the same metric. Clean up entries
 		// that haven't appeared in the last scrape.
-		for s, e := range c.series {
-			if c.iter != e.lastIter {
-				delete(c.series, s)
+		if publishOrder {
+			// Free unseen slots before adopting the new order.
+			for _, slot := range c.slots {
+				if !c.seenThisIter(slot) {
+					c.free(slot)
+				}
 			}
-		}
-		for s, iter := range c.droppedSeries {
-			if c.iter != *iter {
-				delete(c.droppedSeries, s)
+			c.slots, c.nextSlots = c.nextSlots, c.slots[:0]
+		} else {
+			w := 0
+			for _, slot := range c.slots {
+				if c.seenThisIter(slot) {
+					c.slots[w] = slot
+					w++
+					continue
+				}
+				c.free(slot)
 			}
+			c.slots = c.slots[:w]
 		}
+
 		c.metaMtx.Lock()
 		for m, e := range c.metadata {
 			// Keep metadata around for 10 scrapes after its metric disappeared.
@@ -1048,7 +1101,27 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 			}
 		}
 		c.metaMtx.Unlock()
+
+		if completeScrape {
+			// Compact before swapping seriesCur; compaction rewrites slots.
+			c.maybeCompact()
+		}
 	}
+
+	if c.orderChanged {
+		c.orderRuns = 0
+	} else {
+		// Release the map after enough ordered scrapes.
+		c.orderRuns++
+		if c.orderRuns >= orderedRunsBeforeRelease {
+			c.lookup = nil
+		}
+	}
+	c.nextSlots = c.nextSlots[:0]
+	c.orderChanged = false
+	c.pos = 0
+	clear(c.seenDropped)
+	clear(c.seenEntries)
 
 	// Swap current and previous series then clear the new current, to save allocations.
 	c.seriesPrev, c.seriesCur = c.seriesCur, c.seriesPrev
@@ -1057,69 +1130,241 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 	c.iter++
 }
 
-func (c *scrapeCache) get(met []byte) (*cacheEntry, bool, bool) {
-	e, ok := c.series[string(met)]
-	if !ok {
-		return nil, false, false
+func (c *scrapeCache) seenThisIter(slot cacheSlot) bool {
+	if slot.dropped() {
+		return c.seenDropped[slot.index()]
 	}
-	alreadyScraped := e.lastIter == c.iter
-	e.lastIter = c.iter
-	return e, true, alreadyScraped
+	return c.seenEntries[slot.index()]
 }
 
-func (c *scrapeCache) addRef(met []byte, ref storage.SeriesRef, lset labels.Labels, hash uint64) (ce *cacheEntry) {
-	ce = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
-	c.series[string(met)] = ce
-	return ce
+// free releases the storage behind a slot. The slot must no longer be
+// referenced by c.slots.
+func (c *scrapeCache) free(slot cacheSlot) {
+	index := slot.index()
+	if slot.dropped() {
+		delete(c.lookup, c.dropped[index])
+		c.dropped[index] = ""
+		c.freeDropped = append(c.freeDropped, index)
+		return
+	}
+	delete(c.lookup, c.entries[index].met)
+	c.entries[index] = cacheEntry{}
+	c.freeEntries = append(c.freeEntries, index)
+}
+
+// maybeCompact compacts slot storage left unused by series churn.
+func (c *scrapeCache) maybeCompact() {
+	if len(c.entries)+len(c.dropped) > 2*len(c.slots)+compactSlack {
+		c.compact()
+	}
+}
+
+// compact moves all cached series into freshly sized storage. This changes slot
+// indices, so every slot the cache kept has to be rewritten.
+func (c *scrapeCache) compact() {
+	numEntries := 0
+	for _, slot := range c.slots {
+		if !slot.dropped() {
+			numEntries++
+		}
+	}
+
+	var (
+		entries = make([]cacheEntry, 0, numEntries)
+		dropped = make([]string, 0, len(c.slots)-numEntries)
+		slots   = make([]cacheSlot, len(c.slots))
+		remap   = make(map[cacheSlot]cacheSlot, len(c.slots))
+		lookup  map[string]cacheSlot
+	)
+	if c.lookup != nil {
+		lookup = make(map[string]cacheSlot, len(c.slots))
+	}
+	for i, old := range c.slots {
+		var (
+			newSlot cacheSlot
+			met     string
+		)
+		if old.dropped() {
+			dropped = append(dropped, c.dropped[old.index()])
+			newSlot = droppedSlot(uint64(len(dropped) - 1))
+			met = dropped[len(dropped)-1]
+		} else {
+			entries = append(entries, c.entries[old.index()])
+			e := &entries[len(entries)-1]
+			newSlot = cacheSlot(len(entries) - 1)
+			met = e.met
+		}
+
+		slots[i] = newSlot
+		remap[old] = newSlot
+		if lookup != nil {
+			lookup[met] = newSlot
+		}
+	}
+	for ref, oldSlot := range c.seriesCur {
+		c.seriesCur[ref] = remap[oldSlot]
+	}
+
+	// seriesPrev is cleared after compaction, so its slots need not be remapped.
+	c.slots = slots
+	c.entries = entries
+	c.dropped = dropped
+	c.lookup = lookup
+	c.freeEntries = nil
+	c.freeDropped = nil
+	c.nextSlots = nil
+	// Resize seen flags to match the rebuilt storage.
+	c.seenDropped = make([]bool, len(dropped))
+	c.seenEntries = make([]bool, len(entries))
+}
+
+func (c *scrapeCache) metOf(slot cacheSlot) string {
+	if slot.dropped() {
+		return c.dropped[slot.index()]
+	}
+	return c.entries[slot.index()].met
+}
+
+// get returns the slot, entry, cache status, and whether met was already seen.
+//
+// The entry is nil for dropped series and must not be retained past the scrape.
+func (c *scrapeCache) get(met []byte) (cacheSlot, *cacheEntry, bool, bool) {
+	// Fast path: compare the next expected slot.
+	if c.pos < len(c.slots) {
+		slot := c.slots[c.pos]
+		if c.metOf(slot) == string(met) {
+			c.pos++
+			return c.hit(slot)
+		}
+	}
+	return c.getUnordered(met)
+}
+
+// getUnordered looks up met in the map index, building it if needed.
+func (c *scrapeCache) getUnordered(met []byte) (cacheSlot, *cacheEntry, bool, bool) {
+	c.trackOrder()
+
+	slot, ok := c.lookup[string(met)]
+	if !ok {
+		return 0, nil, false, false
+	}
+	return c.hit(slot)
+}
+
+// hit marks a slot seen this scrape.
+func (c *scrapeCache) hit(slot cacheSlot) (cacheSlot, *cacheEntry, bool, bool) {
+	var (
+		e              *cacheEntry
+		alreadyScraped bool
+	)
+	if index := slot.index(); slot.dropped() {
+		alreadyScraped = c.seenDropped[index]
+		c.seenDropped[index] = true
+	} else {
+		e = &c.entries[index]
+		alreadyScraped = c.seenEntries[index]
+		c.seenEntries[index] = true
+	}
+
+	// A series exposed twice in the same scrape must not be recorded twice.
+	if c.orderChanged && !alreadyScraped {
+		c.nextSlots = append(c.nextSlots, slot)
+	}
+	return slot, e, true, alreadyScraped
+}
+
+// trackOrder records a changed order and builds the map index if needed.
+func (c *scrapeCache) trackOrder() {
+	if c.orderChanged {
+		return
+	}
+	c.orderChanged = true
+	c.nextSlots = append(c.nextSlots[:0], c.slots[:c.pos]...)
+
+	if c.lookup == nil {
+		c.lookup = make(map[string]cacheSlot, len(c.slots))
+		for _, slot := range c.slots {
+			c.lookup[c.metOf(slot)] = slot
+		}
+	}
+}
+
+// addSlot records a metric string that was not cached before.
+func (c *scrapeCache) addSlot(met string, slot cacheSlot) {
+	// Keep the cache valid if a caller adds without first missing a lookup.
+	c.trackOrder()
+
+	c.slots = append(c.slots, slot)
+	c.nextSlots = append(c.nextSlots, slot)
+	c.lookup[met] = slot
+}
+
+func (c *scrapeCache) addRef(met []byte, ref storage.SeriesRef, lset labels.Labels, hash uint64) (cacheSlot, *cacheEntry) {
+	var index uint64
+	if n := len(c.freeEntries); n > 0 {
+		index = c.freeEntries[n-1]
+		c.freeEntries = c.freeEntries[:n-1]
+	} else {
+		index = uint64(len(c.entries))
+		c.entries = append(c.entries, cacheEntry{})
+		c.seenEntries = append(c.seenEntries, false)
+	}
+	c.seenEntries[index] = true
+
+	e := &c.entries[index]
+	*e = cacheEntry{ref: ref, lset: lset, hash: hash, met: string(met)}
+	c.addSlot(e.met, cacheSlot(index))
+	return cacheSlot(index), e
 }
 
 func (c *scrapeCache) addDropped(met []byte) {
-	iter := c.iter
-	c.droppedSeries[string(met)] = &iter
-}
-
-func (c *scrapeCache) getDropped(met []byte) bool {
-	iterp, ok := c.droppedSeries[string(met)]
-	if ok {
-		*iterp = c.iter
+	var index uint64
+	if n := len(c.freeDropped); n > 0 {
+		index = c.freeDropped[n-1]
+		c.freeDropped = c.freeDropped[:n-1]
+	} else {
+		index = uint64(len(c.dropped))
+		c.dropped = append(c.dropped, "")
+		c.seenDropped = append(c.seenDropped, false)
 	}
-	return ok
+	c.seenDropped[index] = true
+
+	c.dropped[index] = string(met)
+	c.addSlot(c.dropped[index], droppedSlot(index))
 }
 
-// updateRef points the cache entry at a new storage reference, e.g. because the
-// storage garbage collected the series and had to recreate it. Staleness is tracked
-// per reference, so the tracking has to follow the entry to the new reference,
-// otherwise the series looks like it stopped being exposed and gets a stale marker.
-func (c *scrapeCache) updateRef(ce *cacheEntry, ref storage.SeriesRef) {
-	if ce.ref == ref {
+// updateRef moves a cached series and its staleness tracking to ref.
+func (c *scrapeCache) updateRef(slot cacheSlot, ref storage.SeriesRef) {
+	entry := &c.entries[slot.index()]
+	oldRef := entry.ref
+	if oldRef == ref {
 		return
 	}
-	if ce.ref != 0 {
-		moveStaleness(c.seriesPrev, ce, ref)
-		moveStaleness(c.seriesCur, ce, ref)
+	if oldRef != 0 {
+		moveStaleness(c.seriesPrev, slot, oldRef, ref)
+		moveStaleness(c.seriesCur, slot, oldRef, ref)
 	}
-	ce.ref = ref
+	entry.ref = ref
 }
 
-// moveStaleness re-keys the staleness tracking of ce from ce.ref to ref. Whether the
-// series is considered stale is left as it is, only the reference it is tracked under
-// changes. Tracking that belongs to another cache entry is left alone.
-func moveStaleness(tracked map[storage.SeriesRef]*cacheEntry, ce *cacheEntry, ref storage.SeriesRef) {
-	if tracked[ce.ref] != ce {
+func moveStaleness(tracked map[storage.SeriesRef]cacheSlot, slot cacheSlot, oldRef, ref storage.SeriesRef) {
+	trackedSlot, ok := tracked[oldRef]
+	if !ok || trackedSlot != slot {
 		return
 	}
-	delete(tracked, ce.ref)
-	tracked[ref] = ce
+	delete(tracked, oldRef)
+	tracked[ref] = slot
 }
 
-func (c *scrapeCache) trackStaleness(ref storage.SeriesRef, ce *cacheEntry) {
-	c.seriesCur[ref] = ce
+func (c *scrapeCache) trackStaleness(ref storage.SeriesRef, slot cacheSlot) {
+	c.seriesCur[ref] = slot
 }
 
 func (c *scrapeCache) forEachStale(f func(storage.SeriesRef, labels.Labels) bool) {
-	for ref, ce := range c.seriesPrev {
+	for ref, slot := range c.seriesPrev {
 		if _, ok := c.seriesCur[ref]; !ok {
-			if !f(ce.ref, ce.lset) {
+			entry := c.entries[slot.index()]
+			if !f(entry.ref, entry.lset) {
 				break
 			}
 		}
@@ -1828,10 +2073,10 @@ loop:
 			t = *parsedTimestamp
 		}
 
-		if sl.cache.getDropped(met) {
+		slot, ce, seriesCached, seriesAlreadyScraped := sl.cache.get(met)
+		if seriesCached && slot.dropped() {
 			continue
 		}
-		ce, seriesCached, seriesAlreadyScraped := sl.cache.get(met)
 		var (
 			ref  storage.SeriesRef
 			hash uint64
@@ -1907,10 +2152,10 @@ loop:
 		if err == nil {
 			// Append may return a new ref; keep the cache in sync.
 			if ce != nil && ref != 0 {
-				sl.cache.updateRef(ce, ref)
+				sl.cache.updateRef(slot, ref)
 			}
 			if (parsedTimestamp == nil || sl.trackTimestampsStaleness) && ce != nil && ce.ref != 0 {
-				sl.cache.trackStaleness(ce.ref, ce)
+				sl.cache.trackStaleness(ce.ref, slot)
 			}
 		}
 
@@ -1927,11 +2172,11 @@ loop:
 		// If a series was new but we didn't append it due to sample_limit or other errors then we don't need
 		// it in the scrape cache because we don't need to emit StaleNaNs for it when it disappears.
 		if !seriesCached && sampleAdded {
-			ce = sl.cache.addRef(met, ref, lset, hash)
+			slot, ce = sl.cache.addRef(met, ref, lset, hash)
 			if ce != nil && ce.ref != 0 && (parsedTimestamp == nil || sl.trackTimestampsStaleness) {
 				// Bypass staleness logic if there is an explicit timestamp.
 				// But make sure we only do this if we have a cache entry (ce) for our series.
-				sl.cache.trackStaleness(ref, ce)
+				sl.cache.trackStaleness(ref, slot)
 			}
 			if sampleLimitErr == nil && bucketLimitErr == nil {
 				seriesAdded++
@@ -2311,7 +2556,7 @@ func (sl *scrapeLoop) reportStale(app scrapeLoopAppendAdapter, start time.Time) 
 }
 
 func (sl *scrapeLoopAppender) addReportSample(s reportSample, t int64, v float64, b *labels.Builder, rejectOOO bool) (err error) {
-	ce, ok, _ := sl.cache.get(s.name)
+	_, ce, ok, _ := sl.cache.get(s.name)
 	var ref storage.SeriesRef
 	var lset labels.Labels
 	if ok {
@@ -2338,7 +2583,7 @@ func (sl *scrapeLoopAppender) addReportSample(s reportSample, t int64, v float64
 	switch {
 	case err == nil:
 		if !ok {
-			sl.cache.addRef(s.name, ref, lset, lset.Hash())
+			_, _ = sl.cache.addRef(s.name, ref, lset, lset.Hash())
 			// We only need to add metadata once a scrape target appears.
 			if sl.appendMetadataToWAL {
 				if _, merr := sl.UpdateMetadata(ref, lset, s.Metadata); merr != nil {

--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -201,10 +201,10 @@ loop:
 			t = *parsedTimestamp
 		}
 
-		if sl.cache.getDropped(met) {
+		slot, ce, seriesCached, seriesAlreadyScraped := sl.cache.get(met)
+		if seriesCached && slot.dropped() {
 			continue
 		}
-		ce, seriesCached, seriesAlreadyScraped := sl.cache.get(met)
 		var (
 			ref  storage.SeriesRef
 			hash uint64
@@ -326,13 +326,13 @@ loop:
 				// Append sample to the storage.
 				ref, err = app.Append(ref, lset, st, t, val, h, fh, appOpts)
 				if err == nil && ce != nil && ref != 0 {
-					sl.cache.updateRef(ce, ref)
+					sl.cache.updateRef(slot, ref)
 				}
 			}
 		}
 		if err == nil {
 			if (parsedTimestamp == nil || sl.trackTimestampsStaleness) && ce != nil && ce.ref != 0 {
-				sl.cache.trackStaleness(ce.ref, ce)
+				sl.cache.trackStaleness(ce.ref, slot)
 			}
 		}
 
@@ -349,7 +349,7 @@ loop:
 		// If a series was new, but we didn't append it due to sample_limit or other errors then we don't need
 		// it in the scrape cache because we don't need to emit StaleNaNs for it when it disappears.
 		if !seriesCached && sampleAdded {
-			ce = sl.cache.addRef(met, ref, lset, hash)
+			slot, ce = sl.cache.addRef(met, ref, lset, hash)
 
 			if sampleLimitErr == nil && bucketLimitErr == nil {
 				seriesAdded++
@@ -373,7 +373,7 @@ loop:
 		// - Or we are synthesizing start times (stCache != nil), so we can clear stCache if it goes stale.
 		shouldTrackStaleness := parsedTimestamp == nil || sl.trackTimestampsStaleness || stCache != nil
 		if ce != nil && ce.ref != 0 && shouldTrackStaleness && sampleAdded {
-			sl.cache.trackStaleness(ce.ref, ce)
+			sl.cache.trackStaleness(ce.ref, slot)
 		}
 
 		// Increment added even if there's an error so we correctly report the
@@ -415,7 +415,7 @@ loop:
 }
 
 func (sl *scrapeLoopAppenderV2) addReportSample(s reportSample, t int64, v float64, b *labels.Builder, rejectOOO bool) (err error) {
-	ce, ok, _ := sl.cache.get(s.name)
+	_, ce, ok, _ := sl.cache.get(s.name)
 	var ref storage.SeriesRef
 	var lset labels.Labels
 	if ok {
@@ -438,7 +438,7 @@ func (sl *scrapeLoopAppenderV2) addReportSample(s reportSample, t int64, v float
 	switch {
 	case err == nil:
 		if !ok {
-			sl.cache.addRef(s.name, ref, lset, lset.Hash())
+			_, _ = sl.cache.addRef(s.name, ref, lset, lset.Hash())
 		}
 		return nil
 	case errors.Is(err, storage.ErrOutOfOrderSample), errors.Is(err, storage.ErrDuplicateSampleForTimestamp):

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"maps"
 	"math"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -2560,6 +2561,166 @@ func benchScrapeLoopAppend(
 	}
 }
 
+// benchScrapeOrders returns deterministic permutations, starting with identity.
+func benchScrapeOrders(numSeries, numOrders int) [][]int {
+	rnd := rand.New(rand.NewPCG(0, 0))
+
+	orders := make([][]int, 0, numOrders)
+	for i := range numOrders {
+		order := make([]int, numSeries)
+		for j := range order {
+			order[j] = j
+		}
+		if i > 0 {
+			rnd.Shuffle(len(order), func(a, b int) { order[a], order[b] = order[b], order[a] })
+		}
+		orders = append(orders, order)
+	}
+	return orders
+}
+
+// BenchmarkScrapeCacheGet benchmarks cache lookups by cardinality, series order,
+// and whether relabeling dropped the series.
+//
+// Recommended CLI invocation:
+/*
+	export bench=cacheGet && go test ./scrape/... \
+		-run '^$' -bench '^BenchmarkScrapeCacheGet' \
+		-benchtime 2s -count 6 -cpu 2 -timeout 999m \
+		| tee ${bench}.txt
+*/
+func BenchmarkScrapeCacheGet(b *testing.B) {
+	for _, numSeries := range []int{100, 2000, 100000} {
+		for _, order := range []string{"stable", "churn", "random"} {
+			for _, dropped := range []bool{false, true} {
+				benchScrapeCacheGet(b, numSeries, order, dropped)
+			}
+		}
+	}
+}
+
+func benchScrapeCacheGet(b *testing.B, numSeries int, order string, dropped bool) {
+	const numOrders = 8
+
+	b.Run(fmt.Sprintf("numSeries=%v/order=%v/dropped=%v", numSeries, order, dropped), func(b *testing.B) {
+		// One extra series so that churn has something to swap in.
+		mets := make([][]byte, 0, numSeries+1)
+		for i := range numSeries + 1 {
+			mets = append(mets, fmt.Appendf(nil, "metric_a{foo=%q,bar=%q}", strconv.Itoa(i), strconv.Itoa(i*100)))
+		}
+
+		orders := benchScrapeOrders(numSeries, numOrders)
+		if order != "random" {
+			orders = orders[:1]
+		}
+
+		c := newScrapeCache(newTestScrapeMetrics(b))
+		scrape := func(run int) {
+			swapped := numSeries - 1
+			if order == "churn" {
+				// Replace one series per scrape.
+				swapped = run % numSeries
+			}
+
+			for _, i := range orders[run%len(orders)] {
+				met := mets[i]
+				if i == swapped {
+					met = mets[numSeries]
+				}
+				if _, _, ok, _ := c.get(met); ok {
+					continue
+				}
+				if dropped {
+					c.addDropped(met)
+				} else {
+					c.addRef(met, storage.SeriesRef(i+1), labels.EmptyLabels(), 0)
+				}
+			}
+			c.iterDone(true)
+		}
+
+		// Learn the order and release the map for stable input.
+		for run := range numOrders + orderedRunsBeforeRelease {
+			scrape(run)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for run := 0; b.Loop(); run++ {
+			scrape(run)
+		}
+	})
+}
+
+// makeTestGaugesInOrder returns gauge series in the given order.
+func makeTestGaugesInOrder(order []int) []byte {
+	sb := bytes.Buffer{}
+	sb.WriteString("# TYPE metric_a gauge\n")
+	sb.WriteString("# HELP metric_a help text\n")
+	for _, i := range order {
+		_, _ = fmt.Fprintf(&sb, "metric_a{foo=\"%d\",bar=\"%d\"} 1\n", i, i*100)
+	}
+	sb.WriteString("# EOF\n")
+	return sb.Bytes()
+}
+
+// BenchmarkScrapeLoopAppendSeriesOrder benchmarks append with stable and random
+// series order.
+//
+// Recommended CLI invocation:
+/*
+	export bench=appendOrder && go test ./scrape/... \
+		-run '^$' -bench '^BenchmarkScrapeLoopAppendSeriesOrder' \
+		-benchtime 2s -count 6 -cpu 2 -timeout 999m \
+		| tee ${bench}.txt
+*/
+func BenchmarkScrapeLoopAppendSeriesOrder(b *testing.B) {
+	const (
+		numSeries = 2000
+		numOrders = 8
+	)
+
+	for _, appV2 := range []bool{false, true} {
+		for _, order := range []string{"stable", "random"} {
+			b.Run(fmt.Sprintf("appV2=%v/order=%v", appV2, order), func(b *testing.B) {
+				orders := benchScrapeOrders(numSeries, numOrders)
+				if order == "stable" {
+					orders = orders[:1]
+				}
+				scrapes := make([][]byte, 0, len(orders))
+				for _, o := range orders {
+					scrapes = append(scrapes, makeTestGaugesInOrder(o))
+				}
+
+				sl, _ := newTestScrapeLoop(b, withAppendable(teststorage.NewAppendable().SkipRecording(true), appV2))
+				ts := time.Time{}
+				appendScrape := func(run int) {
+					app := sl.appender()
+					ts = ts.Add(time.Second)
+					if _, _, _, err := app.append(scrapes[run%len(scrapes)], "text/plain", ts); err != nil {
+						b.Fatal(err)
+					}
+					// Reset the appender without retaining benchmark data.
+					if err := app.Rollback(); err != nil {
+						b.Fatal(err)
+					}
+				}
+
+				// Learn the order and release the map for stable input.
+				for run := range numOrders + orderedRunsBeforeRelease {
+					appendScrape(run)
+				}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for run := 0; b.Loop(); run++ {
+					appendScrape(run)
+				}
+			})
+		}
+	}
+}
+
 // BenchmarkScrapeLoopAppend_HistogramsWithExemplars benchmarks OM scrapes with histograms full of exemplars.
 //
 // For e2e TSDB impact, we enable the TSDB exemplar storage
@@ -3045,11 +3206,544 @@ func testScrapeLoopSeriesRefChange(t *testing.T, appV2 bool) {
 
 			teststorage.RequireEqual(t, tc.expectedSamples, app.ResultSamples())
 
-			ce, ok := sl.cache.series["metric_a"]
+			ce, ok := cachedEntry(t, sl.cache, "metric_a")
 			require.True(t, ok)
 			require.Equal(t, tc.expectedRef, ce.ref)
 		})
 	}
+}
+
+// cachedSlot returns the slot for met.
+func cachedSlot(t testing.TB, c *scrapeCache, met string) (cacheSlot, bool) {
+	t.Helper()
+	for _, slot := range c.slots {
+		if c.metOf(slot) == met {
+			return slot, true
+		}
+	}
+	return 0, false
+}
+
+// cachedEntry returns the non-dropped entry for met.
+func cachedEntry(t testing.TB, c *scrapeCache, met string) (cacheEntry, bool) {
+	t.Helper()
+	slot, ok := cachedSlot(t, c, met)
+	if !ok || slot.dropped() {
+		return cacheEntry{}, false
+	}
+	return c.entries[slot.index()], true
+}
+
+// requireCacheConsistent checks slot uniqueness and the optional map index.
+func requireCacheConsistent(t testing.TB, c *scrapeCache) {
+	t.Helper()
+
+	seen := make(map[cacheSlot]string, len(c.slots))
+	for _, slot := range c.slots {
+		met := c.metOf(slot)
+		require.NotContains(t, seen, slot, "slot of %q is used twice", met)
+		seen[slot] = met
+	}
+	require.Len(t, seen, len(c.slots))
+
+	if c.lookup == nil {
+		return
+	}
+	index := make(map[string]cacheSlot, len(c.slots))
+	for slot, met := range seen {
+		index[met] = slot
+	}
+	require.Equal(t, index, c.lookup, "map index and series order disagree")
+}
+
+// cacheOrder returns the expected metric order.
+func cacheOrder(c *scrapeCache) []string {
+	order := make([]string, 0, len(c.slots))
+	for _, slot := range c.slots {
+		order = append(order, c.metOf(slot))
+	}
+	return order
+}
+
+// cacheScraper drives a scrapeCache like the append loop.
+type cacheScraper struct {
+	c       *scrapeCache
+	dropped map[string]bool
+	nextRef storage.SeriesRef
+}
+
+func newCacheScraper(c *scrapeCache, dropped ...string) *cacheScraper {
+	s := &cacheScraper{c: c, dropped: map[string]bool{}}
+	for _, met := range dropped {
+		s.dropped[met] = true
+	}
+	return s
+}
+
+// feed adds uncached metrics and returns cache misses.
+func (s *cacheScraper) feed(mets ...string) []string {
+	var missed []string
+	for _, met := range mets {
+		slot, ce, cached, _ := s.c.get([]byte(met))
+		switch {
+		case cached && slot.dropped():
+			continue
+		case cached:
+			s.c.trackStaleness(ce.ref, slot)
+			continue
+		}
+
+		missed = append(missed, met)
+		if s.dropped[met] {
+			s.c.addDropped([]byte(met))
+			continue
+		}
+		s.nextRef++
+		slot, ce = s.c.addRef([]byte(met), s.nextRef, labels.FromStrings(model.MetricNameLabel, met), 0)
+		s.c.trackStaleness(ce.ref, slot)
+	}
+	return missed
+}
+
+// scrape runs feed and iterDone.
+func (s *cacheScraper) scrape(success bool, mets ...string) []string {
+	missed := s.feed(mets...)
+	s.c.iterDone(success)
+	return missed
+}
+
+func TestScrapeCacheSeriesOrder(t *testing.T) {
+	type scrape struct {
+		mets      []string
+		expMissed []string
+		expOrder  []string
+	}
+	for _, tc := range []struct {
+		name    string
+		dropped []string
+		scrapes []scrape
+	}{
+		{
+			name: "stable order is kept",
+			scrapes: []scrape{
+				{
+					mets:      []string{"a", "b", "c"},
+					expMissed: []string{"a", "b", "c"},
+					expOrder:  []string{"a", "b", "c"},
+				},
+				{
+					mets:     []string{"a", "b", "c"},
+					expOrder: []string{"a", "b", "c"},
+				},
+			},
+		},
+		{
+			name: "series added in the middle",
+			scrapes: []scrape{
+				{
+					mets:      []string{"a", "b", "c"},
+					expMissed: []string{"a", "b", "c"},
+					expOrder:  []string{"a", "b", "c"},
+				},
+				{
+					mets:      []string{"a", "x", "b", "c"},
+					expMissed: []string{"x"},
+					expOrder:  []string{"a", "x", "b", "c"},
+				},
+				{
+					mets:     []string{"a", "x", "b", "c"},
+					expOrder: []string{"a", "x", "b", "c"},
+				},
+			},
+		},
+		{
+			name: "series removed in the middle",
+			scrapes: []scrape{
+				{
+					mets:      []string{"a", "b", "c"},
+					expMissed: []string{"a", "b", "c"},
+					expOrder:  []string{"a", "b", "c"},
+				},
+				{
+					mets:     []string{"a", "c"},
+					expOrder: []string{"a", "c"},
+				},
+			},
+		},
+		{
+			name: "series removed at the end",
+			scrapes: []scrape{
+				{
+					mets:      []string{"a", "b", "c"},
+					expMissed: []string{"a", "b", "c"},
+					expOrder:  []string{"a", "b", "c"},
+				},
+				{
+					mets:     []string{"a", "b"},
+					expOrder: []string{"a", "b"},
+				},
+			},
+		},
+		{
+			name: "order is reversed",
+			scrapes: []scrape{
+				{
+					mets:      []string{"a", "b", "c"},
+					expMissed: []string{"a", "b", "c"},
+					expOrder:  []string{"a", "b", "c"},
+				},
+				{
+					mets:     []string{"c", "b", "a"},
+					expOrder: []string{"c", "b", "a"},
+				},
+				{
+					mets:     []string{"c", "b", "a"},
+					expOrder: []string{"c", "b", "a"},
+				},
+			},
+		},
+		{
+			name: "every series replaced",
+			scrapes: []scrape{
+				{
+					mets:      []string{"a", "b"},
+					expMissed: []string{"a", "b"},
+					expOrder:  []string{"a", "b"},
+				},
+				{
+					mets:      []string{"c", "d"},
+					expMissed: []string{"c", "d"},
+					expOrder:  []string{"c", "d"},
+				},
+			},
+		},
+		{
+			name: "series exposed twice in a row",
+			scrapes: []scrape{
+				{
+					mets:      []string{"a", "a", "b"},
+					expMissed: []string{"a", "b"},
+					expOrder:  []string{"a", "b"},
+				},
+				{
+					mets:     []string{"a", "a", "b"},
+					expOrder: []string{"a", "b"},
+				},
+			},
+		},
+		{
+			name: "series exposed twice with another series in between",
+			scrapes: []scrape{
+				{
+					mets:      []string{"a", "b", "a"},
+					expMissed: []string{"a", "b"},
+					expOrder:  []string{"a", "b"},
+				},
+				{
+					mets:     []string{"a", "b", "a"},
+					expOrder: []string{"a", "b"},
+				},
+			},
+		},
+		{
+			name:    "dropped series keep their place in the order",
+			dropped: []string{"b"},
+			scrapes: []scrape{
+				{
+					mets:      []string{"a", "b", "c"},
+					expMissed: []string{"a", "b", "c"},
+					expOrder:  []string{"a", "b", "c"},
+				},
+				{
+					mets:     []string{"a", "b", "c"},
+					expOrder: []string{"a", "b", "c"},
+				},
+				{
+					mets:     []string{"a", "c"},
+					expOrder: []string{"a", "c"},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newScrapeCache(newTestScrapeMetrics(t))
+			s := newCacheScraper(c, tc.dropped...)
+
+			for i, scrape := range tc.scrapes {
+				missed := s.scrape(true, scrape.mets...)
+				require.Equal(t, scrape.expMissed, missed, "unexpected cache misses in scrape %d", i)
+				require.Equal(t, scrape.expOrder, cacheOrder(c), "unexpected series order after scrape %d", i)
+				requireCacheConsistent(t, c)
+			}
+		})
+	}
+}
+
+func TestScrapeCacheReleasesMapOnStableOrder(t *testing.T) {
+	c := newScrapeCache(newTestScrapeMetrics(t))
+	s := newCacheScraper(c, "b")
+
+	// Adding series builds the map index.
+	s.scrape(true, "a", "b", "c")
+	require.NotNil(t, c.lookup)
+
+	for range orderedRunsBeforeRelease {
+		require.NotNil(t, c.lookup, "map index released too early")
+		s.scrape(true, "a", "b", "c")
+	}
+	require.Nil(t, c.lookup, "map index should be released for a target with a stable order")
+
+	// An order change rebuilds the map.
+	require.Empty(t, s.scrape(true, "a", "b", "c"))
+	require.Nil(t, c.lookup)
+
+	require.Equal(t, []string{"x"}, s.scrape(true, "a", "b", "x", "c"))
+	require.NotNil(t, c.lookup)
+	require.Equal(t, []string{"a", "b", "x", "c"}, cacheOrder(c))
+}
+
+func TestScrapeCacheRandomOrder(t *testing.T) {
+	const numSeries = 200
+
+	c := newScrapeCache(newTestScrapeMetrics(t))
+	s := newCacheScraper(c)
+
+	mets := make([]string, 0, numSeries)
+	for i := range numSeries {
+		mets = append(mets, fmt.Sprintf("metric_%d", i))
+	}
+	require.Len(t, s.scrape(true, mets...), numSeries)
+
+	// Shuffling must not lose or duplicate entries.
+	rnd := rand.New(rand.NewPCG(0, 0))
+	for range 10 {
+		rnd.Shuffle(len(mets), func(i, j int) { mets[i], mets[j] = mets[j], mets[i] })
+
+		require.Empty(t, s.scrape(true, mets...), "shuffled series should all be cached")
+		require.Equal(t, mets, cacheOrder(c))
+		require.Len(t, c.entries, numSeries)
+		requireCacheConsistent(t, c)
+		require.NotNil(t, c.lookup, "map index should be kept for a target with a random order")
+	}
+}
+
+func TestScrapeCacheLookupsDoNotAllocate(t *testing.T) {
+	const numSeries = 100
+
+	c := newScrapeCache(newTestScrapeMetrics(t))
+	s := newCacheScraper(c, `metric_a{foo="7"}`)
+
+	var (
+		mets [][]byte
+		strs []string
+	)
+	for i := range numSeries {
+		met := fmt.Sprintf("metric_a{foo=%q}", strconv.Itoa(i))
+		strs = append(strs, met)
+		mets = append(mets, []byte(met))
+	}
+
+	// Release the map before measuring allocations.
+	for range orderedRunsBeforeRelease + 2 {
+		s.scrape(true, strs...)
+	}
+	require.Nil(t, c.lookup)
+
+	missing := 0
+	allocs := testing.AllocsPerRun(100, func() {
+		for _, met := range mets {
+			if _, _, ok, _ := c.get(met); !ok {
+				missing++
+			}
+		}
+		c.iterDone(true)
+	})
+	require.Zero(t, missing)
+	require.Zero(t, allocs, "looking up cached series of a target with a stable order should not allocate")
+}
+
+func TestScrapeCacheDroppedSeriesLifecycle(t *testing.T) {
+	c := newScrapeCache(newTestScrapeMetrics(t))
+	s := newCacheScraper(c, "dropped")
+
+	require.Equal(t, []string{"kept", "dropped"}, s.scrape(true, "kept", "dropped"))
+
+	// Cached drops skip relabeling.
+	require.Empty(t, s.scrape(true, "kept", "dropped"))
+
+	// Failed scrapes do not evict entries.
+	s.scrape(false, "kept", "dropped")
+	require.Equal(t, []string{"kept", "dropped"}, cacheOrder(c))
+
+	// Successful scrapes evict missing entries immediately.
+	s.scrape(true, "kept")
+	require.Equal(t, []string{"kept"}, cacheOrder(c))
+
+	// Returning series are relabeled again.
+	require.Equal(t, []string{"dropped"}, s.scrape(true, "kept", "dropped"))
+}
+
+func TestScrapeCacheCompaction(t *testing.T) {
+	const numSeries = 5000
+
+	c := newScrapeCache(newTestScrapeMetrics(t))
+	s := newCacheScraper(c, "dropped")
+
+	mets := []string{"kept", "dropped"}
+	for i := range numSeries {
+		mets = append(mets, fmt.Sprintf("metric_%d", i))
+	}
+	s.scrape(true, mets...)
+	require.Len(t, c.entries, numSeries+1)
+	require.Len(t, c.dropped, 1)
+
+	// Release storage after a cardinality peak.
+	s.scrape(true, "kept")
+	require.Equal(t, []string{"kept"}, cacheOrder(c))
+	require.Less(t, len(c.entries), numSeries, "entry storage was not compacted")
+	require.Empty(t, c.dropped)
+	require.Empty(t, c.freeEntries)
+	require.Empty(t, c.freeDropped)
+
+	// Compaction preserves surviving entries.
+	require.Empty(t, s.scrape(true, "kept"))
+	ce, ok := cachedEntry(t, c, "kept")
+	require.True(t, ok)
+	require.Equal(t, storage.SeriesRef(1), ce.ref)
+	require.Equal(t, labels.FromStrings(model.MetricNameLabel, "kept"), ce.lset)
+
+	// Released dropped entries can be cached again.
+	require.Equal(t, []string{"dropped"}, s.scrape(true, "kept", "dropped"))
+	require.Empty(t, s.scrape(true, "kept", "dropped"))
+	requireCacheConsistent(t, c)
+}
+
+func TestScrapeCacheCompactsOnlyAfterCompleteScrape(t *testing.T) {
+	const numSeries = 1100
+
+	c := newScrapeCache(newTestScrapeMetrics(t))
+	s := newCacheScraper(c)
+
+	mets := make([]string, 0, numSeries)
+	for i := range numSeries {
+		mets = append(mets, fmt.Sprintf("metric_%d", i))
+	}
+
+	// Failed scrapes may clean up but must not compact storage.
+	s.scrape(false, mets...)
+	s.scrape(false, mets[0])
+	require.Equal(t, []string{mets[0]}, cacheOrder(c))
+	require.Len(t, c.entries, numSeries, "failed scrape should not compact entry storage")
+	require.Len(t, c.freeEntries, numSeries-1)
+
+	// Successful scrapes may compact after cleanup.
+	s.scrape(true, mets[0])
+	require.Len(t, c.entries, 1)
+	require.Empty(t, c.freeEntries)
+}
+
+func TestScrapeCacheStalenessSlotsSurviveCompaction(t *testing.T) {
+	const numSeries = 1024
+
+	c := newScrapeCache(newTestScrapeMetrics(t))
+	s := newCacheScraper(c)
+
+	mets := make([]string, 0, numSeries)
+	for i := range numSeries {
+		mets = append(mets, fmt.Sprintf("metric_%d", i))
+	}
+	s.scrape(true, mets...)
+
+	// Keep the series that was added last, so that compaction has to move it.
+	kept := mets[len(mets)-1]
+	keptRef := s.nextRef
+
+	s.feed(kept)
+	keptSlot, ok := cachedSlot(t, c, kept)
+	require.True(t, ok)
+	oldLookup := c.lookup
+	// Multiple refs may point to one slot.
+	otherRef := keptRef + 1
+	c.trackStaleness(otherRef, keptSlot)
+	stale := map[storage.SeriesRef]labels.Labels{}
+	c.forEachStale(func(ref storage.SeriesRef, lset labels.Labels) bool {
+		stale[ref] = lset
+		return true
+	})
+	require.Len(t, stale, numSeries-1, "every series but one went stale")
+	require.NotContains(t, stale, keptRef)
+
+	// Compaction must rewrite staleness slots.
+	c.iterDone(true)
+	require.Less(t, len(c.entries), numSeries, "entry storage was not compacted")
+	newSlot, ok := cachedSlot(t, c, kept)
+	require.True(t, ok)
+	require.NotEqual(t, keptSlot, newSlot, "the surviving slot should have moved")
+	require.Equal(t, newSlot, c.seriesPrev[keptRef])
+	require.Equal(t, newSlot, c.seriesPrev[otherRef])
+	require.Equal(t, newSlot, c.lookup[kept])
+	require.Equal(t, keptSlot, oldLookup[kept], "compaction should rebuild the lookup map")
+
+	// Staleness must survive a moved slot.
+	s.feed()
+	stale = map[storage.SeriesRef]labels.Labels{}
+	c.forEachStale(func(ref storage.SeriesRef, lset labels.Labels) bool {
+		stale[ref] = lset
+		return true
+	})
+	require.Equal(t, map[storage.SeriesRef]labels.Labels{
+		keptRef: labels.FromStrings(model.MetricNameLabel, kept),
+	}, stale)
+}
+
+func TestScrapeLoopAppendDroppedSeriesCached(t *testing.T) {
+	foreachAppendable(t, func(t *testing.T, appV2 bool) {
+		mutations := 0
+		sl, _ := newTestScrapeLoop(t, withAppendable(teststorage.NewAppendable(), appV2), func(sl *scrapeLoop) {
+			sl.sampleMutator = func(l labels.Labels) labels.Labels {
+				if l.Has("drop") {
+					mutations++
+					return labels.EmptyLabels()
+				}
+				return l
+			}
+		})
+
+		app := sl.appender()
+		_, _, _, err := app.append([]byte("dropped{drop=\"yes\"} 1\n"), "text/plain", time.Time{})
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		require.Equal(t, 1, mutations)
+
+		app = sl.appender()
+		_, _, _, err = app.append([]byte("dropped{drop=\"yes\"} 2\n"), "text/plain", time.Unix(1, 0))
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		require.Equal(t, 1, mutations)
+	})
+}
+
+func TestScrapeCacheStalenessSlotsSurviveGrowth(t *testing.T) {
+	c := newScrapeCache(newTestScrapeMetrics(t))
+	s := newCacheScraper(c)
+
+	s.scrape(true, "kept")
+	keptRef := s.nextRef
+
+	// Growth must not invalidate staleness slots.
+	mets := make([]string, 0, 1024)
+	for i := range 1024 {
+		mets = append(mets, fmt.Sprintf("metric_%d", i))
+	}
+	s.feed(mets...)
+
+	var stale labels.Labels
+	c.forEachStale(func(_ storage.SeriesRef, lset labels.Labels) bool {
+		stale = lset
+		return true
+	})
+	require.Equal(t, labels.FromStrings(model.MetricNameLabel, "kept"), stale)
+	require.Equal(t, storage.SeriesRef(1), keptRef)
 }
 
 func TestScrapeLoopCache(t *testing.T) {
@@ -3079,14 +3773,14 @@ func testScrapeLoopCache(t *testing.T, appV2 bool) {
 	scraper.scrapeFunc = func(_ context.Context, w io.Writer) error {
 		switch numScrapes {
 		case 1, 2:
-			_, ok := sl.cache.series["metric_a"]
+			_, ok := cachedSlot(t, sl.cache, "metric_a")
 			require.True(t, ok, "metric_a missing from cache after scrape %d", numScrapes)
-			_, ok = sl.cache.series["metric_b"]
+			_, ok = cachedSlot(t, sl.cache, "metric_b")
 			require.True(t, ok, "metric_b missing from cache after scrape %d", numScrapes)
 		case 3:
-			_, ok := sl.cache.series["metric_a"]
+			_, ok := cachedSlot(t, sl.cache, "metric_a")
 			require.True(t, ok, "metric_a missing from cache after scrape %d", numScrapes)
-			_, ok = sl.cache.series["metric_b"]
+			_, ok = cachedSlot(t, sl.cache, "metric_b")
 			require.False(t, ok, "metric_b present in cache after scrape %d", numScrapes)
 		}
 
@@ -3162,7 +3856,8 @@ func testScrapeLoopCacheMemoryExhaustionProtection(t *testing.T, appV2 bool) {
 		require.FailNow(t, "Scrape wasn't stopped.")
 	}
 
-	require.LessOrEqual(t, len(sl.cache.series), 2000, "More than 2000 series cached.")
+	require.LessOrEqual(t, len(sl.cache.slots), 2000, "More than 2000 series cached.")
+	require.LessOrEqual(t, len(sl.cache.entries), 2000, "More than 2000 entries retained.")
 }
 
 func TestScrapeLoopAppend_HonorLabels(t *testing.T) {
@@ -3354,7 +4049,7 @@ func testScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T, appV2 bool) {
 	hash := lset.Hash()
 
 	// Create a fake entry in the cache
-	sl.cache.addRef(metric, fakeRef, lset, hash)
+	_, _ = sl.cache.addRef(metric, fakeRef, lset, hash)
 	now := time.Now()
 
 	app := sl.appender()
@@ -5621,8 +6316,8 @@ func testScrapeAddFast(t *testing.T, appV2 bool) {
 
 	// Poison the cache. There is just one entry, and one series in the
 	// storage. Changing the ref will create a 'not found' error.
-	for _, v := range sl.getCache().series {
-		v.ref++
+	for _, slot := range sl.getCache().slots {
+		sl.getCache().entries[slot.index()].ref++
 	}
 
 	app = sl.appender()


### PR DESCRIPTION
Cached data uses slices because targets usually preserve series order. This allows lookup by the next expected index without maintaining a map. A map index is built only when the order changes.

### Benchmark

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/scrape
cpu: Apple M2 Max
                                                             │  before.txt   │              after.txt              │
                                                             │    sec/op     │    sec/op     vs base               │
ScrapeCacheGet/numSeries=100/order=stable/dropped=false-2      1644.0n ±  5%   682.5n ±  2%  -58.49% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100/order=stable/dropped=true-2       1680.5n ± 15%   649.3n ±  3%  -61.36% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100/order=churn/dropped=false-2        1.771µ ±  5%   1.227µ ±  4%  -30.70% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100/order=churn/dropped=true-2         1.738µ ±  5%   1.249µ ± 29%  -28.14% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100/order=random/dropped=false-2       1.622µ ± 13%   1.644µ ± 11%        ~ (p=0.485 n=6)
ScrapeCacheGet/numSeries=100/order=random/dropped=true-2        1.687µ ±  7%   1.705µ ±  8%        ~ (p=0.372 n=6)
ScrapeCacheGet/numSeries=2000/order=stable/dropped=false-2      40.51µ ±  1%   14.06µ ±  3%  -65.28% (p=0.002 n=6)
ScrapeCacheGet/numSeries=2000/order=stable/dropped=true-2       39.42µ ±  1%   13.22µ ±  2%  -66.48% (p=0.002 n=6)
ScrapeCacheGet/numSeries=2000/order=churn/dropped=false-2       40.97µ ±  1%   29.05µ ± 24%  -29.09% (p=0.002 n=6)
ScrapeCacheGet/numSeries=2000/order=churn/dropped=true-2        39.36µ ±  1%   25.49µ ±  6%  -35.25% (p=0.002 n=6)
ScrapeCacheGet/numSeries=2000/order=random/dropped=false-2      51.12µ ±  1%   44.64µ ±  1%  -12.69% (p=0.002 n=6)
ScrapeCacheGet/numSeries=2000/order=random/dropped=true-2       50.48µ ±  3%   46.24µ ± 16%        ~ (p=0.065 n=6)
ScrapeCacheGet/numSeries=100000/order=stable/dropped=false-2   2684.0µ ±  3%   761.3µ ± 11%  -71.63% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100000/order=stable/dropped=true-2    2356.3µ ±  1%   734.9µ ± 33%  -68.81% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100000/order=churn/dropped=false-2     2.554m ±  2%   2.226m ±  3%  -12.86% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100000/order=churn/dropped=true-2      2.342m ±  1%   2.134m ± 21%        ~ (p=0.180 n=6)
ScrapeCacheGet/numSeries=100000/order=random/dropped=false-2    6.234m ±  9%   4.739m ± 34%  -23.99% (p=0.026 n=6)
ScrapeCacheGet/numSeries=100000/order=random/dropped=true-2     5.332m ± 14%   5.047m ± 20%        ~ (p=0.394 n=6)
ScrapeLoopAppendSeriesOrder/appV2=false/order=stable-2          398.7µ ± 14%   351.0µ ± 20%  -11.96% (p=0.041 n=6)
ScrapeLoopAppendSeriesOrder/appV2=false/order=random-2          433.1µ ±  5%   439.5µ ±  9%        ~ (p=0.132 n=6)
ScrapeLoopAppendSeriesOrder/appV2=true/order=stable-2           429.7µ ± 12%   395.5µ ± 10%   -7.96% (p=0.026 n=6)
ScrapeLoopAppendSeriesOrder/appV2=true/order=random-2           459.1µ ±  3%   465.0µ ±  4%        ~ (p=0.132 n=6)
geomean                                                         88.39µ         59.18µ        -33.04%

                                                             │   before.txt   │               after.txt               │
                                                             │      B/op      │     B/op      vs base                 │
ScrapeCacheGet/numSeries=100/order=stable/dropped=false-2        0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100/order=stable/dropped=true-2         0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100/order=churn/dropped=false-2         80.00 ± 0%       32.00 ± 0%  -60.00% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100/order=churn/dropped=true-2          40.00 ± 0%       32.00 ± 0%  -20.00% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100/order=random/dropped=false-2        0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100/order=random/dropped=true-2         0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=2000/order=stable/dropped=false-2       0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=2000/order=stable/dropped=true-2        0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=2000/order=churn/dropped=false-2        87.00 ± 0%       39.00 ± 0%  -55.17% (p=0.002 n=6)
ScrapeCacheGet/numSeries=2000/order=churn/dropped=true-2         47.00 ± 0%       39.00 ± 0%  -17.02% (p=0.002 n=6)
ScrapeCacheGet/numSeries=2000/order=random/dropped=false-2       0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=2000/order=random/dropped=true-2        0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100000/order=stable/dropped=false-2     0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100000/order=stable/dropped=true-2      0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100000/order=churn/dropped=false-2      80.00 ± 0%       32.00 ± 3%  -60.00% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100000/order=churn/dropped=true-2       40.00 ± 0%       33.00 ± 3%  -17.50% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100000/order=random/dropped=false-2     0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100000/order=random/dropped=true-2      0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeLoopAppendSeriesOrder/appV2=false/order=stable-2         1.219Ki ± 0%     1.219Ki ± 0%        ~ (p=1.000 n=6) ¹
ScrapeLoopAppendSeriesOrder/appV2=false/order=random-2         1.219Ki ± 0%     1.219Ki ± 0%        ~ (p=1.000 n=6) ¹
ScrapeLoopAppendSeriesOrder/appV2=true/order=stable-2          1.266Ki ± 0%     1.266Ki ± 0%        ~ (p=1.000 n=6) ¹
ScrapeLoopAppendSeriesOrder/appV2=true/order=random-2          1.266Ki ± 0%     1.266Ki ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                                     ²                 -13.68%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                             │  before.txt  │              after.txt              │
                                                             │  allocs/op   │ allocs/op   vs base                 │
ScrapeCacheGet/numSeries=100/order=stable/dropped=false-2      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100/order=stable/dropped=true-2       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100/order=churn/dropped=false-2       2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100/order=churn/dropped=true-2        2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100/order=random/dropped=false-2      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100/order=random/dropped=true-2       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=2000/order=stable/dropped=false-2     0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=2000/order=stable/dropped=true-2      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=2000/order=churn/dropped=false-2      2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.002 n=6)
ScrapeCacheGet/numSeries=2000/order=churn/dropped=true-2       2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.002 n=6)
ScrapeCacheGet/numSeries=2000/order=random/dropped=false-2     0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=2000/order=random/dropped=true-2      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100000/order=stable/dropped=false-2   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100000/order=stable/dropped=true-2    0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100000/order=churn/dropped=false-2    2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100000/order=churn/dropped=true-2     2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.002 n=6)
ScrapeCacheGet/numSeries=100000/order=random/dropped=false-2   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeCacheGet/numSeries=100000/order=random/dropped=true-2    0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeLoopAppendSeriesOrder/appV2=false/order=stable-2         13.00 ± 0%     13.00 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeLoopAppendSeriesOrder/appV2=false/order=random-2         13.00 ± 0%     13.00 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeLoopAppendSeriesOrder/appV2=true/order=stable-2          14.00 ± 0%     14.00 ± 0%        ~ (p=1.000 n=6) ¹
ScrapeLoopAppendSeriesOrder/appV2=true/order=random-2          14.00 ± 0%     14.00 ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                                   ²               -17.22%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```


