### PR TITLE
remote write: resolve dropped-sample counters once per Append

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -725,14 +725,34 @@ func isV2TimeSeriesOldFilter(metrics *queueManagerMetrics, baseTime time.Time, s
 	}
 }
 
+// lazyCounter defers resolving a CounterVec child until it is first needed.
+// WithLabelValues hashes the label values and takes a lock on every call, so
+// resolving once per Append is worthwhile when most samples take a dropped
+// path. Resolving lazily keeps reasons that never occur from being created.
+type lazyCounter struct {
+	vec     *prometheus.CounterVec
+	label   string
+	counter prometheus.Counter
+}
+
+func (l *lazyCounter) Inc() {
+	if l.counter == nil {
+		l.counter = l.vec.WithLabelValues(l.label)
+	}
+	l.counter.Inc()
+}
+
 // Append queues a sample to be sent to the remote storage. Blocks until all samples are
 // enqueued on their shards or a shutdown signal is received.
 func (t *QueueManager) Append(samples []record.RefSample) bool {
 	currentTime := time.Now()
+	droppedTooOld := lazyCounter{vec: t.metrics.droppedSamplesTotal, label: reasonTooOld}
+	droppedRelabelled := lazyCounter{vec: t.metrics.droppedSamplesTotal, label: reasonDroppedSeries}
+	droppedUnintentional := lazyCounter{vec: t.metrics.droppedSamplesTotal, label: reasonUnintentionalDroppedSeries}
 outer:
 	for _, s := range samples {
 		if isSampleOld(currentTime, time.Duration(t.cfg.SampleAgeLimit), s.T) {
-			t.metrics.droppedSamplesTotal.WithLabelValues(reasonTooOld).Inc()
+			droppedTooOld.Inc()
 			continue
 		}
 		t.seriesMtx.Lock()
@@ -741,9 +761,9 @@ outer:
 			t.dataDropped.incr(1)
 			if _, ok := t.droppedSeries[s.Ref]; !ok {
 				t.logger.Info("Dropped sample for series that was not explicitly dropped via relabelling", "ref", s.Ref)
-				t.metrics.droppedSamplesTotal.WithLabelValues(reasonUnintentionalDroppedSeries).Inc()
+				droppedUnintentional.Inc()
 			} else {
-				t.metrics.droppedSamplesTotal.WithLabelValues(reasonDroppedSeries).Inc()
+				droppedRelabelled.Inc()
 			}
 			t.seriesMtx.Unlock()
 			continue

--- a/storage/remote/queue_manager_droppath_test.go
+++ b/storage/remote/queue_manager_droppath_test.go
@@ -1,0 +1,166 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"fmt"
+	"testing"
+
+	remoteapi "github.com/prometheus/client_golang/exp/api/remote"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/util/testwal"
+)
+
+func keepRegex(re string) []*relabel.Config {
+	return []*relabel.Config{{
+		SourceLabels:         model.LabelNames{"__name__"},
+		Separator:            ";",
+		Regex:                relabel.MustNewRegexp(re),
+		Action:               relabel.Keep,
+		NameValidationScheme: model.UTF8Validation,
+	}}
+}
+
+// BenchmarkAppendPaths covers QueueManager.Append across the relabel
+// configurations it sees in practice. BenchmarkSampleSend only exercises the
+// case where every series is kept and nothing was ever dropped.
+//
+//   - kept/no-relabel     the default: no write_relabel_configs at all, so
+//     droppedSeries stays empty and every sample is enqueued.
+//   - kept/large-dropped  a selective config whose kept series carry the
+//     traffic while a large droppedSeries map sits alongside.
+//   - dropped/*           a selective config where the dropped series carry
+//     the traffic. The WAL watcher decodes and filters everything TSDB
+//     ingests, so with a selective keep filter this path carries almost the
+//     whole stream and dominates the watcher's per-sample cost.
+func BenchmarkAppendPaths(b *testing.B) {
+	const (
+		trafficSeries = 20_000  // Series that actually emit samples.
+		bystanders    = 500_000 // Series that only sit in droppedSeries.
+	)
+
+	newQM := func(b *testing.B) *QueueManager {
+		cfg := testDefaultQueueConfig()
+		cfg.MinShards = 20
+		cfg.MaxShards = 20
+		return newTestQueueManager(b, cfg, config.DefaultMetadataConfig,
+			defaultFlushDeadline, NewNopWriteClient(), remoteapi.WriteV1MessageType)
+	}
+
+	traffic := testwal.GenerateRecords(recCase{
+		Series: trafficSeries, SamplesPerSeries: 1, ExtraLabels: extraLabels,
+	})
+
+	run := func(b *testing.B, m *QueueManager) {
+		m.Start()
+		defer m.Stop()
+		perIter := len(traffic.Samples)
+		total := 0
+		b.ResetTimer()
+		for b.Loop() {
+			m.Append(traffic.Samples)
+			total += perIter
+		}
+		b.StopTimer()
+		b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(total), "ns/sample")
+	}
+
+	// The default: relabelling is not configured at all, everything is sent.
+	b.Run("kept/no-relabel", func(b *testing.B) {
+		m := newQM(b)
+		m.StoreSeries(traffic.Series, 0)
+		if len(m.droppedSeries) != 0 {
+			b.Fatalf("expected droppedSeries to be empty, got %d", len(m.droppedSeries))
+		}
+		run(b, m)
+	})
+
+	// Traffic flows through kept series while a large droppedSeries map sits
+	// alongside them.
+	b.Run("kept/large-dropped", func(b *testing.B) {
+		m := newQM(b)
+		other := testwal.GenerateRecords(recCase{
+			Series: bystanders, SamplesPerSeries: 0, ExtraLabels: extraLabels,
+		})
+		for i := range other.Series { // Keep refs distinct from traffic.
+			other.Series[i].Ref += 1 << 32
+		}
+		m.relabelConfigs = keepRegex("a_metric_name_that_matches_nothing")
+		m.StoreSeries(other.Series, 0)
+		m.relabelConfigs = nil
+		m.StoreSeries(traffic.Series, 0)
+		if len(m.droppedSeries) != bystanders {
+			b.Fatalf("expected %d dropped series, got %d", bystanders, len(m.droppedSeries))
+		}
+		run(b, m)
+	})
+
+	// Both maps are large and the traffic goes almost entirely through the
+	// dropped series.
+	b.Run("dropped/both-maps-large", func(b *testing.B) {
+		m := newQM(b)
+		kept := testwal.GenerateRecords(recCase{
+			Series: 300_000, SamplesPerSeries: 0, ExtraLabels: extraLabels,
+		})
+		for i := range kept.Series {
+			kept.Series[i].Ref += 1 << 32
+		}
+		dropped := testwal.GenerateRecords(recCase{
+			Series: 300_000, SamplesPerSeries: 1, ExtraLabels: extraLabels,
+		})
+		m.relabelConfigs = nil
+		m.StoreSeries(kept.Series, 0)
+		m.relabelConfigs = keepRegex("a_metric_name_that_matches_nothing")
+		m.StoreSeries(dropped.Series, 0)
+		if len(m.seriesLabels) != 300_000 || len(m.droppedSeries) != 300_000 {
+			b.Fatalf("maps: kept=%d dropped=%d", len(m.seriesLabels), len(m.droppedSeries))
+		}
+		perIter := len(dropped.Samples)
+		total := 0
+		b.ResetTimer()
+		for b.Loop() {
+			m.Append(dropped.Samples)
+			total += perIter
+		}
+		b.StopTimer()
+		b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(total), "ns/sample")
+	})
+
+	// A selective remote write config: the traffic goes through dropped series.
+	for _, n := range []int{100_000, 500_000} {
+		b.Run(fmt.Sprintf("dropped/selective/series=%d", n), func(b *testing.B) {
+			recs := testwal.GenerateRecords(recCase{
+				Series: n, SamplesPerSeries: 1, ExtraLabels: extraLabels,
+			})
+			m := newQM(b)
+			m.relabelConfigs = keepRegex("a_metric_name_that_matches_nothing")
+			m.StoreSeries(recs.Series, 0)
+			if len(m.seriesLabels) != 0 {
+				b.Fatalf("expected every series to be dropped, %d kept", len(m.seriesLabels))
+			}
+			perIter := len(recs.Samples)
+			total := 0
+			b.ResetTimer()
+			for b.Loop() {
+				m.Append(recs.Samples)
+				total += perIter
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(total), "ns/sample")
+		})
+	}
+}


### PR DESCRIPTION
The WAL watcher decodes and filters everything TSDB ingests, regardless of how
many series survive `write_relabel_configs`. With a selective `keep` filter the
dropped path in `QueueManager.Append` therefore carries almost the entire
stream, and `WithLabelValues` is called on every dropped sample — hashing the
label values, taking a lock and validating UTF-8 of what is a compile-time
constant at each of these call sites.

This resolves the counters at most once per `Append` call instead. They are
resolved lazily rather than up front, so reasons that never occur are still not
created and the exported series stay identical to before.

The first commit adds the benchmark. `BenchmarkSampleSend` only covers the case
where every series is kept and nothing was ever dropped, which is the opposite
of what a selective remote write configuration does.

#### Benchmark

`benchstat`, 10 runs each, Apple M3 Pro:

```
                                     │   before    │            after             │
                                     │ sec/sample  │ sec/sample   vs base         │
kept/no-relabel                        115.3n ± 6%  120.2n ±  7%       ~ (p=0.255)
kept/large-dropped                     114.8n ± 3%  117.0n ±  3%  +1.92% (p=0.050)
dropped/both-maps-large                72.81n ±15%  28.75n ± 11% -60.52% (p=0.000)
dropped/selective/series=100000        43.07n ± 1%  14.07n ±  1% -67.33% (p=0.000)
dropped/selective/series=500000        56.99n ± 9%  19.12n ± 17% -66.45% (p=0.000)
geomean                                74.95n       40.49n       -45.99%
```

The `kept/*` cases are where this change could only cost something, and they
come out unchanged. `kept/large-dropped` lands exactly on the significance
threshold at +1.92%; that is three struct initialisations per `Append` call,
amortised over a batch of 20k samples.

#### Production measurement

Measured on an instance ingesting 1.2M samples/s with 42M active series, whose
remote write configuration keeps a handful of recording rule outputs out of the
whole stream. Two replicas of one HA pair, identical targets and identical
load, profiled simultaneously for 60s — one running this change, one not:

```
QueueManager.Append          104.94s  ->  73.04s
Watcher.Run                  114.98s  ->  84.35s
WAL watcher goroutines          1.92  ->   1.41  cores
```

Line-level, the `WithLabelValues` call accounted for 12.47s of the 104.94s, and
the sub-calls it makes per sample show up as `hashLabelValues` 4.96s,
`getOrCreateMetricWithLabelValues` 4.89s and `validateLabelValues` 2.35s.

Before the change that watcher could not keep up with WAL writes and its lag
grew by roughly six WAL segments per hour; after it the lag stays at zero.

Note that the profile above was taken with an earlier revision of this PR that
resolved the counters eagerly. `TestRemoteWrite_PerQueueMetricsAfterRelabeling`
caught that this materialised reasons that had never occurred, so the current
revision resolves them lazily. The hot path is the same either way.

#### A related change I left out

I also have a change that reorders the two map lookups so `droppedSeries` is
tested first. On a selective configuration that is where the common case lives,
so it removes the `seriesLabels` miss from the hot path and roughly halves the
remaining cost again.

It regresses `kept/large-dropped` by ~28% though — a configuration where the
kept series carry the traffic while a large `droppedSeries` map sits alongside
them — because every kept sample then pays an extra probe into the large map.
That seemed like the wrong trade to make on everyone's behalf, so it is not in
this PR. Happy to add it if you think it is worth having.

#### Which issue(s) does the PR fix:

None.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[PERF] Remote-write: Speed up handling of samples dropped by `write_relabel_configs` by up to ~3x, reducing WAL watcher CPU usage for selective remote write configurations.
```
