### PR TITLE
Reduce allocations in Symbols.Lookup

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1190,6 +1190,10 @@ func NewSymbols(bs ByteSlice, version, off int) (*Symbols, error) {
 	return s, nil
 }
 
+// Lookup returns the symbol at the given offset. The returned string is a
+// reference to data in the mmap'd index file, not a copy. It becomes invalid
+// when the index Reader is closed. Callers that need to retain the string
+// past Reader.Close must copy it.
 func (s Symbols) Lookup(o uint32) (string, error) {
 	d := encoding.Decbuf{
 		B: s.bs.Range(0, s.bs.Len()),
@@ -1207,7 +1211,7 @@ func (s Symbols) Lookup(o uint32) (string, error) {
 			d.UvarintBytes()
 		}
 	}
-	sym := d.UvarintStr()
+	sym := yoloString(d.UvarintBytes())
 	if d.Err() != nil {
 		return "", d.Err()
 	}
@@ -1358,8 +1362,8 @@ func (r *Reader) SortedLabelValues(ctx context.Context, name string, hints *stor
 }
 
 // LabelValues returns value tuples that exist for the given label name.
-// It is not safe to use the return value beyond the lifetime of the byte slice
-// passed into the Reader.
+// The returned strings are references to data in the mmap'd index file, not
+// copies. They become invalid when the index Reader is closed.
 // TODO(replay): Support filtering by matchers.
 func (r *Reader) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) > 0 {
@@ -1406,6 +1410,8 @@ func (r *Reader) LabelValues(ctx context.Context, name string, hints *storage.La
 
 // LabelNamesFor returns all the label names for the series referred to by IDs.
 // The names returned are sorted.
+// The returned strings are references to data in the mmap'd index file, not
+// copies. They become invalid when the index Reader is closed.
 func (r *Reader) LabelNamesFor(ctx context.Context, postings Postings) ([]string, error) {
 	// Gather offsetsMap the name offsetsMap in the symbol table first
 	offsetsMap := make(map[uint32]struct{})
@@ -1470,6 +1476,11 @@ func (r *Reader) Series(id storage.SeriesRef, builder *labels.ScratchBuilder, ch
 		return d.Err()
 	}
 	builder.SetSymbolTable(r.st)
+	// Symbols.Lookup returns yoloStrings that point into the mmap'd index
+	// file. These strings are unsafe to retain past Reader.Close(). Tell the
+	// builder to copy them so that slicelabels (which shares string pointers
+	// in Labels()) does not retain mmap-backed strings.
+	builder.SetUnsafeAdd(true)
 	builder.Reset()
 	err := r.dec.Series(d.Get(), builder, chks)
 	if err != nil {


### PR DESCRIPTION
Symbols.Lookup allocates a new string on every call by using UvarintStr() which copies bytes from the mmap'd index file. This can be avoided by using yoloString, same is already done in ReverseLookup().

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: 13th Gen Intel(R) Core(TM) i7-13800H
                                       │  base.txt   │               pr.txt                │
                                       │   sec/op    │   sec/op     vs base                │
QuerierSelect/Block/1of1000000-5         255.8m ± 1%   208.4m ± 0%  -18.55% (p=0.000 n=10)
QuerierSelect/Block/10of1000000-5        258.0m ± 1%   208.0m ± 0%  -19.37% (p=0.000 n=10)
QuerierSelect/Block/100of1000000-5       257.1m ± 1%   208.6m ± 0%  -18.87% (p=0.000 n=10)
QuerierSelect/Block/1000of1000000-5      258.0m ± 1%   208.2m ± 1%  -19.31% (p=0.000 n=10)
QuerierSelect/Block/10000of1000000-5     258.3m ± 1%   210.2m ± 0%  -18.61% (p=0.000 n=10)
QuerierSelect/Block/100000of1000000-5    264.7m ± 0%   219.8m ± 0%  -16.96% (p=0.000 n=10)
QuerierSelect/Block/1000000of1000000-5   356.7m ± 1%   307.5m ± 1%  -13.80% (p=0.000 n=10)
geomean                                  270.8m        222.2m       -17.94%

                                       │     base.txt     │                pr.txt                 │
                                       │       B/op       │     B/op      vs base                 │
QuerierSelect/Block/1of1000000-5          51200632.5 ± 0%     632.0 ± 0%  -100.00% (p=0.000 n=10)
QuerierSelect/Block/10of1000000-5        50001.603Ki ± 0%   1.602Ki ± 0%  -100.00% (p=0.000 n=10)
QuerierSelect/Block/100of1000000-5        50011.45Ki ± 0%   11.45Ki ± 0%   -99.98% (p=0.000 n=10)
QuerierSelect/Block/1000of1000000-5        50109.9Ki ± 0%   109.9Ki ± 0%   -99.78% (p=0.000 n=10)
QuerierSelect/Block/10000of1000000-5        49.897Mi ± 0%   1.069Mi ± 0%   -97.86% (p=0.000 n=10)
QuerierSelect/Block/100000of1000000-5        59.51Mi ± 0%   10.68Mi ± 0%   -82.05% (p=0.000 n=10)
QuerierSelect/Block/1000000of1000000-5       155.6Mi ± 0%   106.8Mi ± 0%   -31.37% (p=0.000 n=10)
geomean                                      59.48Mi        149.0Ki        -99.76%

                                       │    base.txt     │                pr.txt                │
                                       │    allocs/op    │  allocs/op   vs base                 │
QuerierSelect/Block/1of1000000-5         2000011.00 ± 0%    11.00 ± 0%  -100.00% (p=0.000 n=10)
QuerierSelect/Block/10of1000000-5        2000029.00 ± 0%    29.00 ± 0%  -100.00% (p=0.000 n=10)
QuerierSelect/Block/100of1000000-5        2000209.0 ± 0%    209.0 ± 0%   -99.99% (p=0.000 n=10)
QuerierSelect/Block/1000of1000000-5       2002.009k ± 0%   2.009k ± 0%   -99.90% (p=0.000 n=10)
QuerierSelect/Block/10000of1000000-5       2020.01k ± 0%   20.01k ± 0%   -99.01% (p=0.000 n=10)
QuerierSelect/Block/100000of1000000-5       2200.0k ± 0%   200.0k ± 0%   -90.91% (p=0.000 n=10)
QuerierSelect/Block/1000000of1000000-5       4.000M ± 0%   2.000M ± 0%   -50.00% (p=0.000 n=10)
geomean                                      2.242M        2.709k        -99.88%
```

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[PERF] tsdb: reduce allocations in Symbols.Lookup
```
