### PR TITLE
scrape: json log formatter correctly print scrape target info

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1270,7 +1270,7 @@ func newScrapeLoop(opts scrapeLoopOptions) *scrapeLoop {
 		stopped:     make(chan struct{}),
 		parentCtx:   opts.sp.ctx,
 		appenderCtx: appenderCtx,
-		l:           opts.sp.logger.With("target", opts.target),
+		l:           opts.sp.logger.With("target", opts.target.String()),
 		cache:       opts.cache,
 
 		interval: opts.interval,


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Problem

When running Prometheus with `--log.format=json`, warnings about misconfiguration scrape targets do not contain any information about their source. For comparison, default `logfmt` uses `scrape.Target.String()` function for serialization and print target URL.

##### Reproduction

Prometheus config:

```yaml
# prometheus.yml
scrape_configs:
  - job_name: localhost
    metrics_path: /metrics.txt
    scrape_interval: 5s
    static_configs:
      - targets:
          - localhost:8000
```

Static metric file exposed with `python3 -m http.server`:

```
# Intentionally exposing the same gauge twice
static_gauge 0
static_gauge 0
```

Before, `"target": {}` was logged because there is no public fields in `scrape.Target` type

```json
$ timeout 10 ./prometheus --log.level=WARN --log.format=json
{"time":"2026-08-20T20:12:27.45933657+02:00","level":"WARN","source":"scrape_append_v2.go:403","msg":"Error on ingesting samples with different value but same timestamp","component":"scrape manager","scrape_pool":"localhost","target":{},"num_dropped":1}
{"time":"2026-08-20T20:12:28.382175764+02:00","level":"WARN","source":"main.go:1253","msg":"Received an OS signal, exiting gracefully...","signal":"terminated"}
```

After fix, target address is logged, similarly to `logfmt` formatter.

```json
$ timeout 10 ./prometheus --log.level=WARN --log.format=json
{"time":"2026-08-20T19:47:52.459884297+02:00","level":"WARN","source":"scrape_append_v2.go:403","msg":"Error on ingesting samples with different value but same timestamp","component":"scrape manager","scrape_pool":"localhost","target":"http://localhost:8000/metrics.txt","num_dropped":1}
{"time":"2026-08-20T19:47:56.894597163+02:00","level":"WARN","source":"main.go:1253","msg":"Received an OS signal, exiting gracefully...","signal":"terminated"}
```

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Scrape: JSON log formatter correctly format scrape target info
```
