### PR TITLE
discovery/kubernetes: expose loadbalancer hostname label

### DIFF
--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -190,13 +190,14 @@ func serviceSourceFromNamespaceAndName(namespace, name string) string {
 }
 
 const (
-	servicePortNameLabel     = metaLabelPrefix + "service_port_name"
-	servicePortNumberLabel   = metaLabelPrefix + "service_port_number"
-	servicePortProtocolLabel = metaLabelPrefix + "service_port_protocol"
-	serviceClusterIPLabel    = metaLabelPrefix + "service_cluster_ip"
-	serviceLoadBalancerIP    = metaLabelPrefix + "service_loadbalancer_ip"
-	serviceExternalNameLabel = metaLabelPrefix + "service_external_name"
-	serviceType              = metaLabelPrefix + "service_type"
+	servicePortNameLabel        = metaLabelPrefix + "service_port_name"
+	servicePortNumberLabel      = metaLabelPrefix + "service_port_number"
+	servicePortProtocolLabel    = metaLabelPrefix + "service_port_protocol"
+	serviceClusterIPLabel       = metaLabelPrefix + "service_cluster_ip"
+	serviceLoadBalancerIP       = metaLabelPrefix + "service_loadbalancer_ip"
+	serviceLoadBalancerHostname = metaLabelPrefix + "service_loadbalancer_hostname"
+	serviceExternalNameLabel    = metaLabelPrefix + "service_external_name"
+	serviceType                 = metaLabelPrefix + "service_type"
 )
 
 func serviceLabels(svc *apiv1.Service) model.LabelSet {
@@ -235,7 +236,12 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
 		}
 
 		if svc.Spec.Type == apiv1.ServiceTypeLoadBalancer {
-			labelSet[serviceLoadBalancerIP] = lv(loadBalancerIPs(svc))
+			if lbIPs := loadBalancerIPs(svc); lbIPs != "" {
+				labelSet[serviceLoadBalancerIP] = lv(lbIPs)
+			}
+			if lbHostnames := loadBalancerHostnames(svc); lbHostnames != "" {
+				labelSet[serviceLoadBalancerHostname] = lv(lbHostnames)
+			}
 		}
 
 		tg.Targets = append(tg.Targets, labelSet)
@@ -258,4 +264,19 @@ func loadBalancerIPs(svc *apiv1.Service) string {
 		return strings.Join(ips, ",")
 	}
 	return svc.Spec.LoadBalancerIP
+}
+
+// loadBalancerHostnames returns the LoadBalancer hostnames from status.ingress.
+// Multiple ingress hostnames are joined with commas so relabeling can extract them.
+func loadBalancerHostnames(svc *apiv1.Service) string {
+	var hostnames []string
+	for _, ing := range svc.Status.LoadBalancer.Ingress {
+		if ing.Hostname != "" {
+			hostnames = append(hostnames, ing.Hostname)
+		}
+	}
+	if len(hostnames) > 0 {
+		return strings.Join(hostnames, ",")
+	}
+	return ""
 }

--- a/discovery/kubernetes/service_test.go
+++ b/discovery/kubernetes/service_test.go
@@ -141,6 +141,34 @@ func makeLoadBalancerServiceFromIngress() *v1.Service {
 	}
 }
 
+func makeLoadBalancerServiceWithHostname() *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testservice-lb-hostname",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "testport",
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(31900),
+				},
+			},
+			Type:      v1.ServiceTypeLoadBalancer,
+			ClusterIP: "10.0.0.1",
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{Hostname: "lb-1.example.com"},
+					{Hostname: "lb-2.example.com"},
+				},
+			},
+		},
+	}
+}
+
 func TestServiceDiscoveryAdd(t *testing.T) {
 	t.Parallel()
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{})
@@ -156,8 +184,10 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 			c.CoreV1().Services(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
 			obj = makeLoadBalancerServiceFromIngress()
 			c.CoreV1().Services(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+			obj = makeLoadBalancerServiceWithHostname()
+			c.CoreV1().Services(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
 		},
-		expectedMaxItems: 4,
+		expectedMaxItems: 5,
 		expectedRes: map[string]*targetgroup.Group{
 			"svc/default/testservice": {
 				Targets: []model.LabelSet{
@@ -228,6 +258,24 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 					"__meta_kubernetes_namespace":    "default",
 				},
 				Source: "svc/default/testservice-lb-ingress",
+			},
+			"svc/default/testservice-lb-hostname": {
+				Targets: []model.LabelSet{
+					{
+						"__meta_kubernetes_service_port_protocol": "TCP",
+						"__address__":                                     "testservice-lb-hostname.default.svc:31900",
+						"__meta_kubernetes_service_type":                  "LoadBalancer",
+						"__meta_kubernetes_service_port_name":             "testport",
+						"__meta_kubernetes_service_port_number":           "31900",
+						"__meta_kubernetes_service_cluster_ip":            "10.0.0.1",
+						"__meta_kubernetes_service_loadbalancer_hostname": "lb-1.example.com,lb-2.example.com",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_service_name": "testservice-lb-hostname",
+					"__meta_kubernetes_namespace":    "default",
+				},
+				Source: "svc/default/testservice-lb-hostname",
 			},
 		},
 	}.Run(t)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2472,6 +2472,7 @@ Available meta labels:
 * `__meta_kubernetes_service_annotationpresent_<annotationname>`: "true" for each annotation of the service object.
 * `__meta_kubernetes_service_cluster_ip`: The cluster IP address of the service. (Does not apply to services of type ExternalName)
 * `__meta_kubernetes_service_loadbalancer_ip`: The IP address of the load balancer, taken from `status.loadBalancer.ingress` (comma-separated when there are multiple). Falls back to the deprecated `spec.loadBalancerIP`. (Applies to services of type LoadBalancer)
+* `__meta_kubernetes_service_loadbalancer_hostname`: The hostname of the load balancer, taken from `status.loadBalancer.ingress` (comma-separated when there are multiple). (Applies to services of type LoadBalancer)
 * `__meta_kubernetes_service_external_name`: The DNS name of the service. (Applies to services of type ExternalName)
 * `__meta_kubernetes_service_label_<labelname>`: Each label from the service object, with any unsupported characters converted to an underscore.
 * `__meta_kubernetes_service_labelpresent_<labelname>`: `true` for each label of the service object, with any unsupported characters converted to an underscore.


### PR DESCRIPTION
### Description
In Kubernetes clusters running on cloud providers like AWS (EKS) and Azure (AKS), LoadBalancer services are frequently assigned DNS hostnames (e.g. `*.elb.amazonaws.com`) rather than static IP addresses.

Previously, Prometheus only extracted IP addresses into `__meta_kubernetes_service_loadbalancer_ip`.

This PR adds support for `__meta_kubernetes_service_loadbalancer_hostname`, which extracts hostnames from `status.loadBalancer.ingress[*].hostname` (comma-separated if multiple exist).

### Changes
- Added `serviceLoadBalancerHostname` label constant and `loadBalancerHostnames()` extractor in `discovery/kubernetes/service.go`.
- Added unit test cases with mock LoadBalancer ingress hostnames in `discovery/kubernetes/service_test.go`.
- Documented `__meta_kubernetes_service_loadbalancer_hostname` in `docs/configuration/configuration.md`.

#### Which issue(s) does the PR fix:
<!-- No linked issue; standalone enhancement -->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[ENHANCEMENT] discovery/kubernetes: Expose __meta_kubernetes_service_loadbalancer_hostname for LoadBalancer services.
```