### PR TITLE
tsdb: return chunks to pool after query iteration

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -639,7 +639,7 @@ func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.
 
 		for _, chk := range chks {
 			// Load the actual data of the chunk.
-			chk, iterable, err := chunkr.ChunkOrIterable(chk)
+			chk, iterable, _, err := chunkr.ChunkOrIterable(chk)
 			if err != nil {
 				return err
 			}

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -136,10 +136,25 @@ type ChunkReader interface {
 	// Only one of chunk or iterable should be returned. In some cases you may
 	// always expect a chunk to be returned. You can check that iterable is nil
 	// in those cases.
-	ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, error)
+	// The returned bool is true if the chunk is pool-owned and must be returned
+	// via PutChunk when the caller is done with it.
+	ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, bool, error)
+
+	// PutChunk returns a chunk to the pool so it can be reused by subsequent
+	// queries. It must only be called with chunks for which ChunkOrIterable
+	// returned true as the third return value.
+	PutChunk(chunkenc.Chunk) error
 
 	// Close releases all underlying resources of the reader.
 	Close() error
+}
+
+// ChunkIterableReleaser is an optional interface implemented by iterables
+// returned from ChunkReader.ChunkOrIterable that hold pool-owned component
+// chunks. The caller must call Release after the iterator created from the
+// iterable is no longer in use.
+type ChunkIterableReleaser interface {
+	Release()
 }
 
 // BlockReader provides reading access to a data block.

--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -683,24 +683,24 @@ func (s *Reader) Size() int64 {
 }
 
 // ChunkOrIterable returns a chunk from a given reference.
-func (s *Reader) ChunkOrIterable(meta Meta) (chunkenc.Chunk, chunkenc.Iterable, error) {
+func (s *Reader) ChunkOrIterable(meta Meta) (chunkenc.Chunk, chunkenc.Iterable, bool, error) {
 	sgmIndex, chkStart := BlockChunkRef(meta.Ref).Unpack()
 
 	if sgmIndex >= len(s.bs) {
-		return nil, nil, fmt.Errorf("segment index %d out of range", sgmIndex)
+		return nil, nil, false, fmt.Errorf("segment index %d out of range", sgmIndex)
 	}
 
 	sgmBytes := s.bs[sgmIndex]
 
 	if chkStart+MaxChunkLengthFieldSize > sgmBytes.Len() {
-		return nil, nil, fmt.Errorf("segment doesn't include enough bytes to read the chunk size data field - required:%v, available:%v", chkStart+MaxChunkLengthFieldSize, sgmBytes.Len())
+		return nil, nil, false, fmt.Errorf("segment doesn't include enough bytes to read the chunk size data field - required:%v, available:%v", chkStart+MaxChunkLengthFieldSize, sgmBytes.Len())
 	}
 	// With the minimum chunk length this should never cause us reading
 	// over the end of the slice.
 	c := sgmBytes.Range(chkStart, chkStart+MaxChunkLengthFieldSize)
 	chkDataLen, n := binary.Uvarint(c)
 	if n <= 0 {
-		return nil, nil, fmt.Errorf("reading chunk length failed with %d", n)
+		return nil, nil, false, fmt.Errorf("reading chunk length failed with %d", n)
 	}
 
 	chkEncStart := chkStart + n
@@ -709,18 +709,24 @@ func (s *Reader) ChunkOrIterable(meta Meta) (chunkenc.Chunk, chunkenc.Iterable, 
 	chkDataEnd := chkEnd - crc32.Size
 
 	if chkEnd > sgmBytes.Len() {
-		return nil, nil, fmt.Errorf("segment doesn't include enough bytes to read the chunk - required:%v, available:%v", chkEnd, sgmBytes.Len())
+		return nil, nil, false, fmt.Errorf("segment doesn't include enough bytes to read the chunk - required:%v, available:%v", chkEnd, sgmBytes.Len())
 	}
 
 	sum := sgmBytes.Range(chkDataEnd, chkEnd)
 	if err := checkCRC32(sgmBytes.Range(chkEncStart, chkDataEnd), sum); err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 
 	chkData := sgmBytes.Range(chkDataStart, chkDataEnd)
 	chkEnc := sgmBytes.Range(chkEncStart, chkEncStart+ChunkEncodingSize)[0]
 	chk, err := s.pool.Get(chunkenc.Encoding(chkEnc), chkData)
-	return chk, nil, err
+	return chk, nil, true, err
+}
+
+// PutChunk returns a chunk to the pool so it can be reused by subsequent
+// queries.
+func (s *Reader) PutChunk(c chunkenc.Chunk) error {
+	return s.pool.Put(c)
 }
 
 func nextSequenceFile(dir string) (string, int, error) {

--- a/tsdb/chunks/chunks_test.go
+++ b/tsdb/chunks/chunks_test.go
@@ -28,7 +28,7 @@ func TestReaderWithInvalidBuffer(t *testing.T) {
 	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
 	r := &Reader{bs: []ByteSlice{b}}
 
-	_, _, err := r.ChunkOrIterable(Meta{Ref: 0})
+	_, _, _, err := r.ChunkOrIterable(Meta{Ref: 0})
 	require.Error(t, err)
 }
 

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -7637,7 +7637,7 @@ func TestCompactHeadWithSTStorage_AppendV2(t *testing.T) {
 				require.NoError(t, indexr.Series(p.At(), &builder, &chks))
 
 				for _, chk := range chks {
-					chunk, _, err := chunkr.ChunkOrIterable(chk)
+					chunk, _, _, err := chunkr.ChunkOrIterable(chk)
 					require.NoError(t, err)
 					require.Equal(t, c.expectedEncoding, chunk.Encoding(),
 						"unexpected chunk encoding, got %s", chunk.Encoding())

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3351,7 +3351,7 @@ func TestChunkWriter_ReadAfterWrite(t *testing.T) {
 
 			for _, chks := range test.chks {
 				for _, chkExp := range chks {
-					chkAct, iterable, err := r.ChunkOrIterable(chkExp)
+					chkAct, iterable, _, err := r.ChunkOrIterable(chkExp)
 					require.NoError(t, err)
 					require.Nil(t, iterable)
 					require.Equal(t, chkExp.Chunk.Bytes(), chkAct.Bytes())
@@ -3413,7 +3413,7 @@ func TestChunkReader_ConcurrentReads(t *testing.T) {
 			go func(chunk chunks.Meta) {
 				defer wg.Done()
 
-				chkAct, iterable, err := r.ChunkOrIterable(chunk)
+				chkAct, iterable, _, err := r.ChunkOrIterable(chunk)
 				require.NoError(t, err)
 				require.Nil(t, iterable)
 				require.Equal(t, chunk.Chunk.Bytes(), chkAct.Bytes())

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -105,6 +105,7 @@ type Head struct {
 	typeMapPool         zeropool.Pool[map[chunks.HeadSeriesRef]sampleType]
 	bytesPool           zeropool.Pool[[]byte]
 	memChunkPool        sync.Pool
+	safeHeadChunkPool   sync.Pool
 
 	// These pools are only used during WAL/WBL replay and are reset at the end.
 	// NOTE: Adjust resetWLReplayResources() upon changes to the pools.
@@ -321,6 +322,11 @@ func NewHead(r prometheus.Registerer, l *slog.Logger, wal, wbl *wlog.WL, opts *H
 		memChunkPool: sync.Pool{
 			New: func() any {
 				return &memChunk{}
+			},
+		},
+		safeHeadChunkPool: sync.Pool{
+			New: func() any {
+				return &safeHeadChunk{}
 			},
 		},
 		stats:           stats,

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -3879,7 +3879,7 @@ func TestCuttingNewHeadChunks_AppenderV2(t *testing.T) {
 				require.Len(t, chkMetas, len(tc.expectedChks))
 
 				for i, expected := range tc.expectedChks {
-					chk, iterable, err := chkReader.ChunkOrIterable(chkMetas[i])
+					chk, iterable, _, err := chkReader.ChunkOrIterable(chkMetas[i])
 					require.NoError(t, err)
 					require.Nil(t, iterable)
 
@@ -3929,7 +3929,7 @@ func TestHeadDetectsDuplicateSampleAtSizeLimit_AppenderV2(t *testing.T) {
 
 	storedSampleCount := 0
 	for _, chunkMeta := range chunks {
-		chunk, iterable, err := chunkReader.ChunkOrIterable(chunkMeta)
+		chunk, iterable, _, err := chunkReader.ChunkOrIterable(chunkMeta)
 		require.NoError(t, err)
 		require.Nil(t, iterable)
 		storedSampleCount += chunk.NumSamples()
@@ -5051,7 +5051,7 @@ func TestHeadAppenderV2_STStorage(t *testing.T) {
 
 			var actualSTs []int64
 			for _, meta := range chkMetas {
-				chk, iterable, err := chkReader.ChunkOrIterable(meta)
+				chk, iterable, _, err := chkReader.ChunkOrIterable(meta)
 				require.NoError(t, err)
 				require.Nil(t, iterable)
 
@@ -5186,7 +5186,7 @@ func TestHeadAppenderV2_Histogram_STStorage(t *testing.T) {
 
 			var chunkSTs []int64
 			for _, meta := range chkMetas {
-				chk, iterable, err := chkReader.ChunkOrIterable(meta)
+				chk, iterable, _, err := chkReader.ChunkOrIterable(meta)
 				require.NoError(t, err)
 				require.Nil(t, iterable)
 

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -591,7 +591,7 @@ func (h *headChunkReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chu
 
 // PutChunk returns a chunk to the pool.
 func (h *headChunkReader) PutChunk(c chunkenc.Chunk) error {
-	return h.head.opts.ChunkPool.Put(c.(*safeHeadChunk).Chunk)
+	return h.head.putSafeHeadChunk(c)
 }
 
 type ChunkReaderWithCopy interface {
@@ -667,21 +667,24 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 		if err != nil {
 			return nil, 0, false, err
 		}
-		return &safeHeadChunk{
-			Chunk:    chk,
-			s:        s,
-			cid:      cid,
-			isoState: isoState,
-		}, maxTime, true, nil
+		shc := h.safeHeadChunkPool.Get().(*safeHeadChunk)
+		shc.Chunk = chk
+		shc.s = s
+		shc.cid = cid
+		shc.isoState = isoState
+		shc.fromPool = true
+		return shc, maxTime, true, nil
 	}
 
-	// Live head chunk without copy — not pool-owned.
-	return &safeHeadChunk{
-		Chunk:    chk,
-		s:        s,
-		cid:      cid,
-		isoState: isoState,
-	}, maxTime, false, nil
+	// Live head chunk without copy. The inner chunk is not pool-owned but
+	// the safeHeadChunk wrapper is pooled.
+	shc := h.safeHeadChunkPool.Get().(*safeHeadChunk)
+	shc.Chunk = chk
+	shc.s = s
+	shc.cid = cid
+	shc.isoState = isoState
+	shc.fromPool = false
+	return shc, maxTime, true, nil
 }
 
 // chunk returns the chunk for the HeadChunkID from memory or by m-mapping it from the disk.
@@ -777,6 +780,28 @@ type safeHeadChunk struct {
 	s        *memSeries
 	cid      chunks.HeadChunkID
 	isoState *isolationState
+	fromPool bool
+}
+
+func (c *safeHeadChunk) reset() {
+	c.Chunk = nil
+	c.s = nil
+	c.cid = 0
+	c.isoState = nil
+	c.fromPool = false
+}
+
+// putSafeHeadChunk returns a safeHeadChunk wrapper to the pool. The inner
+// chunk is returned to ChunkPool only if it came from there (fromPool is true).
+func (h *Head) putSafeHeadChunk(c chunkenc.Chunk) error {
+	shc := c.(*safeHeadChunk)
+	var err error
+	if shc.fromPool {
+		err = h.opts.ChunkPool.Put(shc.Chunk)
+	}
+	shc.reset()
+	h.safeHeadChunkPool.Put(shc)
+	return err
 }
 
 func (c *safeHeadChunk) Iterator(reuseIter chunkenc.Iterator) chunkenc.Iterator {

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -584,32 +584,37 @@ func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 }
 
 // ChunkOrIterable returns the chunk for the reference number.
-func (h *headChunkReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, error) {
-	chk, _, err := h.chunk(meta, false)
-	return chk, nil, err
+func (h *headChunkReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, bool, error) {
+	chk, _, fromPool, err := h.chunk(meta, false)
+	return chk, nil, fromPool, err
+}
+
+// PutChunk returns a chunk to the pool.
+func (h *headChunkReader) PutChunk(c chunkenc.Chunk) error {
+	return h.head.opts.ChunkPool.Put(c.(*safeHeadChunk).Chunk)
 }
 
 type ChunkReaderWithCopy interface {
-	ChunkOrIterableWithCopy(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, int64, error)
+	ChunkOrIterableWithCopy(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, int64, bool, error)
 }
 
 // ChunkOrIterableWithCopy returns the chunk for the reference number.
 // If the chunk is the in-memory chunk, then it makes a copy and returns the copied chunk, plus the max time of the chunk.
-func (h *headChunkReader) ChunkOrIterableWithCopy(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, int64, error) {
-	chk, maxTime, err := h.chunk(meta, true)
-	return chk, nil, maxTime, err
+func (h *headChunkReader) ChunkOrIterableWithCopy(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, int64, bool, error) {
+	chk, maxTime, fromPool, err := h.chunk(meta, true)
+	return chk, nil, maxTime, fromPool, err
 }
 
 // chunk returns the chunk for the reference number.
 // If copyLastChunk is true, then it makes a copy of the head chunk if asked for it.
 // Also returns max time of the chunk.
-func (h *headChunkReader) chunk(meta chunks.Meta, copyLastChunk bool) (chunkenc.Chunk, int64, error) {
+func (h *headChunkReader) chunk(meta chunks.Meta, copyLastChunk bool) (chunkenc.Chunk, int64, bool, error) {
 	sid, cid, isOOO := unpackHeadChunkRef(meta.Ref)
 
 	s := h.head.series.getByID(sid)
 	// This means that the series has been garbage collected.
 	if s == nil {
-		return nil, 0, storage.ErrNotFound
+		return nil, 0, false, storage.ErrNotFound
 	}
 
 	s.Lock()
@@ -627,14 +632,17 @@ type wrapOOOHeadChunk struct {
 }
 
 // Call with s locked.
-func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool, mint, maxt int64, isoState *isolationState, copyLastChunk bool, headChunks []*memChunk) (chunkenc.Chunk, int64, error) {
+func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool, mint, maxt int64, isoState *isolationState, copyLastChunk bool, headChunks []*memChunk) (chunkenc.Chunk, int64, bool, error) {
 	if isOOO {
 		chk, maxTime, err := s.oooChunk(cid, h.chunkDiskMapper, &h.memChunkPool)
-		return wrapOOOHeadChunk{chk}, maxTime, err
+		// OOO chunks may come from the chunk buffer or write queue rather than
+		// the pool, so they must not be returned to the pool. wrapOOOHeadChunk
+		// makes pool.Put() skip the chunk (unknown type).
+		return wrapOOOHeadChunk{chk}, maxTime, false, err
 	}
 	c, headChunk, isOpen, err := s.chunk(cid, h.chunkDiskMapper, &h.memChunkPool, headChunks)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 	defer func() {
 		if !headChunk {
@@ -647,7 +655,7 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 
 	// This means that the chunk is outside the specified range.
 	if !c.OverlapsClosedInterval(mint, maxt) {
-		return nil, 0, storage.ErrNotFound
+		return nil, 0, false, storage.ErrNotFound
 	}
 
 	chk, maxTime := c.chunk, c.maxTime
@@ -655,19 +663,25 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 		// The caller may ask to copy the head chunk in order to take the
 		// bytes of the chunk without causing the race between read and append.
 		newB := bytes.Clone(s.headChunks.chunk.Bytes())
-		// TODO(codesome): Put back in the pool (non-trivial).
 		chk, err = h.opts.ChunkPool.Get(s.headChunks.chunk.Encoding(), newB)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, false, err
 		}
+		return &safeHeadChunk{
+			Chunk:    chk,
+			s:        s,
+			cid:      cid,
+			isoState: isoState,
+		}, maxTime, true, nil
 	}
 
+	// Live head chunk without copy — not pool-owned.
 	return &safeHeadChunk{
 		Chunk:    chk,
 		s:        s,
 		cid:      cid,
 		isoState: isoState,
-	}, maxTime, nil
+	}, maxTime, false, nil
 }
 
 // chunk returns the chunk for the HeadChunkID from memory or by m-mapping it from the disk.

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -640,7 +640,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		cr.EnableChunkCache()
 
 		// First call: populates the cache.
-		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		_, _, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
 		require.NotNil(t, cr.cachedHeadChunks)
 
@@ -652,7 +652,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		cr.cachedHeadChunks[0] = sentinel
 
 		// Second call (same series, no changes): must take the cache-hit path.
-		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		_, _, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
 		require.Same(t, sentinel, cr.cachedHeadChunks[0], "expected cache hit — the cached slice should not have been re-collected")
 	})
@@ -675,7 +675,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		require.NoError(t, err)
 		cr.EnableChunkCache()
 
-		chk1, _, err := cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		chk1, _, _, err := cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
 		require.NotNil(t, chk1)
 
@@ -703,7 +703,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 
 		// Query the newest head chunk again. With the bug, the stale cache
 		// would be used and return a wrong (mmapped) chunk.
-		chk2, _, err := cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		chk2, _, _, err := cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
 		require.NotNil(t, chk2)
 
@@ -738,7 +738,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		cr.EnableChunkCache()
 
 		// First call: populates the cache.
-		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		_, _, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
 		require.NotNil(t, cr.cachedHeadChunks)
 
@@ -762,7 +762,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		// Query the newest head chunk again. With a stale cache, the
 		// advanced firstChunkID indexes the old slice at the wrong position
 		// and returns an older chunk.
-		chk, _, err := cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		chk, _, _, err := cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
 		require.NotNil(t, chk)
 		require.Len(t, cr.cachedHeadChunks, headChunksLenBefore-1, "the stale cache must be re-collected after truncation")
@@ -806,14 +806,14 @@ func TestHeadChunkReaderCache(t *testing.T) {
 
 		// Populate the cache with the big series: its cap exceeds the bound.
 		bigRef := chunks.NewHeadChunkRef(bigSeries.ref, bigSeries.firstChunkID)
-		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(bigRef)}, false)
+		_, _, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(bigRef)}, false)
 		require.NoError(t, err)
 		require.Greater(t, cap(cr.cachedHeadChunks), headChunksBufMaxCap)
 
 		// Switching to the small series must release the oversized array and
 		// pre-size the replacement from the series' chunk count.
 		smallRef := chunks.NewHeadChunkRef(smallSeries.ref, smallSeries.firstChunkID)
-		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(smallRef)}, false)
+		_, _, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(smallRef)}, false)
 		require.NoError(t, err)
 		require.LessOrEqual(t, cap(cr.cachedHeadChunks), headChunksBufMaxCap)
 	})
@@ -826,7 +826,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		require.NoError(t, err)
 		cr.EnableChunkCache()
 
-		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		_, _, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
 		require.NoError(t, err)
 		require.NotNil(t, cr.cachedHeadChunks)
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2775,16 +2775,16 @@ func TestGCChunkAccess(t *testing.T) {
 
 	cr, err := h.chunksRange(0, 1500, nil)
 	require.NoError(t, err)
-	_, _, err = cr.ChunkOrIterable(chnks[0])
+	_, _, _, err = cr.ChunkOrIterable(chnks[0])
 	require.NoError(t, err)
-	_, _, err = cr.ChunkOrIterable(chnks[1])
+	_, _, _, err = cr.ChunkOrIterable(chnks[1])
 	require.NoError(t, err)
 
 	require.NoError(t, h.Truncate(1500)) // Remove a chunk.
 
-	_, _, err = cr.ChunkOrIterable(chnks[0])
+	_, _, _, err = cr.ChunkOrIterable(chnks[0])
 	require.Equal(t, storage.ErrNotFound, err)
-	_, _, err = cr.ChunkOrIterable(chnks[1])
+	_, _, _, err = cr.ChunkOrIterable(chnks[1])
 	require.NoError(t, err)
 }
 
@@ -2831,18 +2831,18 @@ func TestGCSeriesAccess(t *testing.T) {
 
 	cr, err := h.chunksRange(0, 2000, nil)
 	require.NoError(t, err)
-	_, _, err = cr.ChunkOrIterable(chunks[0])
+	_, _, _, err = cr.ChunkOrIterable(chunks[0])
 	require.NoError(t, err)
-	_, _, err = cr.ChunkOrIterable(chunks[1])
+	_, _, _, err = cr.ChunkOrIterable(chunks[1])
 	require.NoError(t, err)
 
 	require.NoError(t, h.Truncate(2000)) // Remove the series.
 
 	require.Equal(t, (*memSeries)(nil), h.series.getByID(1))
 
-	_, _, err = cr.ChunkOrIterable(chunks[0])
+	_, _, _, err = cr.ChunkOrIterable(chunks[0])
 	require.Equal(t, storage.ErrNotFound, err)
-	_, _, err = cr.ChunkOrIterable(chunks[1])
+	_, _, _, err = cr.ChunkOrIterable(chunks[1])
 	require.Equal(t, storage.ErrNotFound, err)
 }
 
@@ -7187,7 +7187,7 @@ func TestCuttingNewHeadChunks(t *testing.T) {
 				require.Len(t, chkMetas, len(tc.expectedChks))
 
 				for i, expected := range tc.expectedChks {
-					chk, iterable, err := chkReader.ChunkOrIterable(chkMetas[i])
+					chk, iterable, _, err := chkReader.ChunkOrIterable(chkMetas[i])
 					require.NoError(t, err)
 					require.Nil(t, iterable)
 
@@ -7234,7 +7234,7 @@ func TestHeadDetectsDuplicateSampleAtSizeLimit(t *testing.T) {
 
 	storedSampleCount := 0
 	for _, chunkMeta := range chunks {
-		chunk, iterable, err := chunkReader.ChunkOrIterable(chunkMeta)
+		chunk, iterable, _, err := chunkReader.ChunkOrIterable(chunkMeta)
 		require.NoError(t, err)
 		require.Nil(t, iterable)
 		storedSampleCount += chunk.NumSamples()
@@ -8922,7 +8922,7 @@ func TestHeadAppender_STStorage_Disabled(t *testing.T) {
 	require.NoError(t, idxReader.Series(sRef, &lblBuilder, &chkMetas))
 
 	for _, meta := range chkMetas {
-		chk, iterable, err := chkReader.ChunkOrIterable(meta)
+		chk, iterable, _, err := chkReader.ChunkOrIterable(meta)
 		require.NoError(t, err)
 		require.Nil(t, iterable)
 
@@ -9417,7 +9417,7 @@ func TestHeadAppender_STStorage_ChunkEncoding(t *testing.T) {
 				require.NotEmpty(t, chkMetas)
 
 				for _, meta := range chkMetas {
-					chk, iterable, err := chkReader.ChunkOrIterable(meta)
+					chk, iterable, _, err := chkReader.ChunkOrIterable(meta)
 					require.NoError(t, err)
 					require.Nil(t, iterable)
 

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -254,7 +254,7 @@ func (cr *HeadAndOOOChunkReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chu
 
 // PutChunk returns a chunk to the pool.
 func (cr *HeadAndOOOChunkReader) PutChunk(c chunkenc.Chunk) error {
-	return cr.head.opts.ChunkPool.Put(c.(*safeHeadChunk).Chunk)
+	return cr.head.putSafeHeadChunk(c)
 }
 
 // ChunkOrIterableWithCopy implements ChunkReaderWithCopy. The special Copy

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -39,15 +39,32 @@ type HeadAndOOOIndexReader struct {
 	lastGarbageCollectedMmapRef chunks.ChunkDiskMapperRef
 }
 
-var _ chunkenc.Iterable = &mergedOOOChunks{}
+var (
+	_ chunkenc.Iterable     = &mergedOOOChunks{}
+	_ ChunkIterableReleaser = &mergedOOOChunks{}
+)
 
 // mergedOOOChunks holds the list of iterables for overlapping chunks.
+// poolChunks tracks component chunks that came from the pool and must be
+// returned via putChunk after iteration is done.
 type mergedOOOChunks struct {
+	putChunk       func(chunkenc.Chunk) error
 	chunkIterables []chunkenc.Iterable
+	poolChunks     []chunkenc.Chunk
 }
 
-func (o mergedOOOChunks) Iterator(iterator chunkenc.Iterator) chunkenc.Iterator {
+func (o *mergedOOOChunks) Iterator(iterator chunkenc.Iterator) chunkenc.Iterator {
 	return storage.ChainSampleIteratorFromIterables(iterator, o.chunkIterables)
+}
+
+// Release implements ChunkIterableReleaser. It returns pool-owned component
+// chunks to the pool. Must be called after the iterator created from this
+// iterable is no longer in use.
+func (o *mergedOOOChunks) Release() {
+	for _, c := range o.poolChunks {
+		_ = o.putChunk(c)
+	}
+	o.poolChunks = o.poolChunks[:0]
 }
 
 func NewHeadAndOOOIndexReader(head *Head, inoMint, mint, maxt int64, lastGarbageCollectedMmapRef chunks.ChunkDiskMapperRef) *HeadAndOOOIndexReader {
@@ -230,23 +247,28 @@ func NewHeadAndOOOChunkReader(head *Head, mint, maxt int64, cr *headChunkReader,
 	}
 }
 
-func (cr *HeadAndOOOChunkReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, error) {
-	c, it, _, err := cr.chunkOrIterable(meta, false)
-	return c, it, err
+func (cr *HeadAndOOOChunkReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, bool, error) {
+	c, it, _, fromPool, err := cr.chunkOrIterable(meta, false)
+	return c, it, fromPool, err
+}
+
+// PutChunk returns a chunk to the pool.
+func (cr *HeadAndOOOChunkReader) PutChunk(c chunkenc.Chunk) error {
+	return cr.head.opts.ChunkPool.Put(c.(*safeHeadChunk).Chunk)
 }
 
 // ChunkOrIterableWithCopy implements ChunkReaderWithCopy. The special Copy
 // behaviour is only implemented for the in-order head chunk.
-func (cr *HeadAndOOOChunkReader) ChunkOrIterableWithCopy(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, int64, error) {
+func (cr *HeadAndOOOChunkReader) ChunkOrIterableWithCopy(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, int64, bool, error) {
 	return cr.chunkOrIterable(meta, true)
 }
 
-func (cr *HeadAndOOOChunkReader) chunkOrIterable(meta chunks.Meta, copyLastChunk bool) (chunkenc.Chunk, chunkenc.Iterable, int64, error) {
+func (cr *HeadAndOOOChunkReader) chunkOrIterable(meta chunks.Meta, copyLastChunk bool) (chunkenc.Chunk, chunkenc.Iterable, int64, bool, error) {
 	sid, cid, isOOO := unpackHeadChunkRef(meta.Ref)
 	s := cr.head.series.getByID(sid)
 	// This means that the series has been garbage collected.
 	if s == nil {
-		return nil, nil, 0, storage.ErrNotFound
+		return nil, nil, 0, false, storage.ErrNotFound
 	}
 	var isoState *isolationState
 	if cr.cr != nil {
@@ -261,15 +283,17 @@ func (cr *HeadAndOOOChunkReader) chunkOrIterable(meta chunks.Meta, copyLastChunk
 		if !isOOO {
 			headChunks = cr.collectOrGetHeadChunks(s)
 		}
-		c, maxt, err := cr.head.chunkFromSeries(s, cid, isOOO, meta.MinTime, meta.MaxTime, isoState, copyLastChunk, headChunks)
-		return c, nil, maxt, err
+		c, maxt, fromPool, err := cr.head.chunkFromSeries(s, cid, isOOO, meta.MinTime, meta.MaxTime, isoState, copyLastChunk, headChunks)
+		return c, nil, maxt, fromPool, err
 	}
 	mm, ok := meta.Chunk.(*multiMeta)
 	if !ok { // Complete chunk was supplied.
-		return meta.Chunk, nil, meta.MaxTime, nil
+		return meta.Chunk, nil, meta.MaxTime, false, nil
 	}
 	// We have a composite meta: construct a composite iterable.
-	mc := &mergedOOOChunks{}
+	mc := &mergedOOOChunks{putChunk: func(c chunkenc.Chunk) error {
+		return cr.head.opts.ChunkPool.Put(c.(*safeHeadChunk).Chunk)
+	}}
 	var headChunks []*memChunk
 	for _, m := range mm.metas {
 		switch {
@@ -280,14 +304,19 @@ func (cr *HeadAndOOOChunkReader) chunkOrIterable(meta chunks.Meta, copyLastChunk
 			if !isOOO && headChunks == nil {
 				headChunks = cr.collectOrGetHeadChunks(s)
 			}
-			iterable, _, err := cr.head.chunkFromSeries(s, cid, isOOO, m.MinTime, m.MaxTime, isoState, copyLastChunk, headChunks)
+			chk, _, fromPool, err := cr.head.chunkFromSeries(s, cid, isOOO, m.MinTime, m.MaxTime, isoState, copyLastChunk, headChunks)
 			if err != nil {
-				return nil, nil, 0, fmt.Errorf("invalid head chunk: %w", err)
+				// Release any component chunks already collected.
+				mc.Release()
+				return nil, nil, 0, false, fmt.Errorf("invalid head chunk: %w", err)
 			}
-			mc.chunkIterables = append(mc.chunkIterables, iterable)
+			mc.chunkIterables = append(mc.chunkIterables, chk)
+			if fromPool {
+				mc.poolChunks = append(mc.poolChunks, chk)
+			}
 		}
 	}
-	return nil, mc, meta.MaxTime, nil
+	return nil, mc, meta.MaxTime, false, nil
 }
 
 // collectOrGetHeadChunks returns the pre-collected head chunks for s. When the

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -501,7 +501,7 @@ func testOOOHeadChunkReader_Chunk(t *testing.T, scenario sampleTypeScenario) {
 
 		cr := NewHeadAndOOOChunkReader(db.head, 0, 1000, nil, nil, 0)
 		defer cr.Close()
-		c, iterable, err := cr.ChunkOrIterable(chunks.Meta{
+		c, iterable, _, err := cr.ChunkOrIterable(chunks.Meta{
 			Ref: 0x1800000, Chunk: chunkenc.Chunk(nil), MinTime: 100, MaxTime: 300,
 		})
 		require.Nil(t, iterable)
@@ -863,7 +863,7 @@ func testOOOHeadChunkReader_Chunk(t *testing.T, scenario sampleTypeScenario) {
 			cr := NewHeadAndOOOChunkReader(db.head, tc.queryMinT, tc.queryMaxT, nil, nil, 0)
 			defer cr.Close()
 			for i := 0; i < len(chks); i++ {
-				c, iterable, err := cr.ChunkOrIterable(chks[i])
+				c, iterable, _, err := cr.ChunkOrIterable(chks[i])
 				require.NoError(t, err)
 				var it chunkenc.Iterator
 				if tc.expSingleChunks {
@@ -1041,7 +1041,7 @@ func testOOOHeadChunkReader_Chunk_ConsistentQueryResponseDespiteOfHeadExpanding(
 			cr := NewHeadAndOOOChunkReader(db.head, tc.queryMinT, tc.queryMaxT, nil, nil, 0)
 			defer cr.Close()
 			for i := 0; i < len(chks); i++ {
-				c, iterable, err := cr.ChunkOrIterable(chks[i])
+				c, iterable, _, err := cr.ChunkOrIterable(chks[i])
 				require.NoError(t, err)
 				require.Nil(t, c)
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -694,9 +694,28 @@ type populateWithDelGenericSeriesIterator struct {
 	// the chunk returned from cr.ChunkOrIterable(). As that can return a nil
 	// chunk, currMeta.Chunk is not always guaranteed to be set.
 	currMeta chunks.Meta
+	// poolChunk is true if current chunk is pool-owned and must be
+	// returned via PutChunk before next iteration.
+	poolChunk bool
+	// canReturnChunks is true for the sample iterator which returns
+	// chunks to the pool. False for the chunk series iterator which
+	// exposes chunks via At() for the caller to return.
+	canReturnChunks bool
+	// currReleaser is set when the current chunk came from an iterable that
+	// holds pool-owned component chunks (e.g. mergedOOOChunks). It must be
+	// called before advancing to the next chunk or when iteration ends.
+	currReleaser func()
 }
 
 func (p *populateWithDelGenericSeriesIterator) reset(blockID ulid.ULID, cr ChunkReader, chks []chunks.Meta, intervals tombstones.Intervals) {
+	if p.canReturnChunks {
+		if p.poolChunk && p.currMeta.Chunk != nil {
+			_ = p.cr.PutChunk(p.currMeta.Chunk)
+		}
+		if p.currReleaser != nil {
+			p.currReleaser()
+		}
+	}
 	p.blockID = blockID
 	p.cr = cr
 	p.metas = chks
@@ -707,6 +726,8 @@ func (p *populateWithDelGenericSeriesIterator) reset(blockID ulid.ULID, cr Chunk
 	p.intervals = intervals
 	p.currDelIter = nil
 	p.currMeta = chunks.Meta{}
+	p.poolChunk = false
+	p.currReleaser = nil
 }
 
 // If copyHeadChunk is true, then the head chunk (i.e. the in-memory chunk of the TSDB)
@@ -716,6 +737,16 @@ func (p *populateWithDelGenericSeriesIterator) reset(blockID ulid.ULID, cr Chunk
 func (p *populateWithDelGenericSeriesIterator) next(copyHeadChunk bool) bool {
 	if p.err != nil || p.i >= len(p.metas)-1 {
 		return false
+	}
+
+	// Return the previous chunk to the pool before loading the next one.
+	if p.canReturnChunks {
+		if p.poolChunk && p.currMeta.Chunk != nil {
+			_ = p.cr.PutChunk(p.currMeta.Chunk)
+		}
+		if p.currReleaser != nil {
+			p.currReleaser()
+		}
 	}
 
 	p.i++
@@ -733,13 +764,13 @@ func (p *populateWithDelGenericSeriesIterator) next(copyHeadChunk bool) bool {
 	if ok && copyHeadChunk && len(p.bufIter.Intervals) == 0 {
 		// ChunkOrIterableWithCopy will copy the head chunk, if it can.
 		var maxt int64
-		p.currMeta.Chunk, iterable, maxt, p.err = hcr.ChunkOrIterableWithCopy(p.currMeta)
+		p.currMeta.Chunk, iterable, maxt, p.poolChunk, p.err = hcr.ChunkOrIterableWithCopy(p.currMeta)
 		if p.currMeta.Chunk != nil {
 			// For the in-memory head chunk the index reader sets maxt as MaxInt64. We fix it here.
 			p.currMeta.MaxTime = maxt
 		}
 	} else {
-		p.currMeta.Chunk, iterable, p.err = p.cr.ChunkOrIterable(p.currMeta)
+		p.currMeta.Chunk, iterable, p.poolChunk, p.err = p.cr.ChunkOrIterable(p.currMeta)
 	}
 
 	if p.err != nil {
@@ -749,6 +780,7 @@ func (p *populateWithDelGenericSeriesIterator) next(copyHeadChunk bool) bool {
 
 	// Use the single chunk if possible.
 	if p.currMeta.Chunk != nil {
+		p.currReleaser = nil
 		if len(p.bufIter.Intervals) == 0 {
 			// If there is no overlap with deletion intervals and a single chunk is
 			// returned, we can take chunk as it is.
@@ -765,6 +797,13 @@ func (p *populateWithDelGenericSeriesIterator) next(copyHeadChunk bool) bool {
 	// Otherwise, use the iterable to create an iterator.
 	p.bufIter.Iter = iterable.Iterator(p.bufIter.Iter)
 	p.currDelIter = &p.bufIter
+	// If the iterable holds pool-owned component chunks, set up the releaser
+	// so they are returned when advancing past this chunk.
+	if releaser, ok := iterable.(ChunkIterableReleaser); ok {
+		p.currReleaser = releaser.Release
+	} else {
+		p.currReleaser = nil
+	}
 	return true
 }
 
@@ -808,6 +847,7 @@ type populateWithDelSeriesIterator struct {
 }
 
 func (p *populateWithDelSeriesIterator) reset(blockID ulid.ULID, cr ChunkReader, chks []chunks.Meta, intervals tombstones.Intervals) {
+	p.canReturnChunks = true
 	p.populateWithDelGenericSeriesIterator.reset(blockID, cr, chks, intervals)
 	p.curr = nil
 }
@@ -827,6 +867,18 @@ func (p *populateWithDelSeriesIterator) Next() chunkenc.ValueType {
 		}
 		if valueType := p.curr.Next(); valueType != chunkenc.ValNone {
 			return valueType
+		}
+	}
+	// All chunks exhausted. Return the last chunk to the pool.
+	if p.canReturnChunks {
+		if p.poolChunk && p.currMeta.Chunk != nil {
+			_ = p.cr.PutChunk(p.currMeta.Chunk)
+			p.currMeta.Chunk = nil
+			p.poolChunk = false
+		}
+		if p.currReleaser != nil {
+			p.currReleaser()
+			p.currReleaser = nil
 		}
 	}
 	return chunkenc.ValNone
@@ -894,6 +946,7 @@ type populateWithDelChunkSeriesIterator struct {
 }
 
 func (p *populateWithDelChunkSeriesIterator) reset(blockID ulid.ULID, cr ChunkReader, chks []chunks.Meta, intervals tombstones.Intervals) {
+	p.canReturnChunks = false
 	p.populateWithDelGenericSeriesIterator.reset(blockID, cr, chks, intervals)
 	p.currMetaWithChunk = chunks.Meta{}
 	p.chunksFromIterable = p.chunksFromIterable[:0]
@@ -925,13 +978,33 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 			// If ChunkOrIterable() returned a non-nil chunk, the samples in
 			// p.currDelIter will only form one chunk, as the only change
 			// p.currDelIter might make is deleting some samples.
-			if p.populateCurrForSingleChunk() {
+			hasChunk := p.populateCurrForSingleChunk()
+			// The original chunk has been consumed by the re-encoding
+			// iterator and is no longer needed. Return it to the pool if
+			// it came from there. This is safe because the iterator holds
+			// its own copy of the chunk's byte slice, so Reset(nil) in
+			// Pool.Put does not corrupt the iterator.
+			if p.poolChunk {
+				_ = p.cr.PutChunk(p.currMeta.Chunk)
+				p.poolChunk = false
+			}
+			p.currMeta.Chunk = nil
+			if p.currReleaser != nil {
+				p.currReleaser()
+				p.currReleaser = nil
+			}
+			if hasChunk {
 				return true
 			}
 		} else {
 			// If ChunkOrIterable() returned an iterable, multiple chunks may be
 			// created from the samples in p.currDelIter.
-			if p.populateChunksFromIterable() {
+			hasChunk := p.populateChunksFromIterable()
+			if p.currReleaser != nil {
+				p.currReleaser()
+				p.currReleaser = nil
+			}
+			if hasChunk {
 				return true
 			}
 		}
@@ -1361,8 +1434,10 @@ func newNopChunkReader() ChunkReader {
 	}
 }
 
-func (cr nopChunkReader) ChunkOrIterable(chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, error) {
-	return cr.emptyChunk, nil, nil
+func (cr nopChunkReader) ChunkOrIterable(chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, bool, error) {
+	return cr.emptyChunk, nil, false, nil
 }
+
+func (nopChunkReader) PutChunk(chunkenc.Chunk) error { return nil }
 
 func (nopChunkReader) Close() error { return nil }

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/index"
 )
 
@@ -265,15 +266,15 @@ func BenchmarkMergedStringIter(b *testing.B) {
 	b.ReportAllocs()
 }
 
-func createHeadForBenchmarkSelect(b *testing.B, numSeries int, addSeries func(app storage.Appender, i int)) (*Head, *DB) {
-	dir := b.TempDir()
+func createHeadForBenchmarkSelect(tb testing.TB, numSeries int, addSeries func(app storage.Appender, i int)) (*Head, *DB) {
+	dir := tb.TempDir()
 	opts := DefaultOptions()
 	opts.OutOfOrderCapMax = 255
 	opts.OutOfOrderTimeWindow = 1000
 	db, err := Open(dir, nil, nil, opts, nil)
-	require.NoError(b, err)
-	b.Cleanup(func() {
-		require.NoError(b, db.Close())
+	require.NoError(tb, err)
+	tb.Cleanup(func() {
+		require.NoError(tb, db.Close())
 	})
 	h := db.Head()
 
@@ -281,11 +282,11 @@ func createHeadForBenchmarkSelect(b *testing.B, numSeries int, addSeries func(ap
 	for i := range numSeries {
 		addSeries(app, i)
 		if i%1000 == 999 { // Commit every so often, so the appender doesn't get too big.
-			require.NoError(b, app.Commit())
+			require.NoError(tb, app.Commit())
 			app = h.Appender(context.Background())
 		}
 	}
-	require.NoError(b, app.Commit())
+	require.NoError(tb, app.Commit())
 	return h, db
 }
 
@@ -337,6 +338,60 @@ func BenchmarkQuerierSelect(b *testing.B) {
 
 		benchmarkSelect(b, (*queryableBlock)(block), numSeries, false)
 	})
+}
+
+// BenchmarkQuerierSelectWithSamples is like BenchmarkQuerierSelect but also
+// iterates all samples in each series. This exercises the chunk loading and
+// pool return path.
+func BenchmarkQuerierSelectWithSamples(b *testing.B) {
+	numSeries := 1000000
+	h, db := createHeadForBenchmarkSelect(b, numSeries, func(app storage.Appender, i int) {
+		_, err := app.Append(0, labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%d%s", i, postingsBenchSuffix)), int64(i), 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+	})
+
+	b.Run("Head", func(b *testing.B) {
+		benchmarkSelectWithSamples(b, db, numSeries, false)
+	})
+
+	b.Run("Block", func(b *testing.B) {
+		tmpdir := b.TempDir()
+
+		blockdir := createBlockFromHead(b, tmpdir, h)
+		block, err := OpenBlock(nil, blockdir, nil, nil)
+		require.NoError(b, err)
+		defer func() {
+			require.NoError(b, block.Close())
+		}()
+
+		benchmarkSelectWithSamples(b, (*queryableBlock)(block), numSeries, false)
+	})
+}
+
+func benchmarkSelectWithSamples(b *testing.B, queryable storage.Queryable, numSeries int, sorted bool) {
+	matcher := labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")
+	b.ResetTimer()
+	for s := 1; s <= numSeries; s *= 10 {
+		b.Run(fmt.Sprintf("%dof%d", s, numSeries), func(b *testing.B) {
+			q, err := queryable.Querier(0, int64(s-1))
+			require.NoError(b, err)
+
+			b.ResetTimer()
+			var it chunkenc.Iterator
+			for b.Loop() {
+				ss := q.Select(context.Background(), sorted, nil, matcher)
+				for ss.Next() {
+					it = ss.At().Iterator(it)
+					for it.Next() != chunkenc.ValNone {
+					}
+				}
+				require.NoError(b, ss.Err())
+			}
+			q.Close()
+		})
+	}
 }
 
 // Type wrapper to let a Block be a Queryable in benchmarkSelect().

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -772,16 +773,18 @@ func createFakeReaderAndIterables(s ...[]chunks.Sample) (*fakeChunksReader, []ch
 	return f, chks
 }
 
-func (r *fakeChunksReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, error) {
+func (r *fakeChunksReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, bool, error) {
 	if chk, ok := r.chks[meta.Ref]; ok {
-		return chk, nil, nil
+		return chk, nil, false, nil
 	}
 
 	if it, ok := r.iterables[meta.Ref]; ok {
-		return nil, it, nil
+		return nil, it, false, nil
 	}
-	return nil, nil, fmt.Errorf("chunk or iterable not found at ref %v", meta.Ref)
+	return nil, nil, false, fmt.Errorf("chunk or iterable not found at ref %v", meta.Ref)
 }
+
+func (*fakeChunksReader) PutChunk(chunkenc.Chunk) error { return nil }
 
 type mockIterable struct {
 	s []chunks.Sample
@@ -2314,14 +2317,16 @@ func BenchmarkMergedSeriesSet(b *testing.B) {
 
 type mockChunkReader map[chunks.ChunkRef]chunkenc.Chunk
 
-func (cr mockChunkReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, error) {
+func (cr mockChunkReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chunkenc.Iterable, bool, error) {
 	chk, ok := cr[meta.Ref]
 	if ok {
-		return chk, nil, nil
+		return chk, nil, false, nil
 	}
 
-	return nil, nil, errors.New("Chunk with ref not found")
+	return nil, nil, false, errors.New("Chunk with ref not found")
 }
+
+func (mockChunkReader) PutChunk(chunkenc.Chunk) error { return nil }
 
 func (mockChunkReader) Close() error {
 	return nil
@@ -4309,4 +4314,84 @@ func TestBlockBaseQuerierSearchLabelValues(t *testing.T) {
 		}
 		require.Equal(t, []string{"staging", "prod", "dev"}, gotValues)
 	})
+}
+
+// countingPool wraps chunkenc.Pool and counts Get and Put calls.
+type countingPool struct {
+	inner chunkenc.Pool
+	gets  atomic.Int64
+	puts  atomic.Int64
+}
+
+func (p *countingPool) Get(e chunkenc.Encoding, b []byte) (chunkenc.Chunk, error) {
+	p.gets.Inc()
+	return p.inner.Get(e, b)
+}
+
+func (p *countingPool) Put(c chunkenc.Chunk) error {
+	p.puts.Inc()
+	return p.inner.Put(c)
+}
+
+// TestQuerierChunkPoolReturn verifies that chunks obtained from the pool during
+// block query iteration are returned to the pool after the iterator advances
+// to the next chunk or is reset for a new series.
+func TestQuerierChunkPoolReturn(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a head with series that span multiple chunks.
+	// Each series gets 300 samples at 1-second intervals, which with the default
+	// samples-per-chunk setting produces multiple chunks per series.
+	const numSeries = 10
+	const samplesPerSeries = 300
+	h, db := createHeadForBenchmarkSelect(t, numSeries, func(app storage.Appender, i int) {
+		for s := range samplesPerSeries {
+			_, err := app.Append(
+				0,
+				labels.FromStrings("foo", "bar", "i", strconv.Itoa(i)),
+				int64(s),
+				float64(s),
+			)
+			require.NoError(t, err)
+		}
+	})
+	defer func() { require.NoError(t, db.Close()) }()
+
+	// Compact the head into a block.
+	blockdir := createBlockFromHead(t, dir, h)
+
+	// Open the block with a counting pool.
+	pool := &countingPool{inner: chunkenc.NewPool()}
+	block, err := OpenBlock(nil, blockdir, pool, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, block.Close()) }()
+
+	q, err := NewBlockQuerier(block, 0, samplesPerSeries)
+	require.NoError(t, err)
+	defer q.Close()
+
+	matcher := labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")
+	ss := q.Select(context.Background(), false, nil, matcher)
+
+	// Iterate all series and all samples. Reuse the iterator across series
+	// to exercise the reset() path that returns the last chunk.
+	var it chunkenc.Iterator
+	seriesCount := 0
+	for ss.Next() {
+		seriesCount++
+		it = ss.At().Iterator(it)
+		sampleCount := 0
+		for it.Next() != chunkenc.ValNone {
+			sampleCount++
+		}
+		require.NoError(t, it.Err())
+		require.Positive(t, sampleCount)
+	}
+	require.NoError(t, ss.Err())
+	require.Equal(t, numSeries, seriesCount)
+
+	gets := pool.gets.Load()
+	puts := pool.puts.Load()
+	require.Positive(t, gets, "expected chunks to be obtained from the pool")
+	require.Equal(t, gets, puts, "all chunks should be returned to the pool")
 }


### PR DESCRIPTION
I was trying to reduce cpu usage and a lot of it comes from GC, so it's really caused by allocations. From a few pprofs I've collected allocations that are caused by queries are often the main single source, so I was looking at it with the help of LLMs (otherwise it's a ton of data to go through).
One of the thing that was showing up is the old TODO in the code indicating that not everything that's allocated via a pool is returned to the pool, so I tried to work on that.
Turns out that's a very complicated code base that's mixing a lot of different flows - that's because there's the Head that stores all chunks in memory, there are on disk blocks, there's also OoO Head and there are a few different ways chunks are handled on the query path. I wouldn't be able to work on this without LLMs help and it also means that there are flows I might not realise are there, are ways to "hold it".

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: 13th Gen Intel(R) Core(TM) i7-13800H
                                                    │   base.txt    │              return.txt               │             safehead.txt              │
                                                    │    sec/op     │    sec/op      vs base                │    sec/op      vs base                │
QuerierSelect/Head/1of1000000-5                        103.5m ±  5%    109.4m ±  2%   +5.71% (p=0.002 n=10)    111.9m ±  1%   +8.12% (p=0.000 n=10)
QuerierSelect/Head/10of1000000-5                       107.7m ±  1%    108.3m ±  1%        ~ (p=0.089 n=10)    111.6m ±  1%   +3.55% (p=0.000 n=10)
QuerierSelect/Head/100of1000000-5                      103.9m ± 14%    108.0m ±  0%   +3.87% (p=0.000 n=10)    111.3m ±  1%   +7.12% (p=0.000 n=10)
QuerierSelect/Head/1000of1000000-5                     88.97m ±  4%   108.27m ±  1%  +21.69% (p=0.000 n=10)   111.32m ±  0%  +25.12% (p=0.000 n=10)
QuerierSelect/Head/10000of1000000-5                    108.3m ±  1%    108.8m ±  1%        ~ (p=0.280 n=10)    112.0m ±  0%   +3.43% (p=0.000 n=10)
QuerierSelect/Head/100000of1000000-5                   115.2m ±  2%    116.2m ±  3%        ~ (p=0.529 n=10)    119.0m ±  1%   +3.32% (p=0.000 n=10)
QuerierSelect/Head/1000000of1000000-5                  189.4m ±  1%    209.4m ±  3%  +10.57% (p=0.000 n=10)    197.9m ±  3%   +4.49% (p=0.007 n=10)
QuerierSelect/SortedHead/1of1000000-5                  623.1m ±  1%    642.0m ±  2%   +3.02% (p=0.000 n=10)    637.0m ±  0%   +2.22% (p=0.000 n=10)
QuerierSelect/SortedHead/10of1000000-5                 631.7m ±  0%    642.1m ±  3%   +1.65% (p=0.000 n=10)    636.6m ±  0%   +0.77% (p=0.000 n=10)
QuerierSelect/SortedHead/100of1000000-5                631.2m ±  6%    641.0m ±  0%   +1.56% (p=0.023 n=10)    609.6m ±  1%   -3.42% (p=0.001 n=10)
QuerierSelect/SortedHead/1000of1000000-5               631.9m ±  0%    641.9m ±  0%   +1.59% (p=0.001 n=10)    637.3m ±  4%        ~ (p=0.796 n=10)
QuerierSelect/SortedHead/10000of1000000-5              632.4m ±  1%    643.2m ±  2%   +1.72% (p=0.001 n=10)    639.8m ±  2%   +1.18% (p=0.004 n=10)
QuerierSelect/SortedHead/100000of1000000-5             639.9m ±  3%    652.1m ±  0%   +1.91% (p=0.019 n=10)    649.2m ±  1%   +1.45% (p=0.019 n=10)
QuerierSelect/SortedHead/1000000of1000000-5            725.2m ±  6%    750.2m ±  2%        ~ (p=0.089 n=10)    740.3m ±  2%        ~ (p=0.353 n=10)
QuerierSelect/Block/1of1000000-5                       258.0m ±  1%    250.8m ±  1%   -2.79% (p=0.000 n=10)    252.9m ±  1%   -1.99% (p=0.000 n=10)
QuerierSelect/Block/10of1000000-5                      260.0m ±  0%    252.7m ±  1%   -2.81% (p=0.000 n=10)    253.7m ±  0%   -2.43% (p=0.000 n=10)
QuerierSelect/Block/100of1000000-5                     260.4m ±  0%    252.1m ±  1%   -3.17% (p=0.000 n=10)    253.5m ±  0%   -2.63% (p=0.000 n=10)
QuerierSelect/Block/1000of1000000-5                    261.1m ±  1%    251.9m ±  1%   -3.53% (p=0.000 n=10)    253.9m ±  1%   -2.79% (p=0.000 n=10)
QuerierSelect/Block/10000of1000000-5                   259.8m ±  0%    253.3m ±  0%   -2.51% (p=0.000 n=10)    254.9m ±  0%   -1.90% (p=0.000 n=10)
QuerierSelect/Block/100000of1000000-5                  265.6m ±  1%    263.5m ±  0%   -0.78% (p=0.000 n=10)    263.6m ±  1%   -0.76% (p=0.003 n=10)
QuerierSelect/Block/1000000of1000000-5                 357.2m ±  1%    357.0m ±  1%        ~ (p=0.631 n=10)    352.7m ±  1%   -1.25% (p=0.003 n=10)
QuerierSelectWithSamples/Head/1of1000000-5            111.13m ±  1%    91.72m ± 16%  -17.47% (p=0.000 n=10)   111.98m ±  1%   +0.77% (p=0.000 n=10)
QuerierSelectWithSamples/Head/10of1000000-5           111.27m ±  0%    99.62m ± 11%  -10.47% (p=0.000 n=10)   112.10m ±  1%   +0.75% (p=0.009 n=10)
QuerierSelectWithSamples/Head/100of1000000-5           111.1m ±  1%    109.6m ±  1%   -1.29% (p=0.007 n=10)    112.3m ±  1%   +1.13% (p=0.015 n=10)
QuerierSelectWithSamples/Head/1000of1000000-5         111.38m ±  1%   109.79m ±  0%   -1.43% (p=0.000 n=10)    95.42m ±  3%  -14.33% (p=0.000 n=10)
QuerierSelectWithSamples/Head/10000of1000000-5         113.6m ±  1%    112.3m ±  0%   -1.11% (p=0.001 n=10)    114.5m ± 16%        ~ (p=0.529 n=10)
QuerierSelectWithSamples/Head/100000of1000000-5        140.0m ±  1%    137.8m ±  1%   -1.57% (p=0.029 n=10)    140.8m ±  3%        ~ (p=0.796 n=10)
QuerierSelectWithSamples/Head/1000000of1000000-5       393.8m ±  3%    385.8m ±  1%   -2.02% (p=0.000 n=10)    386.1m ±  1%   -1.95% (p=0.002 n=10)
QuerierSelectWithSamples/Block/1of1000000-5            259.0m ±  1%    253.0m ±  2%   -2.33% (p=0.000 n=10)    252.1m ±  1%   -2.68% (p=0.000 n=10)
QuerierSelectWithSamples/Block/10of1000000-5           260.2m ±  0%    251.8m ±  1%   -3.24% (p=0.000 n=10)    253.3m ±  0%   -2.67% (p=0.000 n=10)
QuerierSelectWithSamples/Block/100of1000000-5          260.7m ±  0%    251.8m ±  0%   -3.41% (p=0.000 n=10)    254.1m ±  1%   -2.52% (p=0.000 n=10)
QuerierSelectWithSamples/Block/1000of1000000-5         260.8m ±  0%    252.0m ±  1%   -3.38% (p=0.000 n=10)    254.6m ±  1%   -2.37% (p=0.000 n=10)
QuerierSelectWithSamples/Block/10000of1000000-5        263.0m ±  0%    257.8m ±  0%   -2.00% (p=0.000 n=10)    257.8m ±  0%   -1.97% (p=0.000 n=10)
QuerierSelectWithSamples/Block/100000of1000000-5       304.1m ±  1%    299.9m ±  1%   -1.38% (p=0.001 n=10)    300.1m ±  0%   -1.34% (p=0.000 n=10)
QuerierSelectWithSamples/Block/1000000of1000000-5      618.6m ±  1%    588.1m ±  1%   -4.92% (p=0.000 n=10)    596.3m ±  1%   -3.60% (p=0.000 n=10)
QuerierSelectWithOutOfOrder/Head/1of1000000-5          126.7m ±  1%    122.1m ±  3%   -3.59% (p=0.004 n=10)    125.4m ±  2%        ~ (p=0.684 n=10)
QuerierSelectWithOutOfOrder/Head/10of1000000-5         124.5m ±  1%    105.2m ±  2%  -15.51% (p=0.000 n=10)    125.5m ±  0%   +0.80% (p=0.000 n=10)
QuerierSelectWithOutOfOrder/Head/100of1000000-5        125.5m ± 38%    122.0m ± 12%   -2.76% (p=0.000 n=10)    125.9m ±  2%        ~ (p=0.280 n=10)
QuerierSelectWithOutOfOrder/Head/1000of1000000-5       124.9m ±  3%    122.2m ±  3%   -2.19% (p=0.019 n=10)    126.2m ± 11%        ~ (p=0.739 n=10)
QuerierSelectWithOutOfOrder/Head/10000of1000000-5      129.9m ±  2%    125.3m ±  1%   -3.53% (p=0.000 n=10)    112.1m ±  3%  -13.75% (p=0.000 n=10)
QuerierSelectWithOutOfOrder/Head/100000of1000000-5     165.5m ± 23%    163.9m ±  4%        ~ (p=0.218 n=10)    166.1m ±  6%        ~ (p=0.971 n=10)
QuerierSelectWithOutOfOrder/Head/1000000of1000000-5    482.3m ±  4%    489.5m ±  2%        ~ (p=0.280 n=10)    492.9m ±  1%        ~ (p=0.190 n=10)
geomean                                                225.7m          223.1m         -1.13%                   225.7m         +0.02%

                                                    │   base.txt   │             return.txt              │              safehead.txt              │
                                                    │     B/op     │     B/op      vs base               │     B/op      vs base                  │
QuerierSelect/Head/1of1000000-5                         480.0 ± 0%     480.0 ± 0%       ~ (p=1.000 n=10)     480.0 ± 0%        ~ (p=0.737 n=10)
QuerierSelect/Head/10of1000000-5                      1.031Ki ± 0%   1.031Ki ± 0%       ~ (p=1.000 n=10)   1.031Ki ± 0%        ~ (p=1.000 n=10) ¹
QuerierSelect/Head/100of1000000-5                     6.656Ki ± 0%   6.656Ki ± 0%       ~ (p=1.000 n=10)   6.656Ki ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Head/1000of1000000-5                    62.91Ki ± 0%   62.91Ki ± 0%       ~ (p=1.000 n=10)   62.91Ki ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Head/10000of1000000-5                   625.4Ki ± 0%   625.4Ki ± 0%       ~ (p=1.000 n=10)   625.4Ki ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Head/100000of1000000-5                  6.104Mi ± 0%   6.104Mi ± 0%       ~ (p=1.000 n=10)   6.104Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Head/1000000of1000000-5                 61.04Mi ± 0%   61.04Mi ± 0%       ~ (p=0.721 n=10)   61.04Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/1of1000000-5                 50.50Mi ± 0%   50.50Mi ± 0%       ~ (p=1.000 n=10)   50.50Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/10of1000000-5                50.50Mi ± 0%   50.50Mi ± 0%       ~ (p=1.000 n=10)   50.50Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/100of1000000-5               50.50Mi ± 0%   50.50Mi ± 0%       ~ (p=1.000 n=10)   50.50Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/1000of1000000-5              50.56Mi ± 0%   50.56Mi ± 0%       ~ (p=1.000 n=10)   50.56Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/10000of1000000-5             51.11Mi ± 0%   51.11Mi ± 0%       ~ (p=1.000 n=10)   51.11Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/100000of1000000-5            56.60Mi ± 0%   56.60Mi ± 0%       ~ (p=1.000 n=10)   56.60Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/1000000of1000000-5           111.5Mi ± 0%   111.5Mi ± 0%       ~ (p=1.000 n=10)   111.5Mi ± 0%        ~ (p=0.596 n=10)
QuerierSelect/Block/1of1000000-5                      48.83Mi ± 0%   48.83Mi ± 0%       ~ (p=0.952 n=10)   48.83Mi ± 0%        ~ (p=0.752 n=10)
QuerierSelect/Block/10of1000000-5                     48.83Mi ± 0%   48.83Mi ± 0%       ~ (p=0.776 n=10)   48.83Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Block/100of1000000-5                    48.84Mi ± 0%   48.84Mi ± 0%       ~ (p=0.557 n=10)   48.84Mi ± 0%        ~ (p=0.550 n=10)
QuerierSelect/Block/1000of1000000-5                   48.94Mi ± 0%   48.94Mi ± 0%       ~ (p=0.115 n=10)   48.94Mi ± 0%        ~ (p=0.312 n=10)
QuerierSelect/Block/10000of1000000-5                  49.90Mi ± 0%   49.90Mi ± 0%       ~ (p=0.896 n=10)   49.90Mi ± 0%        ~ (p=0.095 n=10)
QuerierSelect/Block/100000of1000000-5                 59.51Mi ± 0%   59.51Mi ± 0%       ~ (p=0.805 n=10)   59.51Mi ± 0%        ~ (p=0.951 n=10)
QuerierSelect/Block/1000000of1000000-5                155.6Mi ± 0%   155.6Mi ± 0%       ~ (p=0.582 n=10)   155.6Mi ± 0%        ~ (p=0.350 n=10)
QuerierSelectWithSamples/Head/1of1000000-5              630.5 ± 0%     629.0 ± 0%  -0.24% (p=0.026 n=10)     598.0 ± 1%   -5.15% (p=0.001 n=10)
QuerierSelectWithSamples/Head/10of1000000-5           2.443Ki ± 0%   2.443Ki ± 0%       ~ (p=0.148 n=10)   1.990Ki ± 0%  -18.55% (p=0.000 n=10)
QuerierSelectWithSamples/Head/100of1000000-5          20.72Ki ± 0%   20.73Ki ± 0%  +0.00% (p=0.050 n=10)   16.05Ki ± 0%  -22.54% (p=0.000 n=10)
QuerierSelectWithSamples/Head/1000of1000000-5         203.5Ki ± 0%   203.5Ki ± 0%  +0.00% (p=0.020 n=10)   156.7Ki ± 0%  -23.02% (p=0.000 n=10)
QuerierSelectWithSamples/Head/10000of1000000-5        1.984Mi ± 0%   1.984Mi ± 0%  +0.00% (p=0.019 n=10)   1.526Mi ± 0%  -23.07% (p=0.000 n=10)
QuerierSelectWithSamples/Head/100000of1000000-5       19.84Mi ± 0%   19.84Mi ± 0%       ~ (p=0.737 n=10)   15.26Mi ± 0%  -23.08% (p=0.000 n=10)
QuerierSelectWithSamples/Head/1000000of1000000-5      198.4Mi ± 0%   198.4Mi ± 0%       ~ (p=0.471 n=10)   152.6Mi ± 0%  -23.08% (p=0.000 n=10)
QuerierSelectWithSamples/Block/1of1000000-5           48.83Mi ± 0%   48.83Mi ± 0%  -0.00% (p=0.001 n=10)   48.83Mi ± 0%   -0.00% (p=0.001 n=10)
QuerierSelectWithSamples/Block/10of1000000-5          48.83Mi ± 0%   48.83Mi ± 0%  -0.00% (p=0.001 n=10)   48.83Mi ± 0%   -0.00% (p=0.001 n=10)
QuerierSelectWithSamples/Block/100of1000000-5         48.86Mi ± 0%   48.86Mi ± 0%  -0.01% (p=0.000 n=10)   48.86Mi ± 0%   -0.01% (p=0.000 n=10)
QuerierSelectWithSamples/Block/1000of1000000-5        49.16Mi ± 0%   49.13Mi ± 0%  -0.06% (p=0.000 n=10)   49.13Mi ± 0%   -0.06% (p=0.000 n=10)
QuerierSelectWithSamples/Block/10000of1000000-5       52.19Mi ± 0%   51.88Mi ± 0%  -0.58% (p=0.000 n=10)   51.88Mi ± 0%   -0.58% (p=0.000 n=10)
QuerierSelectWithSamples/Block/100000of1000000-5      82.40Mi ± 0%   79.35Mi ± 0%  -3.70% (p=0.000 n=10)   79.35Mi ± 0%   -3.70% (p=0.000 n=10)
QuerierSelectWithSamples/Block/1000000of1000000-5     384.5Mi ± 0%   354.0Mi ± 0%  -7.94% (p=0.000 n=10)   354.0Mi ± 0%   -7.94% (p=0.000 n=10)
QuerierSelectWithOutOfOrder/Head/1of1000000-5           768.0 ± 0%     768.0 ± 0%       ~ (p=1.000 n=10)     768.0 ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/10of1000000-5        5.047Ki ± 0%   5.047Ki ± 0%       ~ (p=1.000 n=10)   5.047Ki ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/100of1000000-5       47.23Ki ± 0%   47.23Ki ± 0%       ~ (p=1.000 n=10)   47.23Ki ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/1000of1000000-5      469.1Ki ± 0%   469.1Ki ± 0%       ~ (p=1.000 n=10)   469.1Ki ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/10000of1000000-5     4.578Mi ± 0%   4.578Mi ± 0%       ~ (p=1.000 n=10)   4.578Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/100000of1000000-5    45.78Mi ± 0%   45.78Mi ± 0%       ~ (p=1.000 n=10)   45.78Mi ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/1000000of1000000-5   457.8Mi ± 0%   457.8Mi ± 0%       ~ (p=0.652 n=10)   457.8Mi ± 0%        ~ (p=1.000 n=10)
geomean                                               3.699Mi        3.688Mi       -0.31%                  3.553Mi        -3.94%
¹ all samples are equal

                                                    │  base.txt   │              return.txt               │             safehead.txt              │
                                                    │  allocs/op  │  allocs/op   vs base                  │  allocs/op   vs base                  │
QuerierSelect/Head/1of1000000-5                        9.000 ± 0%    9.000 ± 0%        ~ (p=1.000 n=10) ¹    9.000 ± 0%        ~ (p=1.000 n=10) ¹
QuerierSelect/Head/10of1000000-5                       27.00 ± 0%    27.00 ± 0%        ~ (p=1.000 n=10) ¹    27.00 ± 0%        ~ (p=1.000 n=10) ¹
QuerierSelect/Head/100of1000000-5                      207.0 ± 0%    207.0 ± 0%        ~ (p=1.000 n=10) ¹    207.0 ± 0%        ~ (p=1.000 n=10) ¹
QuerierSelect/Head/1000of1000000-5                    2.007k ± 0%   2.007k ± 0%        ~ (p=1.000 n=10) ¹   2.007k ± 0%        ~ (p=1.000 n=10) ¹
QuerierSelect/Head/10000of1000000-5                   20.01k ± 0%   20.01k ± 0%        ~ (p=1.000 n=10) ¹   20.01k ± 0%        ~ (p=1.000 n=10) ¹
QuerierSelect/Head/100000of1000000-5                  200.0k ± 0%   200.0k ± 0%        ~ (p=1.000 n=10)     200.0k ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Head/1000000of1000000-5                 2.000M ± 0%   2.000M ± 0%        ~ (p=1.000 n=10)     2.000M ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/1of1000000-5                  41.00 ± 0%    41.00 ± 0%        ~ (p=1.000 n=10)      41.00 ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/10of1000000-5                 59.00 ± 0%    59.00 ± 0%        ~ (p=1.000 n=10)      59.00 ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/100of1000000-5                239.0 ± 0%    239.0 ± 0%        ~ (p=1.000 n=10)      239.0 ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/1000of1000000-5              2.039k ± 0%   2.039k ± 0%        ~ (p=1.000 n=10)     2.039k ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/10000of1000000-5             20.04k ± 0%   20.04k ± 0%        ~ (p=1.000 n=10)     20.04k ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/100000of1000000-5            200.0k ± 0%   200.0k ± 0%        ~ (p=1.000 n=10)     200.0k ± 0%        ~ (p=1.000 n=10)
QuerierSelect/SortedHead/1000000of1000000-5           2.000M ± 0%   2.000M ± 0%        ~ (p=1.000 n=10)     2.000M ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Block/1of1000000-5                      2.000M ± 0%   2.000M ± 0%        ~ (p=1.000 n=10)     2.000M ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Block/10of1000000-5                     2.000M ± 0%   2.000M ± 0%        ~ (p=1.000 n=10)     2.000M ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Block/100of1000000-5                    2.000M ± 0%   2.000M ± 0%        ~ (p=1.000 n=10)     2.000M ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Block/1000of1000000-5                   2.002M ± 0%   2.002M ± 0%        ~ (p=1.000 n=10)     2.002M ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Block/10000of1000000-5                  2.020M ± 0%   2.020M ± 0%        ~ (p=1.000 n=10)     2.020M ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Block/100000of1000000-5                 2.200M ± 0%   2.200M ± 0%        ~ (p=1.000 n=10)     2.200M ± 0%        ~ (p=1.000 n=10)
QuerierSelect/Block/1000000of1000000-5                4.000M ± 0%   4.000M ± 0%        ~ (p=1.000 n=10)     4.000M ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithSamples/Head/1of1000000-5             11.00 ± 0%    11.00 ± 0%        ~ (p=1.000 n=10) ¹    10.00 ± 0%   -9.09% (p=0.000 n=10)
QuerierSelectWithSamples/Head/10of1000000-5            47.00 ± 0%    47.00 ± 0%        ~ (p=1.000 n=10) ¹    37.00 ± 0%  -21.28% (p=0.000 n=10)
QuerierSelectWithSamples/Head/100of1000000-5           407.0 ± 0%    407.0 ± 0%        ~ (p=1.000 n=10)      307.0 ± 0%  -24.57% (p=0.000 n=10)
QuerierSelectWithSamples/Head/1000of1000000-5         4.007k ± 0%   4.007k ± 0%        ~ (p=1.000 n=10) ¹   3.007k ± 0%  -24.96% (p=0.000 n=10)
QuerierSelectWithSamples/Head/10000of1000000-5        40.01k ± 0%   40.01k ± 0%        ~ (p=1.000 n=10)     30.01k ± 0%  -25.00% (p=0.000 n=10)
QuerierSelectWithSamples/Head/100000of1000000-5       400.0k ± 0%   400.0k ± 0%        ~ (p=1.000 n=10)     300.0k ± 0%  -25.00% (p=0.000 n=10)
QuerierSelectWithSamples/Head/1000000of1000000-5      4.000M ± 0%   4.000M ± 0%        ~ (p=1.000 n=10)     3.000M ± 0%  -25.00% (p=0.000 n=10)
QuerierSelectWithSamples/Block/1of1000000-5           2.000M ± 0%   2.000M ± 0%   -0.00% (p=0.000 n=10)     2.000M ± 0%   -0.00% (p=0.000 n=10)
QuerierSelectWithSamples/Block/10of1000000-5          2.000M ± 0%   2.000M ± 0%   -0.00% (p=0.000 n=10)     2.000M ± 0%   -0.00% (p=0.000 n=10)
QuerierSelectWithSamples/Block/100of1000000-5         2.001M ± 0%   2.000M ± 0%   -0.00% (p=0.000 n=10)     2.000M ± 0%   -0.00% (p=0.000 n=10)
QuerierSelectWithSamples/Block/1000of1000000-5        2.005M ± 0%   2.004M ± 0%   -0.05% (p=0.000 n=10)     2.004M ± 0%   -0.05% (p=0.000 n=10)
QuerierSelectWithSamples/Block/10000of1000000-5       2.050M ± 0%   2.040M ± 0%   -0.49% (p=0.000 n=10)     2.040M ± 0%   -0.49% (p=0.000 n=10)
QuerierSelectWithSamples/Block/100000of1000000-5      2.500M ± 0%   2.400M ± 0%   -4.00% (p=0.000 n=10)     2.400M ± 0%   -4.00% (p=0.000 n=10)
QuerierSelectWithSamples/Block/1000000of1000000-5     7.000M ± 0%   6.000M ± 0%  -14.29% (p=0.000 n=10)     6.000M ± 0%  -14.29% (p=0.000 n=10)
QuerierSelectWithOutOfOrder/Head/1of1000000-5          13.00 ± 0%    13.00 ± 0%        ~ (p=1.000 n=10)      13.00 ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/10of1000000-5         86.00 ± 0%    86.00 ± 0%        ~ (p=1.000 n=10)      86.00 ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/100of1000000-5        806.0 ± 0%    806.0 ± 0%        ~ (p=1.000 n=10)      806.0 ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/1000of1000000-5      8.006k ± 0%   8.006k ± 0%        ~ (p=1.000 n=10)     8.006k ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/10000of1000000-5     80.01k ± 0%   80.01k ± 0%        ~ (p=1.000 n=10)     80.01k ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/100000of1000000-5    800.0k ± 0%   800.0k ± 0%        ~ (p=1.000 n=10)     800.0k ± 0%        ~ (p=1.000 n=10)
QuerierSelectWithOutOfOrder/Head/1000000of1000000-5   8.000M ± 0%   8.000M ± 0%        ~ (p=1.000 n=10)     8.000M ± 0%        ~ (p=1.000 n=10)
geomean                                               36.06k        35.89k        -0.48%                    34.41k        -4.58%
¹ all samples are equal

```

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes

```
