### PR TITLE
discovery/http: add support for etag based caching

### DIFF
--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -56,6 +56,7 @@ type SDConfig struct {
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 	RefreshInterval  model.Duration          `yaml:"refresh_interval,omitempty"`
 	URL              string                  `yaml:"url"`
+	UseETag          bool                    `yaml:"use_etag"`
 }
 
 // NewDiscovererMetrics implements discovery.Config.
@@ -111,6 +112,8 @@ type Discovery struct {
 	refreshInterval time.Duration
 	tgLastLength    int
 	metrics         *httpMetrics
+	useEtag         bool
+	etag            string
 }
 
 // NewDiscovery returns a new HTTP discovery for the given config.
@@ -135,6 +138,7 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 		client:          client,
 		refreshInterval: time.Duration(conf.RefreshInterval), // Stored to be sent as headers.
 		metrics:         m,
+		useEtag:         conf.UseETag,
 	}
 
 	d.Discovery = refresh.NewDiscovery(
@@ -158,6 +162,9 @@ func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Prometheus-Refresh-Interval-Seconds", strconv.FormatFloat(d.refreshInterval.Seconds(), 'f', -1, 64))
+	if d.etag != "" {
+		req.Header.Set("If-None-Match", d.etag)
+	}
 
 	resp, err := d.client.Do(req.WithContext(ctx))
 	if err != nil {
@@ -169,6 +176,11 @@ func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		resp.Body.Close()
 	}()
 
+	// only allow StatusNotModified if we sent along an etag as there is no other
+	// way for the server to know the current state of prometheus
+	if d.etag != "" && resp.StatusCode == http.StatusNotModified {
+		return nil, nil
+	}
 	if resp.StatusCode != http.StatusOK {
 		d.metrics.failuresCount.Inc()
 		return nil, fmt.Errorf("server returned HTTP status %s", resp.Status)
@@ -213,6 +225,9 @@ func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	}
 	d.tgLastLength = l
 
+	if d.useEtag {
+		d.etag = resp.Header.Get("etag")
+	}
 	return targetGroups, nil
 }
 

--- a/discovery/http/http_test.go
+++ b/discovery/http/http_test.go
@@ -15,6 +15,7 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -473,4 +474,72 @@ func TestSourceDisappeared(t *testing.T) {
 			require.Equal(t, test.expectedTargets[i], tgs)
 		}
 	}
+}
+
+func TestHTTPEtagCaching(t *testing.T) {
+	targets := []targetgroup.Group{
+		{
+			Targets: []model.LabelSet{
+				{
+					model.AddressLabel: model.LabelValue("127.0.0.1:9090"),
+				},
+			},
+			Labels: model.LabelSet{
+				model.LabelName("__meta_datacenter"): model.LabelValue("bru1"),
+				model.LabelName("__meta_url"):        model.LabelValue("test-host.local/metrics"),
+			},
+		},
+	}
+	etag := "server-generated-content-hash"
+
+	notModifiedCount := 0
+	fullResponseCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("If-None-Match") == etag {
+			notModifiedCount++
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		fullResponseCount++
+		w.Header().Add("Etag", etag)
+		w.Header().Add("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(targets)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(ts.Close)
+
+	cfg := SDConfig{
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
+		URL:              ts.URL,
+		RefreshInterval:  model.Duration(30 * time.Second),
+		UseETag:          true,
+	}
+
+	reg := prometheus.NewRegistry()
+	refreshMetrics := discovery.NewRefreshMetrics(reg)
+	defer refreshMetrics.Unregister()
+	metrics := cfg.NewDiscovererMetrics(reg, refreshMetrics)
+	require.NoError(t, metrics.Register())
+	defer metrics.Unregister()
+
+	d, err := NewDiscovery(&cfg, discovery.DiscovererOptions{
+		Logger:            promslog.NewNopLogger(),
+		HTTPClientOptions: nil,
+		Metrics:           metrics,
+		SetName:           "http",
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tgs, err := d.Refresh(ctx)
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Equal(t, 1, fullResponseCount)
+	require.Equal(t, 0, notModifiedCount)
+
+	tgs, err = d.Refresh(ctx)
+	require.NoError(t, err)
+	require.Nil(t, tgs)
+	require.Equal(t, 1, fullResponseCount)
+	require.Equal(t, 1, notModifiedCount)
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2348,6 +2348,12 @@ It fetches targets from an HTTP endpoint containing a list of zero or more
 The HTTP header `Content-Type` must be `application/json`, and the body must be
 valid JSON.
 
+To allow for request caching using `ETag`/`If-None-Match`, enable the `use_etag`
+option.  If enabled, Prometheus will remember the value of the `ETag` header
+returned by the server and add it to subsequent requests in the `If-None-Match`
+header. The server can then opt to return HTTP 304 Not Modified which will tell
+Prometheus to keep using the previously discovered targets.
+
 Example response body:
 
 ```json
@@ -2384,6 +2390,11 @@ url: <string>
 # HTTP client settings, including authentication methods (such as basic auth and
 # authorization), proxy configurations, TLS options, custom HTTP headers, etc.
 [ <http_config> ]
+
+# Store the value of the ETag header value & send it on subsequent requests in
+# the If-None-Match header. Allows the endpoint to reply with 304 Not Modified
+# to tell prometheus to keep using the previously discovered targets
+[ use_etag:  <boolean> | default = false ]
 ```
 
 ### `<ionos_sd_config>`

--- a/docs/http_sd.md
+++ b/docs/http_sd.md
@@ -37,6 +37,13 @@ The SD endpoint must answer with an HTTP 200 response, with the HTTP Header
 If no targets should be transmitted, HTTP 200 must also be emitted, with
 an empty list `[]`. Target lists are unordered.
 
+It is possible to opt in to support for ETag based caching by specifying
+`use_etag` in the service discovery configuration. In this case, Prometheus will
+cache the value of the `ETag` header returned by the SD endpoint and send it on
+subsequent requests in the `If-None-Match` header. If the server recognizes the
+value, it can choose to return HTTP 304 Not Modified to tell prometheus to keep
+using the previously discovered targets.
+
 Prometheus caches target lists. If an error occurs while fetching an updated
 targets list, Prometheus keeps using the current targets list. The targets list
 is not saved across restart. The `prometheus_sd_refresh_failures_total` counter


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
This feature allows the http_sd mechanism to opt into [etag based caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#etagif-none-match).

By storing the value of the server generated entity tag and sending it on subsequent requests, this allows the server to return early and indicate that nothing has changed since the last request.

In my specific situation, I'm developing a service that exposes an `http_sd` endpoint & fetches the targets from a database. With this feature, I can avoid a round trip to the database without introducing complicated caching logic or significantly increasing Prometheus memory usage.

I considered opening up an issue/proposal first but while testing if this is feasible at all, I realized the actual changes needed are very small so I'm submitting this as a PR directly. Let me know if I should first bring this up in another form and I'll do that instead :)

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[FEATURE] discovery/http: add support for etag based caching.
```
