### PR TITLE
discovery/rds: skip DB clusters whose ARN is unset

### DIFF
--- a/discovery/aws/rds.go
+++ b/discovery/aws/rds.go
@@ -535,6 +535,12 @@ func (d *RDSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 		wg sync.WaitGroup
 	)
 	for _, cluster := range clusters {
+		if cluster.DBClusterArn == nil {
+			// DBClusterArn is optional in the API response; without it the
+			// cluster's instances cannot be looked up.
+			d.logger.Warn("Skipping DB cluster without an ARN", "identifier", aws.ToString(cluster.DBClusterIdentifier))
+			continue
+		}
 		wg.Add(1)
 
 		instances, err := d.describeDBInstances(ctx, *cluster.DBClusterArn)

--- a/discovery/aws/rds_test.go
+++ b/discovery/aws/rds_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -556,4 +557,58 @@ func TestDescribeAllDBClusters(t *testing.T) {
 	require.Len(t, clusters, 2)
 	require.Contains(t, clusters, "arn:aws:rds:us-east-1:123456789012:cluster:cluster-1")
 	require.Contains(t, clusters, "arn:aws:rds:us-east-1:123456789012:cluster:cluster-2")
+}
+
+func TestRDSRefreshSkipsClusterWithoutArn(t *testing.T) {
+	t.Parallel()
+
+	// DBClusterArn is optional in the DescribeDBClusters response. The
+	// explicit-cluster path stores whatever comes back keyed by the
+	// configured ARN, so refresh() must skip a cluster whose ARN is unset
+	// instead of dereferencing it.
+	const okClusterARN = "arn:aws:rds:us-east-1:123456789012:cluster:ok-cluster"
+	mockClient := &mockRDSClient{
+		clusters: map[string]types.DBCluster{
+			okClusterARN: {
+				DBClusterArn:        aws.String(okClusterARN),
+				DBClusterIdentifier: aws.String("ok-cluster"),
+			},
+			"arnless": {
+				DBClusterIdentifier: aws.String("arnless"),
+			},
+		},
+		instances: map[string][]types.DBInstance{
+			okClusterARN: {
+				{
+					DBInstanceArn:        aws.String("arn:aws:rds:us-east-1:123456789012:db:ok-instance"),
+					DBInstanceIdentifier: aws.String("ok-instance"),
+					DBClusterIdentifier:  aws.String("ok-cluster"),
+					Endpoint: &types.Endpoint{
+						Address: aws.String("ok.instance.aws.internal"),
+						Port:    aws.Int32(5432),
+					},
+				},
+			},
+		},
+	}
+
+	d := &RDSDiscovery{
+		rds:    mockClient,
+		logger: promslog.NewNopLogger(),
+		cfg: &RDSSDConfig{
+			Region:             "us-east-1",
+			Port:               5432,
+			RequestConcurrency: 10,
+			Clusters:           []string{"arnless", okClusterARN},
+		},
+	}
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+
+	// The ARN-less cluster contributes no targets; the healthy one still does.
+	require.Len(t, tgs[0].Targets, 1)
+	addr := tgs[0].Targets[0][model.AddressLabel]
+	require.Equal(t, "ok.instance.aws.internal:5432", string(addr))
 }


### PR DESCRIPTION
Fixes a panic in the RDS service discovery refresh; no tracking issue, found by code reading in the same class as #19324/#19396.

**Problem**

`refresh()` dereferences `*cluster.DBClusterArn` to look up the cluster's instances (rds.go:540 on main). `DBClusterArn` is optional in the `DescribeDBClusters` response — the SDK marks no member of `DBCluster` as required — so a cluster response missing it panics the refresh goroutine and takes the whole process down.

The explicit-cluster path (`clusters:` config) reaches this most easily: `describeDBClusters` stores whatever the API returns keyed by the configured ARN without checking the ARN came back. `describeAllDBClusters` already skips ARN-less clusters (rds.go:421), which is why the all-clusters path never trips this.

**Fix**

Skip the cluster with a warning, mirroring the existing `describeAllDBClusters` behaviour and the "Skipping invalid ElastiCache ARN" precedent in elasticache.go.

**Tests**

`TestRDSRefreshSkipsClusterWithoutArn` drives the real `refresh()` — the existing table test rebuilds the target list inline and never calls it, which is how this survived review. Against unfixed code:

```
panic: runtime error: invalid memory address or nil pointer dereference
\tdiscovery/aws/rds.go:540 +0x294
```

With the fix the ARN-less cluster is skipped, the healthy cluster in the same config still produces its target, and the package suite is green (`ok github.com/prometheus/prometheus/discovery/aws`, matching main).

```release-notes
[BUGFIX] Discovery: RDS SD no longer panics when a described DB cluster has no ARN.
```