### PR TITLE
tsdb: retry appends when GC retires the resolved series

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -11072,6 +11072,136 @@ func TestCompactSelectedSeries_OpenAppenderCommittingDuringCompaction(t *testing
 		"the late sample must survive restart, proving no tombstone was written for sel")
 }
 
+// selectedSeriesTestAppender adapts the v1 and v2 appenders to a common float-append
+// signature so the selected-series eviction tests below can run against both.
+type selectedSeriesTestAppender struct {
+	storage.AppenderTransaction
+	append func(storage.SeriesRef, labels.Labels, int64, float64) (storage.SeriesRef, error)
+}
+
+func requireSelectedSeriesSamples(t *testing.T, db *DB, lset labels.Labels, stage string, expected []chunks.Sample) {
+	t.Helper()
+
+	matchers := make([]*labels.Matcher, 0, lset.Len())
+	lset.Range(func(l labels.Label) {
+		matchers = append(matchers, labels.MustNewMatcher(labels.MatchEqual, l.Name, l.Value))
+	})
+	q, err := db.Querier(math.MinInt64, math.MaxInt64)
+	require.NoError(t, err)
+	result := query(t, q, matchers...)
+	require.Len(t, result, 1, "%s", stage)
+	requireEqualSamples(t, stage, expected, result[lset.String()])
+}
+
+func restartDBForSelectedSeries(t *testing.T, db *DB, opts *Options) *DB {
+	t.Helper()
+
+	dir := db.Dir()
+	require.NoError(t, db.Close())
+	restarted, err := Open(dir, nil, nil, opts, nil)
+	require.NoError(t, err)
+	restarted.DisableCompactions()
+	t.Cleanup(func() { require.NoError(t, restarted.Close()) })
+	return restarted
+}
+
+// TestCompactSelectedSeries_RetriesAfterSeriesEvicted verifies that an appender
+// which resolved a series just before eviction unlinked it retries against a live
+// series instead of appending into the evicted one.
+//
+// The append-ID watermark cannot cover this case: the appender has not reached the
+// series lock yet, so it has neither an append ID nor pending state when shouldEvict
+// runs. Both appender versions are exercised, in either isolation mode.
+func TestCompactSelectedSeries_RetriesAfterSeriesEvicted(t *testing.T) {
+	for _, appender := range []struct {
+		name string
+		new  func(*testing.T, *Head) selectedSeriesTestAppender
+	}{
+		{
+			name: "v1",
+			new: func(t *testing.T, h *Head) selectedSeriesTestAppender {
+				a := h.Appender(t.Context()).(*headAppender)
+				return selectedSeriesTestAppender{
+					AppenderTransaction: a,
+					append:              a.Append,
+				}
+			},
+		},
+		{
+			name: "v2",
+			new: func(t *testing.T, h *Head) selectedSeriesTestAppender {
+				a := h.AppenderV2(t.Context()).(*headAppenderV2)
+				return selectedSeriesTestAppender{
+					AppenderTransaction: a,
+					append: func(ref storage.SeriesRef, lset labels.Labels, ts int64, v float64) (storage.SeriesRef, error) {
+						return a.Append(ref, lset, 0, ts, v, nil, nil, storage.AOptions{})
+					},
+				}
+			},
+		},
+	} {
+		t.Run(appender.name, func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.MinBlockDuration = 1000
+			opts.MaxBlockDuration = 1000
+			db := newTestDB(t, withOpts(opts))
+			db.DisableCompactions()
+			h := db.Head()
+
+			lset := labels.FromStrings("series", "resolved-before-gc")
+			baseline := db.Appender(t.Context())
+			oldRef, err := baseline.Append(0, lset, 100, 1)
+			require.NoError(t, err)
+			require.NoError(t, baseline.Commit())
+			oldSeries := h.series.getByID(chunks.HeadSeriesRef(oldRef))
+			require.NotNil(t, oldSeries)
+
+			pending := appender.new(t, h)
+			lookupDone := make(chan struct{})
+			resumeAppend := make(chan struct{})
+			// Pause after the appender resolves oldSeries but before it can append,
+			// leaving it with a pointer that GC will unlink.
+			h.testAfterSeriesLookup = func(series *memSeries) {
+				if series != oldSeries {
+					return
+				}
+				close(lookupDone)
+				<-resumeAppend
+			}
+			t.Cleanup(func() { h.testAfterSeriesLookup = nil })
+
+			appendDone := make(chan error, 1)
+			go func() {
+				_, err := pending.append(oldRef, lset, 200, 2)
+				appendDone <- err
+			}()
+			select {
+			case <-lookupDone:
+			case appendErr := <-appendDone:
+				require.NoError(t, pending.Rollback())
+				t.Fatalf("append completed before reaching the series lookup hook: %v", appendErr)
+			}
+
+			// Delete the resolved series while the append is paused. On resume, the appender
+			// must retry against a live series rather than using this stale pointer.
+			compactErr := db.CompactSelectedSeries([]storage.SeriesRef{oldRef})
+			close(resumeAppend)
+			appendErr := <-appendDone
+			require.NoError(t, compactErr)
+			require.Len(t, db.Blocks(), 1, "selected-series compaction must produce a block")
+			require.NoError(t, appendErr)
+			require.NoError(t, pending.Commit())
+
+			// Compaction persisted t=100 in a block. The post-GC append at t=200
+			// must remain in Head and survive WAL replay under its replacement ref.
+			expected := []chunks.Sample{newSample(0, 100, 1, nil, nil), newSample(0, 200, 2, nil, nil)}
+			requireSelectedSeriesSamples(t, db, lset, "before WAL restart", expected)
+			db = restartDBForSelectedSeries(t, db, opts)
+			requireSelectedSeriesSamples(t, db, lset, "after WAL restart", expected)
+		})
+	}
+}
+
 // TestSelectedBlockNotMergedWithNonSelectedBlock reproduces the data-loss path
 // that occurs when a from-selected-series block is merged with a non-selected
 // block by ordinary leveled compaction.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -156,6 +156,7 @@ type Head struct {
 
 	memTruncationInProcess atomic.Bool
 	memTruncationCallBack  func() // For testing purposes.
+	testAfterSeriesLookup  func(*memSeries)
 }
 
 type ExemplarStorage interface {
@@ -2370,6 +2371,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 			s.locks[stripe].Lock()
 			defer s.locks[stripe].Unlock()
 		}
+		series.setRetired()
 
 		stale, isHist, buckets := series.sampleState()
 		if stale {
@@ -2577,6 +2579,7 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 			s.locks[stripe].Lock()
 			defer s.locks[stripe].Unlock()
 		}
+		series.setRetired()
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		stale, isHist, buckets := series.sampleState()
@@ -2776,11 +2779,12 @@ type memSeries struct {
 	nextAt                           int64 // Timestamp at which to cut the next chunk.
 	histogramChunkHasComputedEndTime bool  // True if nextAt has been predicted for the current histograms chunk; false otherwise.
 	pendingCommit                    bool  // Whether there are samples waiting to be committed to this series.
+	retired                          bool  // Whether the series has been unlinked from the head by GC.
 	// headChunkCount tracks the number of head chunks. All mutations of the
 	// headChunks/headChunkCount pair go through pushHeadChunk and setHeadChunks.
 	// Chunk counts are bounded by the 3-byte field in HeadChunkRef, so cannot overflow uint32.
 	// Explicitly uses sync/atomic.Uint32 (4 bytes) to fit in the existing padding
-	// between two bools and a float64.
+	// between three bools and a float64.
 	headChunkCount stdatomic.Uint32
 
 	// We keep the last value here (in addition to appending it to the chunk) so we can check for duplicates.
@@ -2797,6 +2801,22 @@ type memSeries struct {
 
 	// txs is nil if isolation is disabled.
 	txs *txRing
+}
+
+// isRetired reports whether GC has unlinked the series from the head. A retired
+// series still resolves through pointers that were handed out before it was
+// unlinked, but appending to it would silently drop the samples.
+//
+// Must be called with the series lock held.
+func (s *memSeries) isRetired() bool {
+	return s.retired
+}
+
+// setRetired marks the series as unlinked from the head.
+//
+// Must be called with the series lock held.
+func (s *memSeries) setRetired() {
+	s.retired = true
 }
 
 // sampleState reports the latest in-order sample's staleness, type, and bucket

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -443,10 +443,15 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
-	var err error
-	s, err = a.getOrCreateAndLock(s, lset)
-	if err != nil {
-		return 0, err
+	if hook := a.head.testAfterSeriesLookup; hook != nil {
+		hook(s)
+	}
+	if s == nil {
+		var err error
+		s, _, err = a.getOrCreate(lset)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	if value.IsStaleNaN(v) {
@@ -459,12 +464,8 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		// an optimization for the more likely case.
 		switch a.typesInBatch[s.ref] {
 		case stHistogram, stCustomBucketHistogram:
-			ref = storage.SeriesRef(s.ref)
-			s.Unlock()
 			return a.AppendHistogram(ref, lset, t, &histogram.Histogram{Sum: v}, nil)
 		case stFloatHistogram, stCustomBucketFloatHistogram:
-			ref = storage.SeriesRef(s.ref)
-			s.Unlock()
 			return a.AppendHistogram(ref, lset, t, nil, &histogram.FloatHistogram{Sum: v})
 		}
 		// Note that a series reference not yet in the map will come out
@@ -473,8 +474,10 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		// series" and "known series with stNone".
 	}
 
-	// Deferred from here rather than at the lookup: the staleness redirect above unlocks
-	// and hands the series to AppendHistogram, which takes the lock itself.
+	s, err := a.lockForAppend(s)
+	if err != nil {
+		return 0, err
+	}
 	defer s.Unlock()
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
@@ -518,15 +521,21 @@ func (a *headAppender) AppendSTZeroSample(ref storage.SeriesRef, lset labels.Lab
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
-	var err error
-	s, err = a.getOrCreateAndLock(s, lset)
-	if err != nil {
-		return 0, err
+	if s == nil {
+		var err error
+		s, _, err = a.getOrCreate(lset)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	// Check if ST wouldn't be OOO vs samples we already might have for this series.
 	// NOTE(bwplotka): This will be often hit as it's expected for long living
 	// counters to share the same ST.
+	s, err := a.lockForAppend(s)
+	if err != nil {
+		return 0, err
+	}
 	isOOO, _, err := s.appendable(st, 0, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if err == nil {
 		s.pendingCommit = true
@@ -568,29 +577,20 @@ func (a *headAppenderBase) getOrCreate(lset labels.Labels) (s *memSeries, create
 	return s, created, nil
 }
 
-// getOrCreateAndLock returns a live series with its lock held, creating it from lset if
-// s is nil. A series retired by GC after it was looked up is discarded and recreated
-// from its own labels.
-func (a *headAppenderBase) getOrCreateAndLock(s *memSeries, lset labels.Labels) (*memSeries, error) {
-	if hook := a.head.testAfterSeriesLookup; hook != nil {
-		hook(s)
-	}
+// lockForAppend returns a live series locked for append. It may replace s if GC retired it.
+func (a *headAppenderBase) lockForAppend(s *memSeries) (*memSeries, error) {
 	for {
-		if s == nil {
-			var err error
-			s, _, err = a.getOrCreate(lset)
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		s.Lock()
 		if !s.isRetired() {
 			return s, nil
 		}
-		lset = s.lset
+		lset := s.lset
 		s.Unlock()
-		s = nil
+
+		var err error
+		if s, _, err = a.getOrCreate(lset); err != nil {
+			return nil, err
+		}
 	}
 }
 
@@ -863,14 +863,20 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
-	var err error
-	s, err = a.getOrCreateAndLock(s, lset)
-	if err != nil {
-		return 0, err
+	if s == nil {
+		var err error
+		s, _, err = a.getOrCreate(lset)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	switch {
 	case h != nil:
+		var lockErr error
+		if s, lockErr = a.lockForAppend(s); lockErr != nil {
+			return 0, lockErr
+		}
 		// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 		// to skip that sample from the WAL and write only in the WBL.
 		_, delta, err := s.appendableHistogram(t, h, a.headMaxt, a.minValidTime, a.oooTimeWindow)
@@ -902,6 +908,10 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 		})
 		b.histogramSeries = append(b.histogramSeries, s)
 	case fh != nil:
+		var lockErr error
+		if s, lockErr = a.lockForAppend(s); lockErr != nil {
+			return 0, lockErr
+		}
 		// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 		// to skip that sample from the WAL and write only in the WBL.
 		_, delta, err := s.appendableFloatHistogram(t, fh, a.headMaxt, a.minValidTime, a.oooTimeWindow)
@@ -932,8 +942,6 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 			FH:  fh,
 		})
 		b.floatHistogramSeries = append(b.floatHistogramSeries, s)
-	default:
-		s.Unlock()
 	}
 
 	return storage.SeriesRef(s.ref), nil
@@ -945,10 +953,12 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
-	var err error
-	s, err = a.getOrCreateAndLock(s, lset)
-	if err != nil {
-		return 0, err
+	if s == nil {
+		var err error
+		s, _, err = a.getOrCreate(lset)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	switch {
@@ -960,6 +970,10 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 			Schema:        h.Schema,
 			ZeroThreshold: h.ZeroThreshold,
 			CustomValues:  h.CustomValues,
+		}
+		var lockErr error
+		if s, lockErr = a.lockForAppend(s); lockErr != nil {
+			return 0, lockErr
 		}
 		// For STZeroSamples OOO is not allowed.
 		// We set it to true to make this implementation as close as possible to the float implementation.
@@ -1002,6 +1016,10 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 			ZeroThreshold: fh.ZeroThreshold,
 			CustomValues:  fh.CustomValues,
 		}
+		var lockErr error
+		if s, lockErr = a.lockForAppend(s); lockErr != nil {
+			return 0, lockErr
+		}
 		// We set it to true to make this implementation as close as possible to the float implementation.
 		isOOO, _, err := s.appendableFloatHistogram(st, zeroFloatHistogram, a.headMaxt, a.minValidTime, a.oooTimeWindow) // OOO is not allowed for STZeroSamples.
 		if err != nil {
@@ -1033,8 +1051,6 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 			FH:  zeroFloatHistogram,
 		})
 		b.floatHistogramSeries = append(b.floatHistogramSeries, s)
-	default:
-		s.Unlock()
 	}
 
 	return storage.SeriesRef(s.ref), nil

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -443,12 +443,10 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
-	if s == nil {
-		var err error
-		s, _, err = a.getOrCreate(lset)
-		if err != nil {
-			return 0, err
-		}
+	var err error
+	s, err = a.getOrCreateAndLock(s, lset)
+	if err != nil {
+		return 0, err
 	}
 
 	if value.IsStaleNaN(v) {
@@ -461,8 +459,12 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		// an optimization for the more likely case.
 		switch a.typesInBatch[s.ref] {
 		case stHistogram, stCustomBucketHistogram:
+			ref = storage.SeriesRef(s.ref)
+			s.Unlock()
 			return a.AppendHistogram(ref, lset, t, &histogram.Histogram{Sum: v}, nil)
 		case stFloatHistogram, stCustomBucketFloatHistogram:
+			ref = storage.SeriesRef(s.ref)
+			s.Unlock()
 			return a.AppendHistogram(ref, lset, t, nil, &histogram.FloatHistogram{Sum: v})
 		}
 		// Note that a series reference not yet in the map will come out
@@ -471,7 +473,8 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		// series" and "known series with stNone".
 	}
 
-	s.Lock()
+	// Deferred from here rather than at the lookup: the staleness redirect above unlocks
+	// and hands the series to AppendHistogram, which takes the lock itself.
 	defer s.Unlock()
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
@@ -515,18 +518,15 @@ func (a *headAppender) AppendSTZeroSample(ref storage.SeriesRef, lset labels.Lab
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
-	if s == nil {
-		var err error
-		s, _, err = a.getOrCreate(lset)
-		if err != nil {
-			return 0, err
-		}
+	var err error
+	s, err = a.getOrCreateAndLock(s, lset)
+	if err != nil {
+		return 0, err
 	}
 
 	// Check if ST wouldn't be OOO vs samples we already might have for this series.
 	// NOTE(bwplotka): This will be often hit as it's expected for long living
 	// counters to share the same ST.
-	s.Lock()
 	isOOO, _, err := s.appendable(st, 0, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if err == nil {
 		s.pendingCommit = true
@@ -566,6 +566,32 @@ func (a *headAppenderBase) getOrCreate(lset labels.Labels) (s *memSeries, create
 		a.series = append(a.series, s)
 	}
 	return s, created, nil
+}
+
+// getOrCreateAndLock returns a live series with its lock held, creating it from lset if
+// s is nil. A series retired by GC after it was looked up is discarded and recreated
+// from its own labels.
+func (a *headAppenderBase) getOrCreateAndLock(s *memSeries, lset labels.Labels) (*memSeries, error) {
+	if hook := a.head.testAfterSeriesLookup; hook != nil {
+		hook(s)
+	}
+	for {
+		if s == nil {
+			var err error
+			s, _, err = a.getOrCreate(lset)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		s.Lock()
+		if !s.isRetired() {
+			return s, nil
+		}
+		lset = s.lset
+		s.Unlock()
+		s = nil
+	}
 }
 
 // getCurrentBatch returns the current batch if it fits the provided sampleType
@@ -837,17 +863,14 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
-	if s == nil {
-		var err error
-		s, _, err = a.getOrCreate(lset)
-		if err != nil {
-			return 0, err
-		}
+	var err error
+	s, err = a.getOrCreateAndLock(s, lset)
+	if err != nil {
+		return 0, err
 	}
 
 	switch {
 	case h != nil:
-		s.Lock()
 		// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 		// to skip that sample from the WAL and write only in the WBL.
 		_, delta, err := s.appendableHistogram(t, h, a.headMaxt, a.minValidTime, a.oooTimeWindow)
@@ -879,7 +902,6 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 		})
 		b.histogramSeries = append(b.histogramSeries, s)
 	case fh != nil:
-		s.Lock()
 		// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 		// to skip that sample from the WAL and write only in the WBL.
 		_, delta, err := s.appendableFloatHistogram(t, fh, a.headMaxt, a.minValidTime, a.oooTimeWindow)
@@ -910,6 +932,8 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 			FH:  fh,
 		})
 		b.floatHistogramSeries = append(b.floatHistogramSeries, s)
+	default:
+		s.Unlock()
 	}
 
 	return storage.SeriesRef(s.ref), nil
@@ -921,12 +945,10 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
-	if s == nil {
-		var err error
-		s, _, err = a.getOrCreate(lset)
-		if err != nil {
-			return 0, err
-		}
+	var err error
+	s, err = a.getOrCreateAndLock(s, lset)
+	if err != nil {
+		return 0, err
 	}
 
 	switch {
@@ -939,7 +961,6 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 			ZeroThreshold: h.ZeroThreshold,
 			CustomValues:  h.CustomValues,
 		}
-		s.Lock()
 		// For STZeroSamples OOO is not allowed.
 		// We set it to true to make this implementation as close as possible to the float implementation.
 		isOOO, _, err := s.appendableHistogram(st, zeroHistogram, a.headMaxt, a.minValidTime, a.oooTimeWindow)
@@ -981,7 +1002,6 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 			ZeroThreshold: fh.ZeroThreshold,
 			CustomValues:  fh.CustomValues,
 		}
-		s.Lock()
 		// We set it to true to make this implementation as close as possible to the float implementation.
 		isOOO, _, err := s.appendableFloatHistogram(st, zeroFloatHistogram, a.headMaxt, a.minValidTime, a.oooTimeWindow) // OOO is not allowed for STZeroSamples.
 		if err != nil {
@@ -1013,6 +1033,8 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 			FH:  zeroFloatHistogram,
 		})
 		b.floatHistogramSeries = append(b.floatHistogramSeries, s)
+	default:
+		s.Unlock()
 	}
 
 	return storage.SeriesRef(s.ref), nil

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -136,20 +136,28 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
-	s, valErr = a.getOrCreateAndLock(s, ls)
-	if valErr != nil {
-		return 0, valErr
+	if hook := a.head.testAfterSeriesLookup; hook != nil {
+		hook(s)
+	}
+	if s == nil {
+		s, _, valErr = a.getOrCreate(ls)
+		if valErr != nil {
+			return 0, valErr
+		}
 	}
 
 	if a.head.opts.EnableSTAsZeroSample && st != 0 {
-		a.bestEffortAppendSTZeroSample(s, ls, st, t, h, fh)
+		s = a.bestEffortAppendSTZeroSample(s, ls, st, t, h, fh)
 	}
 
+	var appended *memSeries
 	switch {
 	case fh != nil:
 		isStale = value.IsStaleNaN(fh.Sum)
+		appended, appErr = a.appendFloatHistogram(s, st, t, fh, opts.RejectOutOfOrder)
 	case h != nil:
 		isStale = value.IsStaleNaN(h.Sum)
+		appended, appErr = a.appendHistogram(s, st, t, h, opts.RejectOutOfOrder)
 	default:
 		isStale = value.IsStaleNaN(v)
 		if isStale {
@@ -162,12 +170,10 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 			// an optimization for the more likely case.
 			switch a.typesInBatch[s.ref] {
 			case stHistogram, stCustomBucketHistogram:
-				s.Unlock()
 				return a.Append(storage.SeriesRef(s.ref), ls, st, t, 0, &histogram.Histogram{Sum: v}, nil, storage.AOptions{
 					RejectOutOfOrder: opts.RejectOutOfOrder,
 				})
 			case stFloatHistogram, stCustomBucketFloatHistogram:
-				s.Unlock()
 				return a.Append(storage.SeriesRef(s.ref), ls, st, t, 0, nil, &histogram.FloatHistogram{Sum: v}, storage.AOptions{
 					RejectOutOfOrder: opts.RejectOutOfOrder,
 				})
@@ -177,17 +183,8 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 			// we do not need to check for the difference between "unknown
 			// series" and "known series with stNone".
 		}
+		appended, appErr = a.appendFloat(s, st, t, v, opts.RejectOutOfOrder)
 	}
-
-	switch {
-	case fh != nil:
-		appErr = a.appendFloatHistogram(s, st, t, fh, opts.RejectOutOfOrder)
-	case h != nil:
-		appErr = a.appendHistogram(s, st, t, h, opts.RejectOutOfOrder)
-	default:
-		appErr = a.appendFloat(s, st, t, v, opts.RejectOutOfOrder)
-	}
-	s.Unlock()
 	// Handle append error, if any.
 	if appErr != nil {
 		switch {
@@ -198,6 +195,7 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 		}
 		return 0, appErr
 	}
+	s = appended
 
 	if isStale {
 		// For stale values we never attempt to process metadata/exemplars, claim the success.
@@ -227,46 +225,56 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	return storage.SeriesRef(s.ref), partialErr
 }
 
-// The caller must hold the series lock.
-func (a *headAppenderV2) appendFloat(s *memSeries, st, t int64, v float64, fastRejectOOO bool) error {
+func (a *headAppenderV2) appendFloat(s *memSeries, st, t int64, v float64, fastRejectOOO bool) (*memSeries, error) {
+	s, err := a.lockForAppend(s)
+	if err != nil {
+		return nil, err
+	}
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
 	isOOO, delta, err := s.appendable(t, v, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if isOOO && fastRejectOOO {
-		return storage.ErrOutOfOrderSample
+		s.Unlock()
+		return nil, storage.ErrOutOfOrderSample
 	}
 	if err == nil {
 		s.pendingCommit = true
 	}
+	s.Unlock()
 	if delta > 0 {
 		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	b := a.getCurrentBatch(stFloat, s.ref)
 	b.floats = append(b.floats, record.RefSample{Ref: s.ref, ST: st, T: t, V: v})
 	b.floatSeries = append(b.floatSeries, s)
-	return nil
+	return s, nil
 }
 
-// The caller must hold the series lock.
-func (a *headAppenderV2) appendHistogram(s *memSeries, st, t int64, h *histogram.Histogram, fastRejectOOO bool) error {
+func (a *headAppenderV2) appendHistogram(s *memSeries, st, t int64, h *histogram.Histogram, fastRejectOOO bool) (*memSeries, error) {
+	s, err := a.lockForAppend(s)
+	if err != nil {
+		return nil, err
+	}
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
 	isOOO, delta, err := s.appendableHistogram(t, h, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if isOOO && fastRejectOOO {
-		return storage.ErrOutOfOrderSample
+		s.Unlock()
+		return nil, storage.ErrOutOfOrderSample
 	}
 	if err == nil {
 		s.pendingCommit = true
 	}
+	s.Unlock()
 	if delta > 0 {
 		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	sTyp := stHistogram
 	if h.UsesCustomBuckets() {
@@ -275,25 +283,30 @@ func (a *headAppenderV2) appendHistogram(s *memSeries, st, t int64, h *histogram
 	b := a.getCurrentBatch(sTyp, s.ref)
 	b.histograms = append(b.histograms, record.RefHistogramSample{Ref: s.ref, ST: st, T: t, H: h})
 	b.histogramSeries = append(b.histogramSeries, s)
-	return nil
+	return s, nil
 }
 
-// The caller must hold the series lock.
-func (a *headAppenderV2) appendFloatHistogram(s *memSeries, st, t int64, fh *histogram.FloatHistogram, fastRejectOOO bool) error {
+func (a *headAppenderV2) appendFloatHistogram(s *memSeries, st, t int64, fh *histogram.FloatHistogram, fastRejectOOO bool) (*memSeries, error) {
+	s, err := a.lockForAppend(s)
+	if err != nil {
+		return nil, err
+	}
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
 	isOOO, delta, err := s.appendableFloatHistogram(t, fh, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if isOOO && fastRejectOOO {
-		return storage.ErrOutOfOrderSample
+		s.Unlock()
+		return nil, storage.ErrOutOfOrderSample
 	}
 	if err == nil {
 		s.pendingCommit = true
 	}
+	s.Unlock()
 	if delta > 0 {
 		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	sTyp := stFloatHistogram
 	if fh.UsesCustomBuckets() {
@@ -302,7 +315,7 @@ func (a *headAppenderV2) appendFloatHistogram(s *memSeries, st, t int64, fh *his
 	b := a.getCurrentBatch(sTyp, s.ref)
 	b.floatHistograms = append(b.floatHistograms, record.RefFloatHistogramSample{Ref: s.ref, ST: st, T: t, FH: fh})
 	b.floatHistogramSeries = append(b.floatHistogramSeries, s)
-	return nil
+	return s, nil
 }
 
 func (a *headAppenderV2) appendExemplars(s *memSeries, exemplar []exemplar.Exemplar) error {
@@ -335,18 +348,21 @@ func (a *headAppenderV2) appendExemplars(s *memSeries, exemplar []exemplar.Exemp
 // is implemented.
 //
 // ST is an experimental feature, we don't fail the append on errors, just debug log.
-func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.Labels, st, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) {
+func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.Labels, st, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) *memSeries {
 	// Use the caller-provided labels so rejected samples don't need to copy the series labels for logging.
 	if st >= t {
 		a.head.logger.Debug("Error when appending ST", "series", ls.String(), "st", st, "t", t, "err", storage.ErrSTNewerThanSample)
-		return
+		return s
 	}
 	if st < a.minValidTime {
 		a.head.logger.Debug("Error when appending ST", "series", ls.String(), "st", st, "t", t, "err", storage.ErrOutOfBounds)
-		return
+		return s
 	}
 
-	var err error
+	var (
+		appended *memSeries
+		err      error
+	)
 	switch {
 	case fh != nil:
 		zeroFloatHistogram := &histogram.FloatHistogram{
@@ -357,7 +373,7 @@ func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.La
 			ZeroThreshold: fh.ZeroThreshold,
 			CustomValues:  fh.CustomValues,
 		}
-		err = a.appendFloatHistogram(s, 0, st, zeroFloatHistogram, true)
+		appended, err = a.appendFloatHistogram(s, 0, st, zeroFloatHistogram, true)
 	case h != nil:
 		zeroHistogram := &histogram.Histogram{
 			// The STZeroSample represents a counter reset by definition.
@@ -367,19 +383,20 @@ func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.La
 			ZeroThreshold: h.ZeroThreshold,
 			CustomValues:  h.CustomValues,
 		}
-		err = a.appendHistogram(s, 0, st, zeroHistogram, true)
+		appended, err = a.appendHistogram(s, 0, st, zeroHistogram, true)
 	default:
-		err = a.appendFloat(s, 0, st, 0, true)
+		appended, err = a.appendFloat(s, 0, st, 0, true)
 	}
 
 	if err != nil {
 		if errors.Is(err, storage.ErrOutOfOrderSample) {
 			// OOO errors are common and expected (cumulative). Explicitly ignored.
-			return
+			return s
 		}
 		a.head.logger.Debug("Error when appending ST", "series", s.lset.String(), "st", st, "t", t, "err", err)
-		return
+		return s
 	}
+	return appended
 }
 
 var _ storage.GetRef = &headAppenderV2{}

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -136,12 +136,9 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
-	if s == nil {
-		var err error
-		s, _, err = a.getOrCreate(ls)
-		if err != nil {
-			return 0, err
-		}
+	s, valErr = a.getOrCreateAndLock(s, ls)
+	if valErr != nil {
+		return 0, valErr
 	}
 
 	if a.head.opts.EnableSTAsZeroSample && st != 0 {
@@ -151,10 +148,8 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	switch {
 	case fh != nil:
 		isStale = value.IsStaleNaN(fh.Sum)
-		appErr = a.appendFloatHistogram(s, st, t, fh, opts.RejectOutOfOrder)
 	case h != nil:
 		isStale = value.IsStaleNaN(h.Sum)
-		appErr = a.appendHistogram(s, st, t, h, opts.RejectOutOfOrder)
 	default:
 		isStale = value.IsStaleNaN(v)
 		if isStale {
@@ -167,10 +162,12 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 			// an optimization for the more likely case.
 			switch a.typesInBatch[s.ref] {
 			case stHistogram, stCustomBucketHistogram:
+				s.Unlock()
 				return a.Append(storage.SeriesRef(s.ref), ls, st, t, 0, &histogram.Histogram{Sum: v}, nil, storage.AOptions{
 					RejectOutOfOrder: opts.RejectOutOfOrder,
 				})
 			case stFloatHistogram, stCustomBucketFloatHistogram:
+				s.Unlock()
 				return a.Append(storage.SeriesRef(s.ref), ls, st, t, 0, nil, &histogram.FloatHistogram{Sum: v}, storage.AOptions{
 					RejectOutOfOrder: opts.RejectOutOfOrder,
 				})
@@ -180,8 +177,17 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 			// we do not need to check for the difference between "unknown
 			// series" and "known series with stNone".
 		}
+	}
+
+	switch {
+	case fh != nil:
+		appErr = a.appendFloatHistogram(s, st, t, fh, opts.RejectOutOfOrder)
+	case h != nil:
+		appErr = a.appendHistogram(s, st, t, h, opts.RejectOutOfOrder)
+	default:
 		appErr = a.appendFloat(s, st, t, v, opts.RejectOutOfOrder)
 	}
+	s.Unlock()
 	// Handle append error, if any.
 	if appErr != nil {
 		switch {
@@ -221,19 +227,17 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	return storage.SeriesRef(s.ref), partialErr
 }
 
+// The caller must hold the series lock.
 func (a *headAppenderV2) appendFloat(s *memSeries, st, t int64, v float64, fastRejectOOO bool) error {
-	s.Lock()
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
 	isOOO, delta, err := s.appendable(t, v, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if isOOO && fastRejectOOO {
-		s.Unlock()
 		return storage.ErrOutOfOrderSample
 	}
 	if err == nil {
 		s.pendingCommit = true
 	}
-	s.Unlock()
 	if delta > 0 {
 		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
 	}
@@ -247,19 +251,17 @@ func (a *headAppenderV2) appendFloat(s *memSeries, st, t int64, v float64, fastR
 	return nil
 }
 
+// The caller must hold the series lock.
 func (a *headAppenderV2) appendHistogram(s *memSeries, st, t int64, h *histogram.Histogram, fastRejectOOO bool) error {
-	s.Lock()
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
 	isOOO, delta, err := s.appendableHistogram(t, h, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if isOOO && fastRejectOOO {
-		s.Unlock()
 		return storage.ErrOutOfOrderSample
 	}
 	if err == nil {
 		s.pendingCommit = true
 	}
-	s.Unlock()
 	if delta > 0 {
 		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
 	}
@@ -276,19 +278,17 @@ func (a *headAppenderV2) appendHistogram(s *memSeries, st, t int64, h *histogram
 	return nil
 }
 
+// The caller must hold the series lock.
 func (a *headAppenderV2) appendFloatHistogram(s *memSeries, st, t int64, fh *histogram.FloatHistogram, fastRejectOOO bool) error {
-	s.Lock()
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
 	isOOO, delta, err := s.appendableFloatHistogram(t, fh, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if isOOO && fastRejectOOO {
-		s.Unlock()
 		return storage.ErrOutOfOrderSample
 	}
 	if err == nil {
 		s.pendingCommit = true
 	}
-	s.Unlock()
 	if delta > 0 {
 		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
 	}
@@ -336,7 +336,7 @@ func (a *headAppenderV2) appendExemplars(s *memSeries, exemplar []exemplar.Exemp
 //
 // ST is an experimental feature, we don't fail the append on errors, just debug log.
 func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.Labels, st, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) {
-	// NOTE: Use lset instead of s.lset to avoid locking memSeries. Using s.ref is acceptable without locking.
+	// Use the caller-provided labels so rejected samples don't need to copy the series labels for logging.
 	if st >= t {
 		a.head.logger.Debug("Error when appending ST", "series", ls.String(), "st", st, "t", t, "err", storage.ErrSTNewerThanSample)
 		return

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -7346,9 +7346,11 @@ func stripeSeriesWithCollidingSeries(t *testing.T) (*stripeSeries, *memSeries, *
 	lbls1, lbls2 := labelsWithHashCollision()
 	ms1 := memSeries{
 		lset: lbls1,
+		ref:  1,
 	}
 	ms2 := memSeries{
 		lset: lbls2,
+		ref:  2,
 	}
 	hash := lbls1.Hash()
 	s := newStripeSeries(1, noopSeriesLifecycleCallback{})
@@ -7387,6 +7389,12 @@ func TestStripeSeries_gc(t *testing.T) {
 	require.Nil(t, got)
 	got = s.getByHash(hash, ms2.lset)
 	require.Nil(t, got)
+	ms1.Lock()
+	require.True(t, ms1.isRetired())
+	ms1.Unlock()
+	ms2.Lock()
+	require.True(t, ms2.isRetired())
+	ms2.Unlock()
 }
 
 func TestPostingsCardinalityStats(t *testing.T) {


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
An appender resolves a series by ref before it takes the series lock, so GC can unlink the series in between. The append then lands in a `memSeries` that is no longer in the head index: queries never see the samples and WAL replay discards them under the eviction tombstone. Both GC paths are affected, the ordinary head truncation as well as the selected- and stale-series eviction behind `CompactStaleHead` and `CompactSelectedSeries`. The stripe locks do not close this window, because an appender takes no stripe lock once it has the series pointer.

Mark evicted series as retired under the series lock, and resolve and lock a series in one step so an appender that finds a retired series can retry against a live one, recreating it from the retired series' labels. A series this appender has already marked pending cannot be retired, so the retry only ever runs on the first append for a series in a transaction.

The retired flag is a bool in the padding the struct already had, so `memSeries` stays at 168 bytes.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] TSDB: Fix samples being silently dropped when head garbage collection removes a series while it is being appended to
```
