### PR TITLE
ci: derive the oldest supported Go version dynamically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,21 @@ jobs:
       # Don't run NPM build; don't run race-detector.
       - run: make test GO_ONLY=1 test-flags=""
 
+  test_go_oldest_status:
+    # Empty check with a stable name for branch protection rules, since
+    # test_go_oldest now runs as a matrix job.
+    name: Go tests with previous Go version
+    runs-on: ubuntu-latest
+    needs: [test_go_oldest]
+    if: always()
+    steps:
+      - name: Successful tests
+        if: ${{ !(contains(needs.*.result, 'failure')) && !(contains(needs.*.result, 'cancelled')) }}
+        run: exit 0
+      - name: Failing or cancelled tests
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+
   test_ui:
     name: UI tests
     runs-on: ubuntu-latest
@@ -385,7 +400,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: [test_ui, test_go, test_go_more, test_go_oldest, test_windows, golangci, codeql, build_all]
+    needs: [test_ui, test_go, test_go_more, test_go_oldest_status, test_windows, golangci, codeql, build_all]
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
       - uses: prometheus/promci/publish_main@370e8c15dcec50043cbe66f2f34633d9efc0a190 # v0.9.0
@@ -401,7 +416,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    needs: [test_ui, test_go, test_go_more, test_go_oldest, test_windows, golangci, codeql, build_all]
+    needs: [test_ui, test_go, test_go_more, test_go_oldest_status, test_windows, golangci, codeql, build_all]
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
       ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,16 +99,33 @@ jobs:
           cache_key_suffix: upgrade
       - run: go test -v --race ./cmd/prometheus/ --test.version-upgrade=true --test.lts-version=${{ matrix.lts_version }} -run TestVersionUpgrade
 
+  list_oldest_go_version:
+    name: List the oldest supported Go version
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.go.outputs.versions }}
+    steps:
+      - id: go
+        # Upstream only supports the two latest minor releases, so the oldest
+        # supported one is the lowest version listed. Emit it as a
+        # single-element JSON array consumed by the matrix below.
+        run: |
+          versions=$(curl -sSf 'https://go.dev/dl/?mode=json' \
+            | jq -c '[[.[].version | ltrimstr("go") | split(".")[1] | tonumber] | min | "1.\(.)"]')
+          echo "versions=$versions" >> "$GITHUB_OUTPUT"
+
   test_go_oldest:
     name: Go tests with previous Go version
+    needs: list_oldest_go_version
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go_version: ${{ fromJSON(needs.list_oldest_go_version.outputs.versions) }}
     env:
       # Enforce the Go version.
       GOTOOLCHAIN: local
     container:
-      # The go version in this image should be the oldest Go version upstream
-      # still supports, which scripts/check-go-mod-version.sh enforces.
-      image: quay.io/prometheus/golang-builder:1.26-base
+      image: quay.io/prometheus/golang-builder:${{ matrix.go_version }}-base
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/scripts/check-go-mod-version.sh
+++ b/scripts/check-go-mod-version.sh
@@ -47,25 +47,3 @@ if [[ "${matches}" -ne 1 ]]; then
   echo 'Not all go.mod/go.work files have matching go versions'
   exit 1
 fi
-
-ci_workflow=".github/workflows/ci.yml"
-if [[ -f "${ci_workflow}" ]] && yq -e '.jobs.test_go_oldest' "${ci_workflow}" > /dev/null 2>&1; then
-  echo "Checking CI workflow test_go_oldest uses N-1 Go version"
-
-  # Extract Go version from test_go_oldest job.
-  get_test_go_oldest_version() {
-    yq '.jobs.test_go_oldest.container.image' "${ci_workflow}" \
-      | grep -oP 'golang-builder:1\.\K[0-9]+'
-  }
-
-  test_go_oldest_version="$(get_test_go_oldest_version)"
-  if [[ -z "${test_go_oldest_version}" || "${test_go_oldest_version}" -le 0 ]]; then
-    echo "Error: Could not extract Go version from test_go_oldest job in ${ci_workflow}"
-    exit 1
-  fi
-
-  if [[ "${test_go_oldest_version}" -ne "${supported_version}" ]]; then
-    echo "Error: test_go_oldest uses Go 1.${test_go_oldest_version}, but should use Go 1.${supported_version} (oldest supported version)"
-    exit 1
-  fi
-fi


### PR DESCRIPTION
The test_go_oldest job pinned the golang-builder image tag by hand, which had to be bumped on every Go release and was enforced by scripts/check-go-mod-version.sh. Compute the oldest supported Go version from https://go.dev/dl/?mode=json instead, and feed it to the job as a single-row matrix, like list_lts_releases already does for LTS releases.

This also keeps CI green on the next Go minor release. With the version pinned in the tree, upstream releasing a new minor makes the check fail on every PR that is not on top of main, and each one has to be rebased on the bump commit. Reading the version at runtime means every PR picks up the new N-1 version on its own.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
