### PR TITLE
discovery: run tests in parallel

### DIFF
--- a/discovery/digitalocean/digitalocean_db_test.go
+++ b/discovery/digitalocean/digitalocean_db_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestDigitalOceanDBRefresh(t *testing.T) {
+	t.Parallel()
 	mock := NewSDMock(t)
 	mock.Setup()
 	defer mock.ShutdownServer()
@@ -94,6 +95,7 @@ func TestDigitalOceanDBRefresh(t *testing.T) {
 }
 
 func TestDigitalOceanDBRefreshPagination(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		page := r.URL.Query().Get("page")
 		switch page {

--- a/discovery/digitalocean/digitalocean_test.go
+++ b/discovery/digitalocean/digitalocean_test.go
@@ -42,6 +42,7 @@ func (s *DigitalOceanSDTestSuite) SetupTest(t *testing.T) {
 }
 
 func TestDigitalOceanSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := &DigitalOceanSDTestSuite{}
 	sdmock.SetupTest(t)
 	t.Cleanup(sdmock.TearDownSuite)

--- a/discovery/http/http_test.go
+++ b/discovery/http/http_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestHTTPValidRefresh(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.FileServer(http.Dir("./fixtures")))
 	t.Cleanup(ts.Close)
 
@@ -80,6 +81,7 @@ func TestHTTPValidRefresh(t *testing.T) {
 }
 
 func TestHTTPInvalidCode(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
@@ -114,6 +116,7 @@ func TestHTTPInvalidCode(t *testing.T) {
 }
 
 func TestHTTPInvalidFormat(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintln(w, "{}")
 	}))
@@ -168,6 +171,7 @@ func getFailureCount(failuresCount prometheus.Counter) float64 {
 }
 
 func TestContentTypeRegex(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		header string
 		match  bool
@@ -226,6 +230,7 @@ func TestContentTypeRegex(t *testing.T) {
 }
 
 func TestSourceDisappeared(t *testing.T) {
+	t.Parallel()
 	var stubResponse string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/discovery/ionos/server_test.go
+++ b/discovery/ionos/server_test.go
@@ -34,6 +34,7 @@ var (
 )
 
 func TestIONOSServerRefresh(t *testing.T) {
+	t.Parallel()
 	mock := httptest.NewServer(http.HandlerFunc(mockIONOSServers))
 	defer mock.Close()
 
@@ -142,6 +143,7 @@ func ionosServersBody(items string) string {
 // NIC with no IPs panicked the whole Prometheus process instead of degrading the
 // target.
 func TestIONOSServerRefreshNilContainers(t *testing.T) {
+	t.Parallel()
 	const serversID = "8feda53f-15f0-447f-badf-ebe32dad2fc0/servers"
 
 	for _, tc := range []struct {

--- a/discovery/linode/linode_test.go
+++ b/discovery/linode/linode_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestLinodeSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t)
 	sdmock.Setup()
 

--- a/discovery/moby/docker_test.go
+++ b/discovery/moby/docker_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestDockerSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "dockerprom")
 	sdmock.Setup()
 
@@ -227,6 +228,7 @@ host: %s
 }
 
 func TestDockerSDRefreshMatchAllNetworks(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "dockerprom")
 	sdmock.Setup()
 
@@ -523,6 +525,7 @@ func sortFunc(labelSets []model.LabelSet) {
 }
 
 func TestDockerSDRefreshIPv6Only(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "dockeripv6")
 	sdmock.Setup()
 

--- a/discovery/moby/moby_test.go
+++ b/discovery/moby/moby_test.go
@@ -50,6 +50,7 @@ type refresher interface {
 // accepts the connection but never answers cannot block discovery forever. The
 // http case also guards the option ordering the timeout relies on.
 func TestRefreshTimesOutOnUnresponsiveDaemon(t *testing.T) {
+	t.Parallel()
 	for _, host := range []struct {
 		name string
 		host func(t *testing.T) string

--- a/discovery/moby/nodes_test.go
+++ b/discovery/moby/nodes_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestDockerSwarmNodesSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 

--- a/discovery/moby/services_test.go
+++ b/discovery/moby/services_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestDockerSwarmSDServicesRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 
@@ -330,6 +331,7 @@ host: %s
 }
 
 func TestDockerSwarmSDServicesRefreshWithFilters(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 
@@ -453,6 +455,7 @@ filters:
 // discovery does not panic when a service has no container spec, which is the
 // case for services whose task runtime is a plugin or a network attachment.
 func TestDockerSwarmSDServicesRefreshNoContainerSpec(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "swarmprom-plugin")
 	sdmock.Setup()
 

--- a/discovery/moby/tasks_test.go
+++ b/discovery/moby/tasks_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestDockerSwarmTasksSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -132,6 +132,7 @@ func singleInstanceDiscovery(inst core.Instance, vnic *core.Vnic) *Discovery {
 // ---- instanceLabels ---------------------------------------------------------
 
 func TestInstanceLabels_CoreLabels(t *testing.T) {
+	t.Parallel()
 	inst := makeInstance()
 	labels := instanceLabels(&inst, primaryOnly("ocid1.vnic.oc1..v001", "10.0.0.5", "203.0.113.1"), testTenancy, 9100)
 
@@ -157,18 +158,21 @@ func TestInstanceLabels_CoreLabels(t *testing.T) {
 }
 
 func TestInstanceLabels_AddressIsPrivateIPWhenBothPresent(t *testing.T) {
+	t.Parallel()
 	inst := makeInstance()
 	labels := instanceLabels(&inst, primaryOnly("v", "10.0.0.5", "203.0.113.1"), "tenancy", 80)
 	require.Equal(t, model.LabelValue("10.0.0.5:80"), labels[model.AddressLabel])
 }
 
 func TestInstanceLabels_AddressFallsBackToPublicIP(t *testing.T) {
+	t.Parallel()
 	inst := makeInstance()
 	labels := instanceLabels(&inst, primaryOnly("v", "", "203.0.113.1"), "tenancy", 80)
 	require.Equal(t, model.LabelValue("203.0.113.1:80"), labels[model.AddressLabel])
 }
 
 func TestInstanceLabels_FreeformTagsSanitized(t *testing.T) {
+	t.Parallel()
 	// Sanitization replaces invalid characters with underscores but preserves
 	// case so that case-sensitive OCI tag keys do not collide (e.g. Env vs env).
 	inst := makeInstance(func(i *core.Instance) {
@@ -190,6 +194,7 @@ func TestInstanceLabels_FreeformTagsSanitized(t *testing.T) {
 }
 
 func TestInstanceLabels_DefinedTagsStringifyScalars(t *testing.T) {
+	t.Parallel()
 	// OCI defined tag values may be strings, numbers, or booleans. The SDK
 	// decodes JSON numbers as float64. All scalars are stringified so that
 	// keep/drop relabel rules on numeric or boolean tags match correctly.
@@ -224,6 +229,7 @@ func TestInstanceLabels_DefinedTagsStringifyScalars(t *testing.T) {
 }
 
 func TestStringifyDefinedTag(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		in   any
@@ -254,6 +260,7 @@ func TestStringifyDefinedTag(t *testing.T) {
 }
 
 func TestInstanceLabels_NilOptionalFields(t *testing.T) {
+	t.Parallel()
 	inst := core.Instance{
 		LifecycleState: core.InstanceLifecycleStateRunning,
 		FreeformTags:   map[string]string{},
@@ -267,6 +274,7 @@ func TestInstanceLabels_NilOptionalFields(t *testing.T) {
 }
 
 func TestInstanceLabels_PortInAddress(t *testing.T) {
+	t.Parallel()
 	inst := makeInstance()
 	for _, port := range []int{80, 9100, 9182, 443} {
 		labels := instanceLabels(&inst, primaryOnly("v", "10.0.0.1", ""), "tenancy", port)
@@ -280,6 +288,7 @@ func TestInstanceLabels_PortInAddress(t *testing.T) {
 }
 
 func TestInstanceLabels_IPv6AndHostname(t *testing.T) {
+	t.Parallel()
 	inst := makeInstance()
 	vnics := instanceVnics{primary: vnicInfo{
 		id:            "ocid1.vnic.oc1..v001",
@@ -294,6 +303,7 @@ func TestInstanceLabels_IPv6AndHostname(t *testing.T) {
 }
 
 func TestInstanceLabels_IPv6AndHostnameEmptyWhenAbsent(t *testing.T) {
+	t.Parallel()
 	// Both labels are set unconditionally, empty when the VNIC has no IPv6
 	// address or hostname label.
 	inst := makeInstance()
@@ -304,6 +314,7 @@ func TestInstanceLabels_IPv6AndHostnameEmptyWhenAbsent(t *testing.T) {
 }
 
 func TestJoinIPv6(t *testing.T) {
+	t.Parallel()
 	require.Empty(t, joinIPv6(nil))
 	require.Empty(t, joinIPv6([]string{}))
 	require.Equal(t, ",2001:db8::1,", joinIPv6([]string{"2001:db8::1"}))
@@ -311,6 +322,7 @@ func TestJoinIPv6(t *testing.T) {
 }
 
 func TestJoinIPv6_MatchableByRegex(t *testing.T) {
+	t.Parallel()
 	// The list is comma-wrapped so a relabel regex can match a whole address
 	// with `.*,addr,.*`, including the first and last entries.
 	value := joinIPv6([]string{"2001:db8::1", "2001:db8::2"})
@@ -321,6 +333,7 @@ func TestJoinIPv6_MatchableByRegex(t *testing.T) {
 }
 
 func TestInstanceLabels_IPv6OnlyAddress(t *testing.T) {
+	t.Parallel()
 	// With no IPv4 address the target falls back to the first (sorted) IPv6
 	// address, bracketed by net.JoinHostPort.
 	inst := makeInstance()
@@ -336,6 +349,7 @@ func TestInstanceLabels_IPv6OnlyAddress(t *testing.T) {
 // ---- refresh ----------------------------------------------------------------
 
 func TestRefresh_SingleInstance(t *testing.T) {
+	t.Parallel()
 	inst := makeInstance()
 	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.5", "203.0.113.10")
 	d := singleInstanceDiscovery(inst, vnic)
@@ -356,6 +370,7 @@ func TestRefresh_SingleInstance(t *testing.T) {
 }
 
 func TestRefresh_PrimaryVnicIPv6SortedAndHostname(t *testing.T) {
+	t.Parallel()
 	// The primary VNIC's IPv6 addresses are exposed sorted for deterministic
 	// output even though OCI returns them in an unspecified order.
 	inst := makeInstance()
@@ -379,6 +394,7 @@ func TestRefresh_PrimaryVnicIPv6SortedAndHostname(t *testing.T) {
 }
 
 func TestRefresh_IPv6OnlyInstanceNotSkipped(t *testing.T) {
+	t.Parallel()
 	// An IPv6-only primary VNIC (no IPv4 private or public IP) is still
 	// discovered, with its first IPv6 address used as the target address.
 	inst := makeInstance()
@@ -400,6 +416,7 @@ func TestRefresh_IPv6OnlyInstanceNotSkipped(t *testing.T) {
 }
 
 func TestResolveVnics_DoesNotMutateSDKSlice(t *testing.T) {
+	t.Parallel()
 	// resolveVnics sorts a copy of the VNIC's IPv6 addresses, so the slice
 	// owned by the SDK response is left untouched.
 	inst := makeInstance()
@@ -418,6 +435,7 @@ func TestResolveVnics_DoesNotMutateSDKSlice(t *testing.T) {
 }
 
 func TestRefresh_ResolvesPrimaryVnicAndStops(t *testing.T) {
+	t.Parallel()
 	// Only the primary VNIC is resolved: once it is found the walk stops so a
 	// multi-VNIC instance does not fan out a GetVnic call per attachment. The
 	// primary supplies the address and the VNIC labels; the secondary is never
@@ -472,6 +490,7 @@ func TestRefresh_ResolvesPrimaryVnicAndStops(t *testing.T) {
 }
 
 func TestRefresh_MultipleCompartments(t *testing.T) {
+	t.Parallel()
 	comp1 := "ocid1.compartment.oc1..c001"
 	comp2 := "ocid1.compartment.oc1..c002"
 	comp3 := "ocid1.compartment.oc1..c003"
@@ -526,6 +545,7 @@ func TestRefresh_MultipleCompartments(t *testing.T) {
 }
 
 func TestRefresh_DisappearingCompartmentCleared(t *testing.T) {
+	t.Parallel()
 	comp1 := "ocid1.compartment.oc1..c001"
 	comp2 := "ocid1.compartment.oc1..c002"
 	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.1", "")
@@ -575,6 +595,7 @@ func TestRefresh_DisappearingCompartmentCleared(t *testing.T) {
 }
 
 func TestRefresh_CompartmentListError_Propagates(t *testing.T) {
+	t.Parallel()
 	sentinel := errors.New("identity API unavailable")
 	d := baseDiscovery()
 	d.listCompartments = func(_ context.Context) ([]string, error) {
@@ -586,6 +607,7 @@ func TestRefresh_CompartmentListError_Propagates(t *testing.T) {
 }
 
 func TestRefresh_ListInstancesError_PropagatesError(t *testing.T) {
+	t.Parallel()
 	// listInstances error -> the refresh fails as a whole so the refresh
 	// framework keeps the last known good targets rather than flapping the
 	// compartment's targets down for a cycle.
@@ -601,6 +623,7 @@ func TestRefresh_ListInstancesError_PropagatesError(t *testing.T) {
 }
 
 func TestRefresh_EmptyCompartment(t *testing.T) {
+	t.Parallel()
 	d := baseDiscovery()
 
 	tgs, err := d.refresh(context.Background())
@@ -610,6 +633,7 @@ func TestRefresh_EmptyCompartment(t *testing.T) {
 }
 
 func TestRefresh_VnicAttachmentError_InstanceSkipped(t *testing.T) {
+	t.Parallel()
 	inst := makeInstance()
 	sentinel := errors.New("VNIC list failed")
 
@@ -629,6 +653,7 @@ func TestRefresh_VnicAttachmentError_InstanceSkipped(t *testing.T) {
 }
 
 func TestRefresh_GetVnicError_InstanceSkipped(t *testing.T) {
+	t.Parallel()
 	inst := makeInstance()
 	att := makeAttachment(stringVal(inst.Id), "ocid1.vnic.oc1..v001")
 	sentinel := errors.New("GetVnic failed")
@@ -651,6 +676,7 @@ func TestRefresh_GetVnicError_InstanceSkipped(t *testing.T) {
 }
 
 func TestRefresh_NoPrimaryVnic_InstanceDropped(t *testing.T) {
+	t.Parallel()
 	// An instance with no resolvable primary VNIC has no usable IP, so the
 	// SD drops it rather than emit an unscrapeable :port target.
 	inst := makeInstance()
@@ -677,6 +703,7 @@ func TestRefresh_NoPrimaryVnic_InstanceDropped(t *testing.T) {
 }
 
 func TestRefresh_InstanceWithNilIDDropped(t *testing.T) {
+	t.Parallel()
 	// Defensive: an instance with a nil OCID would panic on dereference;
 	// it must be skipped with a warning.
 	inst := makeInstance(func(i *core.Instance) {
@@ -701,6 +728,7 @@ func TestRefresh_InstanceWithNilIDDropped(t *testing.T) {
 }
 
 func TestRefresh_ContextCanceled(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -774,6 +802,7 @@ func inactiveComp(id string) identity.Compartment {
 }
 
 func TestListAllCompartments_BFSIncludesRoot(t *testing.T) {
+	t.Parallel()
 	tree := &fakeCompartmentTree{
 		children: map[string][]identity.Compartment{
 			"root": {activeComp("c1"), activeComp("c2")},
@@ -787,6 +816,7 @@ func TestListAllCompartments_BFSIncludesRoot(t *testing.T) {
 }
 
 func TestListAllCompartments_PagedResults(t *testing.T) {
+	t.Parallel()
 	tree := &fakeCompartmentTree{
 		children: map[string][]identity.Compartment{
 			"root": {activeComp("c1"), activeComp("c2"), activeComp("c3"), activeComp("c4"), activeComp("c5")},
@@ -801,6 +831,7 @@ func TestListAllCompartments_PagedResults(t *testing.T) {
 }
 
 func TestListAllCompartments_InactiveCompartmentSkipped(t *testing.T) {
+	t.Parallel()
 	tree := &fakeCompartmentTree{
 		children: map[string][]identity.Compartment{
 			"root": {activeComp("c1"), inactiveComp("c2-dead"), activeComp("c3")},
@@ -813,6 +844,7 @@ func TestListAllCompartments_InactiveCompartmentSkipped(t *testing.T) {
 }
 
 func TestListAllCompartments_CycleVisitedOnce(t *testing.T) {
+	t.Parallel()
 	// A child that references back to root must not cause an infinite loop.
 	tree := &fakeCompartmentTree{
 		children: map[string][]identity.Compartment{
@@ -828,6 +860,7 @@ func TestListAllCompartments_CycleVisitedOnce(t *testing.T) {
 }
 
 func TestListAllCompartments_PermissionErrorSkipsSubtree(t *testing.T) {
+	t.Parallel()
 	tree := &fakeCompartmentTree{
 		children: map[string][]identity.Compartment{
 			"root": {activeComp("c1"), activeComp("c2")},
@@ -843,6 +876,7 @@ func TestListAllCompartments_PermissionErrorSkipsSubtree(t *testing.T) {
 }
 
 func TestListAllCompartments_CanceledContextAborts(t *testing.T) {
+	t.Parallel()
 	// A cancelled context must abort the walk immediately rather than be
 	// silently treated as a permission gap.
 	tree := &fakeCompartmentTree{
@@ -861,6 +895,7 @@ func TestListAllCompartments_CanceledContextAborts(t *testing.T) {
 // ---- SDConfig validation ----------------------------------------------------
 
 func TestSDConfig_Validation(t *testing.T) {
+	t.Parallel()
 	validAPIKey := SDConfig{
 		Auth:             authAPIKey,
 		Region:           "us-ashburn-1",
@@ -966,6 +1001,7 @@ func TestSDConfig_Validation(t *testing.T) {
 }
 
 func TestSDConfig_ValidInstancePrincipal(t *testing.T) {
+	t.Parallel()
 	cfg := SDConfig{
 		Auth:             authInstancePrincipal,
 		Region:           "us-ashburn-1",
@@ -976,6 +1012,7 @@ func TestSDConfig_ValidInstancePrincipal(t *testing.T) {
 }
 
 func TestSDConfig_ValidWithExplicitCompartments(t *testing.T) {
+	t.Parallel()
 	cfg := SDConfig{
 		Auth:             authAPIKey,
 		Region:           "us-ashburn-1",
@@ -991,6 +1028,7 @@ func TestSDConfig_ValidWithExplicitCompartments(t *testing.T) {
 }
 
 func TestSDConfig_ValidAutoDiscovery(t *testing.T) {
+	t.Parallel()
 	// Compartments empty -> auto-discover. Should be valid.
 	cfg := SDConfig{
 		Auth:             authAPIKey,
@@ -1006,6 +1044,7 @@ func TestSDConfig_ValidAutoDiscovery(t *testing.T) {
 }
 
 func TestSDConfig_ValidWithKeyPassphraseFile(t *testing.T) {
+	t.Parallel()
 	cfg := SDConfig{
 		Auth:              authAPIKey,
 		Region:            "us-ashburn-1",
@@ -1023,12 +1062,14 @@ func TestSDConfig_ValidWithKeyPassphraseFile(t *testing.T) {
 // ---- resolveKeyPassphrase ---------------------------------------------------
 
 func TestResolveKeyPassphrase_InlinePreferredWhenSetAlone(t *testing.T) {
+	t.Parallel()
 	got, err := resolveKeyPassphrase(&SDConfig{KeyPassphrase: "topsecret"})
 	require.NoError(t, err)
 	require.Equal(t, "topsecret", got)
 }
 
 func TestResolveKeyPassphrase_FileTrimsTrailingNewline(t *testing.T) {
+	t.Parallel()
 	path := filepath.Join(t.TempDir(), "pass")
 	require.NoError(t, writeFile(path, "topsecret\n"))
 
@@ -1038,6 +1079,7 @@ func TestResolveKeyPassphrase_FileTrimsTrailingNewline(t *testing.T) {
 }
 
 func TestResolveKeyPassphrase_FileMissing(t *testing.T) {
+	t.Parallel()
 	_, err := resolveKeyPassphrase(&SDConfig{KeyPassphraseFile: filepath.Join(t.TempDir(), "nope")})
 	require.Error(t, err)
 }
@@ -1045,6 +1087,7 @@ func TestResolveKeyPassphrase_FileMissing(t *testing.T) {
 // ---- SetDirectory -----------------------------------------------------------
 
 func TestSDConfig_SetDirectory_RelativePath(t *testing.T) {
+	t.Parallel()
 	dir := filepath.FromSlash("/etc/prometheus")
 	cfg := SDConfig{KeyFile: filepath.FromSlash("keys/oci.pem")}
 	cfg.SetDirectory(dir)
@@ -1052,6 +1095,7 @@ func TestSDConfig_SetDirectory_RelativePath(t *testing.T) {
 }
 
 func TestSDConfig_SetDirectory_AbsolutePathUnchanged(t *testing.T) {
+	t.Parallel()
 	abs := filepath.Join(t.TempDir(), "oci.pem")
 	cfg := SDConfig{KeyFile: abs}
 	cfg.SetDirectory(filepath.FromSlash("/etc/prometheus"))
@@ -1059,12 +1103,14 @@ func TestSDConfig_SetDirectory_AbsolutePathUnchanged(t *testing.T) {
 }
 
 func TestSDConfig_SetDirectory_EmptyKeyFile(t *testing.T) {
+	t.Parallel()
 	cfg := SDConfig{}
 	cfg.SetDirectory("/etc/prometheus")
 	require.Empty(t, cfg.KeyFile)
 }
 
 func TestSDConfig_SetDirectory_KeyPassphraseFileJoined(t *testing.T) {
+	t.Parallel()
 	dir := filepath.FromSlash("/etc/prometheus")
 	cfg := SDConfig{KeyPassphraseFile: filepath.FromSlash("keys/oci.pass")}
 	cfg.SetDirectory(dir)

--- a/discovery/openstack/hypervisor_test.go
+++ b/discovery/openstack/hypervisor_test.go
@@ -47,6 +47,7 @@ func (s *OpenstackSDHypervisorTestSuite) openstackAuthSuccess() (refresher, erro
 }
 
 func TestOpenstackSDHypervisorRefresh(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 
@@ -86,6 +87,7 @@ func TestOpenstackSDHypervisorRefresh(t *testing.T) {
 }
 
 func TestOpenstackSDHypervisorRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 

--- a/discovery/openstack/instance_test.go
+++ b/discovery/openstack/instance_test.go
@@ -52,6 +52,7 @@ func (s *OpenstackSDInstanceTestSuite) openstackAuthSuccess() (refresher, error)
 }
 
 func TestOpenstackSDInstanceRefresh(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDInstanceTestSuite{}
 	mock.SetupTest(t)
 
@@ -153,6 +154,7 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 }
 
 func TestOpenstackSDInstanceRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 

--- a/discovery/openstack/loadbalancer_test.go
+++ b/discovery/openstack/loadbalancer_test.go
@@ -51,6 +51,7 @@ func (s *OpenstackSDLoadBalancerTestSuite) openstackAuthSuccess() (refresher, er
 }
 
 func TestOpenstackSDLoadBalancerRefresh(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDLoadBalancerTestSuite{}
 	mock.SetupTest(t)
 
@@ -126,6 +127,7 @@ func TestOpenstackSDLoadBalancerRefresh(t *testing.T) {
 }
 
 func TestOpenstackSDLoadBalancerRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDLoadBalancerTestSuite{}
 	mock.SetupTest(t)
 

--- a/discovery/outscale/vm_test.go
+++ b/discovery/outscale/vm_test.go
@@ -24,6 +24,7 @@ import (
 func strptr(s string) *string { return &s }
 
 func TestVmsToLabelSets(t *testing.T) {
+	t.Parallel()
 	cfg := &SDConfig{
 		Region: "eu-west-2",
 		Port:   9090,

--- a/discovery/puppetdb/puppetdb_test.go
+++ b/discovery/puppetdb/puppetdb_test.go
@@ -49,6 +49,7 @@ func mockServer(t *testing.T) *httptest.Server {
 }
 
 func TestPuppetSlashInURL(t *testing.T) {
+	t.Parallel()
 	tests := map[string]string{
 		"https://puppetserver":      "https://puppetserver/pdb/query/v4",
 		"https://puppetserver/":     "https://puppetserver/pdb/query/v4",
@@ -83,6 +84,7 @@ func TestPuppetSlashInURL(t *testing.T) {
 }
 
 func TestPuppetDBRefresh(t *testing.T) {
+	t.Parallel()
 	ts := mockServer(t)
 
 	cfg := SDConfig{
@@ -134,6 +136,7 @@ func TestPuppetDBRefresh(t *testing.T) {
 }
 
 func TestPuppetDBRefreshWithParameters(t *testing.T) {
+	t.Parallel()
 	ts := mockServer(t)
 
 	cfg := SDConfig{
@@ -196,6 +199,7 @@ func TestPuppetDBRefreshWithParameters(t *testing.T) {
 }
 
 func TestPuppetDBInvalidCode(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
@@ -228,6 +232,7 @@ func TestPuppetDBInvalidCode(t *testing.T) {
 }
 
 func TestPuppetDBInvalidFormat(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintln(w, "{}")
 	}))

--- a/discovery/scaleway/instance_test.go
+++ b/discovery/scaleway/instance_test.go
@@ -34,6 +34,7 @@ var (
 )
 
 func TestScalewayInstanceRefresh(t *testing.T) {
+	t.Parallel()
 	mock := httptest.NewServer(http.HandlerFunc(mockScalewayInstance))
 	defer mock.Close()
 
@@ -188,6 +189,7 @@ func mockScalewayInstance(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestScalewayInstanceRefreshIPAMPrivateNIC(t *testing.T) {
+	t.Parallel()
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("X-Auth-Token") != testSecretKey {
 			http.Error(w, "bad token id", http.StatusUnauthorized)
@@ -277,6 +279,7 @@ api_url: %s
 }
 
 func TestScalewayInstanceAuthToken(t *testing.T) {
+	t.Parallel()
 	mock := httptest.NewServer(http.HandlerFunc(mockScalewayInstance))
 	defer mock.Close()
 

--- a/discovery/stackit/server_test.go
+++ b/discovery/stackit/server_test.go
@@ -39,6 +39,7 @@ func (s *serverSDTestSuite) SetupTest(t *testing.T) {
 }
 
 func TestServerSDRefresh(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		cfg  SDConfig

--- a/discovery/triton/triton_test.go
+++ b/discovery/triton/triton_test.go
@@ -102,6 +102,7 @@ func newTritonDiscovery(c SDConfig) (*Discovery, discovery.DiscovererMetrics, er
 }
 
 func TestTritonSDNew(t *testing.T) {
+	t.Parallel()
 	td, m, err := newTritonDiscovery(conf)
 	require.NoError(t, err)
 	require.NotNil(t, td)
@@ -116,12 +117,14 @@ func TestTritonSDNew(t *testing.T) {
 }
 
 func TestTritonSDNewBadConfig(t *testing.T) {
+	t.Parallel()
 	td, _, err := newTritonDiscovery(badconf)
 	require.Error(t, err)
 	require.Nil(t, td)
 }
 
 func TestTritonSDNewGroupsConfig(t *testing.T) {
+	t.Parallel()
 	td, m, err := newTritonDiscovery(groupsconf)
 	require.NoError(t, err)
 	require.NotNil(t, td)
@@ -137,6 +140,7 @@ func TestTritonSDNewGroupsConfig(t *testing.T) {
 }
 
 func TestTritonSDNewCNConfig(t *testing.T) {
+	t.Parallel()
 	td, m, err := newTritonDiscovery(cnconf)
 	require.NoError(t, err)
 	require.NotNil(t, td)
@@ -152,11 +156,13 @@ func TestTritonSDNewCNConfig(t *testing.T) {
 }
 
 func TestTritonSDRefreshNoTargets(t *testing.T) {
+	t.Parallel()
 	tgts := testTritonSDRefresh(t, conf, "{\"containers\":[]}")
 	require.Nil(t, tgts)
 }
 
 func TestTritonSDRefreshMultipleTargets(t *testing.T) {
+	t.Parallel()
 	dstr := `{"containers":[
 		 	{
                                 "groups":["foo","bar","baz"],
@@ -181,6 +187,7 @@ func TestTritonSDRefreshMultipleTargets(t *testing.T) {
 }
 
 func TestTritonSDRefreshNoServer(t *testing.T) {
+	t.Parallel()
 	td, m, _ := newTritonDiscovery(conf)
 
 	_, err := td.refresh(context.Background())
@@ -189,6 +196,7 @@ func TestTritonSDRefreshNoServer(t *testing.T) {
 }
 
 func TestTritonSDRefreshCancelled(t *testing.T) {
+	t.Parallel()
 	td, m, _ := newTritonDiscovery(conf)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -199,6 +207,7 @@ func TestTritonSDRefreshCancelled(t *testing.T) {
 }
 
 func TestTritonSDRefreshCNsUUIDOnly(t *testing.T) {
+	t.Parallel()
 	dstr := `{"cns":[
 		 	{
 				"server_uuid":"44454c4c-5000-104d-8037-b7c04f5a5131"
@@ -214,6 +223,7 @@ func TestTritonSDRefreshCNsUUIDOnly(t *testing.T) {
 }
 
 func TestTritonSDRefreshCNsWithHostname(t *testing.T) {
+	t.Parallel()
 	dstr := `{"cns":[
 		 	{
 				"server_uuid":"44454c4c-5000-104d-8037-b7c04f5a5131",

--- a/discovery/vultr/vultr_test.go
+++ b/discovery/vultr/vultr_test.go
@@ -43,6 +43,7 @@ func (s *VultrSDTestSuite) SetupTest(t *testing.T) {
 }
 
 func TestVultrSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdMock := &VultrSDTestSuite{}
 	sdMock.SetupTest(t)
 	t.Cleanup(sdMock.TearDownSuite)

--- a/discovery/zookeeper/zookeeper_test.go
+++ b/discovery/zookeeper/zookeeper_test.go
@@ -29,6 +29,7 @@ func TestMain(m *testing.M) {
 // TestNewDiscoveryError can fail if the DNS resolver mistakenly resolves the domain below.
 // See https://github.com/prometheus/prometheus/issues/16191 for a precedent.
 func TestNewDiscoveryError(t *testing.T) {
+	t.Parallel()
 	_, err := NewDiscovery(
 		[]string{"unreachable.invalid"},
 		time.Second, []string{"/"},


### PR DESCRIPTION
Finishes the `run tests in parallel` sweep started in #18611 (consul), #18613 (marathon) and
#18904 (nomad), and continued for aws, eureka, uyuni and `discovery` itself. These are the 14
`discovery/*` packages that still had no `t.Parallel()`.

One commit per package, `t.Parallel()` as the first statement of each top-level test, the
same shape as the earlier commits. `TestMain` is left alone.

Nothing here uses `t.Setenv`, `os.Chdir` or mutable package-level state, which is what would
have made the tests unsafe to run in parallel — I checked before changing them.

`go test -race -count=3` passes for all 14 packages, run together so they interleave.
`make common-check_license`, `make common-style` and `golangci-lint run ./discovery/...` are
clean.

```release-notes
NONE
```
