### PR TITLE
mixin: add remote write send-batch latency panel

### DIFF
--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -763,6 +763,31 @@ local row = panel.row;
           + prometheus.withLegendFormat('{{%(clusterLabel)s}}:{{instance}} {{remote_name}}:{{url}}' % $._config),
         ]);
 
+      local sendBatchLatencyQuantiles =
+        panel.timeSeries.new('Send Batch Duration (p95 / p99)')
+        + panelTimeSeriesStdOptions
+        + panel.timeSeries.standardOptions.withUnit('s')
+        + panel.timeSeries.queryOptions.withTargets([
+          prometheus.new(
+            '$datasource',
+            |||
+              histogram_quantile(0.95, sum by (le, %(clusterLabel)s, instance, remote_name, url) (rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}[5m])))
+            ||| % $._config
+          )
+          + prometheus.withFormat('time_series')
+          + prometheus.withIntervalFactor(2)
+          + prometheus.withLegendFormat('{{%(clusterLabel)s}}:{{instance}} {{remote_name}}:{{url}} p95' % $._config),
+          prometheus.new(
+            '$datasource',
+            |||
+              histogram_quantile(0.99, sum by (le, %(clusterLabel)s, instance, remote_name, url) (rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}[5m])))
+            ||| % $._config
+          )
+          + prometheus.withFormat('time_series')
+          + prometheus.withIntervalFactor(2)
+          + prometheus.withLegendFormat('{{%(clusterLabel)s}}:{{instance}} {{remote_name}}:{{url}} p99' % $._config),
+        ]);
+
       dashboard.new('%(prefix)sRemote Write' % $._config.grafanaPrometheus)
       + dashboard.time.withFrom('now-1h')
       + dashboard.withTags($._config.grafanaPrometheus.tags)
@@ -822,6 +847,14 @@ local row = panel.row;
             enqueueRetries,
           ]),
         ], panelWidth=6, panelHeight=7, startY=40)
+        +
+        grafana.util.grid.makeGrid([
+          row.new('Latencies')
+          + row.withPanels([
+            sendBatchLatencyQuantiles
+            + panel.timeSeries.gridPos.withW(24),
+          ]),
+        ], panelWidth=24, panelHeight=7, startY=48)
       ),
   },
 }


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #7218

#### What does this PR do:

Adds a new **Latencies** row to the `prometheus-remote-write` dashboard in the prometheus-mixin, with a single time-series panel plotting the p95 and p99 of the remote write send-batch duration, computed via `histogram_quantile` over `prometheus_remote_storage_sent_batch_duration_seconds_bucket`.

#### Why is it needed:

When debugging the "RW is falling behind" alert or unexpected resharding, the existing dashboard shows shard counts, sample rates, and timestamp lag, but not the actual latency of sending batches to the remote endpoint. Issue #7218 explicitly asks for "a graph of remote write's latencies, either a heatmap via the buckets or histogram_quantile to show p95/p99".

#### Implementation notes

- Uses the existing `panel.timeSeries` + `panelTimeSeriesStdOptions` helpers already used by every other panel in this dashboard, so no new grafonnet surface area is introduced.
- The histogram metric `prometheus_remote_storage_sent_batch_duration_seconds` is emitted by `storage/remote/queue_manager.go` and is labelled with `remote_name` and `url`, so the panel reuses the dashboard's existing `$url` variable and the `remote_name`/`url` legend pattern used by the surrounding panels.
- The query uses `sum by (le, <clusterLabel>, instance, remote_name, url)` so it composes correctly with the dashboard's `$cluster` / `$instance` / `$url` template variables, matching the selector style of the adjacent panels.
- Went with `histogram_quantile` (p95/p99) rather than a heatmap to keep the change to a single well-tested grafonnet panel type; the issue explicitly offers either option.

#### Verification

Could not run `make dashboards_out` locally (no `jsonnet`/`jb` in this environment). The change is a straight copy of the patterns used by the surrounding panels (`samplesRate`, `currentShards`, etc.) and the `||| ... ||| % $._config` string interpolation is the same idiom already used for the timestamp-comparison queries.

#### Release notes for end users (ALL commits must be considered).
```release-notes
[ENHANCEMENT] Mixin: Add a p95/p99 remote-write send-batch latency panel to the remote-write dashboard.
```

#### DCO

Signed-off-by: adisivaprasad <254348101+adisivaprasad@users.noreply.github.com>