### PR TITLE
discovery/aws: describe RDS instances concurrently

### DIFF
--- a/discovery/aws/rds.go
+++ b/discovery/aws/rds.go
@@ -531,20 +531,15 @@ func (d *RDSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 		}
 	}
 
-	var (
-		mu sync.Mutex
-		wg sync.WaitGroup
-	)
+	var mu sync.Mutex
+	errg, ectx := errgroup.WithContext(ctx)
+	errg.SetLimit(d.cfg.RequestConcurrency)
 	for _, cluster := range clusters {
-		wg.Add(1)
-
-		instances, err := d.describeDBInstances(ctx, *cluster.DBClusterArn)
-		if err != nil {
-			return nil, fmt.Errorf("error describing DB instances: %w", err)
-		}
-
-		go func(cluster types.DBCluster, instances []types.DBInstance) {
-			defer wg.Done()
+		errg.Go(func() error {
+			instances, err := d.describeDBInstances(ectx, *cluster.DBClusterArn)
+			if err != nil {
+				return fmt.Errorf("error describing DB instances: %w", err)
+			}
 
 			// Build a map of instance identifiers to their IsClusterWriter status
 			writerMap := make(map[string]bool)
@@ -1040,9 +1035,12 @@ func (d *RDSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 				tg.Targets = append(tg.Targets, labels)
 				mu.Unlock()
 			}
-		}(cluster, instances)
+			return nil
+		})
 	}
 
-	wg.Wait()
+	if err := errg.Wait(); err != nil {
+		return nil, err
+	}
 	return []*targetgroup.Group{tg}, nil
 }

--- a/discovery/aws/rds.go
+++ b/discovery/aws/rds.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"strconv"
 	"sync"
@@ -553,220 +554,230 @@ func (d *RDSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 				}
 			}
 
-			for _, instance := range instances {
-				labels := model.LabelSet{}
+			// Cluster labels are the same for every instance of the cluster, so
+			// build them once and copy them into each target below.
+			commonLabels := model.LabelSet{}
 
-				// Cluster labels
-				if cluster.DBClusterArn != nil {
-					labels[rdsLabelClusterDBClusterArn] = model.LabelValue(*cluster.DBClusterArn)
-				}
-				if cluster.DBClusterIdentifier != nil {
-					labels[rdsLabelClusterDBClusterIdentifier] = model.LabelValue(*cluster.DBClusterIdentifier)
-				}
-				if cluster.ActivityStreamKinesisStreamName != nil {
-					labels[rdsLabelClusterActivityStreamKinesisStreamName] = model.LabelValue(*cluster.ActivityStreamKinesisStreamName)
-				}
-				if cluster.ActivityStreamKmsKeyId != nil {
-					labels[rdsLabelClusterActivityStreamKMSKeyID] = model.LabelValue(*cluster.ActivityStreamKmsKeyId)
-				}
-				if cluster.ActivityStreamMode != "" {
-					labels[rdsLabelClusterActivityStreamMode] = model.LabelValue(cluster.ActivityStreamMode)
-				}
-				if cluster.ActivityStreamStatus != "" {
-					labels[rdsLabelClusterActivityStreamStatus] = model.LabelValue(cluster.ActivityStreamStatus)
-				}
-				if cluster.AllocatedStorage != nil {
-					labels[rdsLabelClusterAllocatedStorage] = model.LabelValue(strconv.Itoa(int(*cluster.AllocatedStorage)))
-				}
-				if cluster.AutoMinorVersionUpgrade != nil {
-					labels[rdsLabelClusterAutoMinorVersionUpgrade] = model.LabelValue(strconv.FormatBool(*cluster.AutoMinorVersionUpgrade))
-				}
-				if cluster.AutomaticRestartTime != nil {
-					labels[rdsLabelClusterAutomaticRestartTime] = model.LabelValue(cluster.AutomaticRestartTime.Format(time.RFC3339))
-				}
-				if cluster.AwsBackupRecoveryPointArn != nil {
-					labels[rdsLabelClusterAwsBackupRecoveryPointArn] = model.LabelValue(*cluster.AwsBackupRecoveryPointArn)
-				}
-				if cluster.BacktrackConsumedChangeRecords != nil {
-					labels[rdsLabelClusterBacktrackConsumedChangeRecords] = model.LabelValue(strconv.FormatInt(*cluster.BacktrackConsumedChangeRecords, 10))
-				}
-				if cluster.BacktrackWindow != nil {
-					labels[rdsLabelClusterBacktrackWindow] = model.LabelValue(strconv.FormatInt(*cluster.BacktrackWindow, 10))
-				}
-				if cluster.BackupRetentionPeriod != nil {
-					labels[rdsLabelClusterBackupRetentionPeriod] = model.LabelValue(strconv.Itoa(int(*cluster.BackupRetentionPeriod)))
-				}
-				if cluster.Capacity != nil {
-					labels[rdsLabelClusterCapacity] = model.LabelValue(strconv.Itoa(int(*cluster.Capacity)))
-				}
-				if cluster.CharacterSetName != nil {
-					labels[rdsLabelClusterCharacterSetName] = model.LabelValue(*cluster.CharacterSetName)
-				}
-				if cluster.CloneGroupId != nil {
-					labels[rdsLabelClusterCloneGroupID] = model.LabelValue(*cluster.CloneGroupId)
-				}
-				if cluster.ClusterCreateTime != nil {
-					labels[rdsLabelClusterClusterCreateTime] = model.LabelValue(cluster.ClusterCreateTime.Format(time.RFC3339))
-				}
-				if cluster.ClusterScalabilityType != "" {
-					labels[rdsLabelClusterClusterScalabilityType] = model.LabelValue(cluster.ClusterScalabilityType)
-				}
-				if cluster.CopyTagsToSnapshot != nil {
-					labels[rdsLabelClusterCopyTagsToSnapshot] = model.LabelValue(strconv.FormatBool(*cluster.CopyTagsToSnapshot))
-				}
-				if cluster.CrossAccountClone != nil {
-					labels[rdsLabelClusterCrossAccountClone] = model.LabelValue(strconv.FormatBool(*cluster.CrossAccountClone))
-				}
-				if cluster.DBClusterInstanceClass != nil {
-					labels[rdsLabelClusterDBClusterInstanceClass] = model.LabelValue(*cluster.DBClusterInstanceClass)
-				}
-				if cluster.DBClusterParameterGroup != nil {
-					labels[rdsLabelClusterDBClusterParameterGroup] = model.LabelValue(*cluster.DBClusterParameterGroup)
-				}
-				if cluster.DBSubnetGroup != nil {
-					labels[rdsLabelClusterDBSubnetGroup] = model.LabelValue(*cluster.DBSubnetGroup)
-				}
-				if cluster.DBSystemId != nil {
-					labels[rdsLabelClusterDBSystemID] = model.LabelValue(*cluster.DBSystemId)
-				}
-				if cluster.DatabaseInsightsMode != "" {
-					labels[rdsLabelClusterDatabaseInsightsMode] = model.LabelValue(cluster.DatabaseInsightsMode)
-				}
-				if cluster.DatabaseName != nil {
-					labels[rdsLabelClusterDatabaseName] = model.LabelValue(*cluster.DatabaseName)
-				}
-				if cluster.DbClusterResourceId != nil {
-					labels[rdsLabelClusterDBClusterResourceID] = model.LabelValue(*cluster.DbClusterResourceId)
-				}
-				if cluster.DeletionProtection != nil {
-					labels[rdsLabelClusterDeletionProtection] = model.LabelValue(strconv.FormatBool(*cluster.DeletionProtection))
-				}
-				if cluster.EarliestBacktrackTime != nil {
-					labels[rdsLabelClusterEarliestBacktrackTime] = model.LabelValue(cluster.EarliestBacktrackTime.Format(time.RFC3339))
-				}
-				if cluster.EarliestRestorableTime != nil {
-					labels[rdsLabelClusterEarliestRestorableTime] = model.LabelValue(cluster.EarliestRestorableTime.Format(time.RFC3339))
-				}
-				if cluster.Endpoint != nil {
-					labels[rdsLabelClusterEndpoint] = model.LabelValue(*cluster.Endpoint)
-				}
-				if cluster.Engine != nil {
-					labels[rdsLabelClusterEngine] = model.LabelValue(*cluster.Engine)
-				}
-				if cluster.EngineLifecycleSupport != nil {
-					labels[rdsLabelClusterEngineLifecycleSupport] = model.LabelValue(*cluster.EngineLifecycleSupport)
-				}
-				if cluster.EngineMode != nil {
-					labels[rdsLabelClusterEngineMode] = model.LabelValue(*cluster.EngineMode)
-				}
-				if cluster.EngineVersion != nil {
-					labels[rdsLabelClusterEngineVersion] = model.LabelValue(*cluster.EngineVersion)
-				}
-				if cluster.GlobalClusterIdentifier != nil {
-					labels[rdsLabelClusterGlobalClusterIdentifier] = model.LabelValue(*cluster.GlobalClusterIdentifier)
-				}
-				if cluster.GlobalWriteForwardingRequested != nil {
-					labels[rdsLabelClusterGlobalWriteForwardingRequested] = model.LabelValue(strconv.FormatBool(*cluster.GlobalWriteForwardingRequested))
-				}
-				if cluster.GlobalWriteForwardingStatus != "" {
-					labels[rdsLabelClusterGlobalWriteForwardingStatus] = model.LabelValue(cluster.GlobalWriteForwardingStatus)
-				}
-				if cluster.HostedZoneId != nil {
-					labels[rdsLabelClusterHostedZoneID] = model.LabelValue(*cluster.HostedZoneId)
-				}
-				if cluster.HttpEndpointEnabled != nil {
-					labels[rdsLabelClusterHTTPEndpointEnabled] = model.LabelValue(strconv.FormatBool(*cluster.HttpEndpointEnabled))
-				}
-				if cluster.IAMDatabaseAuthenticationEnabled != nil {
-					labels[rdsLabelClusterIAMDatabaseAuthenticationEnabled] = model.LabelValue(strconv.FormatBool(*cluster.IAMDatabaseAuthenticationEnabled))
-				}
-				if cluster.IOOptimizedNextAllowedModificationTime != nil {
-					labels[rdsLabelClusterIOOptimizedNextAllowedModificationTime] = model.LabelValue(cluster.IOOptimizedNextAllowedModificationTime.Format(time.RFC3339))
-				}
-				if cluster.Iops != nil {
-					labels[rdsLabelClusterIops] = model.LabelValue(strconv.Itoa(int(*cluster.Iops)))
-				}
-				if cluster.KmsKeyId != nil {
-					labels[rdsLabelClusterKMSKeyID] = model.LabelValue(*cluster.KmsKeyId)
-				}
-				if cluster.LatestRestorableTime != nil {
-					labels[rdsLabelClusterLatestRestorableTime] = model.LabelValue(cluster.LatestRestorableTime.Format(time.RFC3339))
-				}
-				if cluster.LocalWriteForwardingStatus != "" {
-					labels[rdsLabelClusterLocalWriteForwardingStatus] = model.LabelValue(cluster.LocalWriteForwardingStatus)
-				}
-				if cluster.MasterUsername != nil {
-					labels[rdsLabelClusterMasterUsername] = model.LabelValue(*cluster.MasterUsername)
-				}
-				if cluster.MonitoringInterval != nil {
-					labels[rdsLabelClusterMonitoringInterval] = model.LabelValue(strconv.Itoa(int(*cluster.MonitoringInterval)))
-				}
-				if cluster.MonitoringRoleArn != nil {
-					labels[rdsLabelClusterMonitoringRoleArn] = model.LabelValue(*cluster.MonitoringRoleArn)
-				}
-				if cluster.MultiAZ != nil {
-					labels[rdsLabelClusterMultiAZ] = model.LabelValue(strconv.FormatBool(*cluster.MultiAZ))
-				}
-				if cluster.NetworkType != nil {
-					labels[rdsLabelClusterNetworkType] = model.LabelValue(*cluster.NetworkType)
-				}
-				if cluster.PercentProgress != nil {
-					labels[rdsLabelClusterPercentProgress] = model.LabelValue(*cluster.PercentProgress)
-				}
-				if cluster.PerformanceInsightsEnabled != nil {
-					labels[rdsLabelClusterPerformanceInsightsEnabled] = model.LabelValue(strconv.FormatBool(*cluster.PerformanceInsightsEnabled))
-				}
-				if cluster.PerformanceInsightsKMSKeyId != nil {
-					labels[rdsLabelClusterPerformanceInsightsKMSKeyID] = model.LabelValue(*cluster.PerformanceInsightsKMSKeyId)
-				}
-				if cluster.PerformanceInsightsRetentionPeriod != nil {
-					labels[rdsLabelClusterPerformanceInsightsRetentionPeriod] = model.LabelValue(strconv.Itoa(int(*cluster.PerformanceInsightsRetentionPeriod)))
-				}
-				if cluster.Port != nil {
-					labels[rdsLabelClusterPort] = model.LabelValue(strconv.Itoa(int(*cluster.Port)))
-				}
-				if cluster.PreferredBackupWindow != nil {
-					labels[rdsLabelClusterPreferredBackupWindow] = model.LabelValue(*cluster.PreferredBackupWindow)
-				}
-				if cluster.PreferredMaintenanceWindow != nil {
-					labels[rdsLabelClusterPreferredMaintenanceWindow] = model.LabelValue(*cluster.PreferredMaintenanceWindow)
-				}
-				if cluster.PubliclyAccessible != nil {
-					labels[rdsLabelClusterPubliclyAccessible] = model.LabelValue(strconv.FormatBool(*cluster.PubliclyAccessible))
-				}
-				if cluster.ReaderEndpoint != nil {
-					labels[rdsLabelClusterReaderEndpoint] = model.LabelValue(*cluster.ReaderEndpoint)
-				}
-				if cluster.ReplicationSourceIdentifier != nil {
-					labels[rdsLabelClusterReplicationSourceIdentifier] = model.LabelValue(*cluster.ReplicationSourceIdentifier)
-				}
-				if cluster.ServerlessV2PlatformVersion != nil {
-					labels[rdsLabelClusterServerlessV2PlatformVersion] = model.LabelValue(*cluster.ServerlessV2PlatformVersion)
-				}
-				if cluster.Status != nil {
-					labels[rdsLabelClusterStatus] = model.LabelValue(*cluster.Status)
-				}
-				if cluster.StorageEncrypted != nil {
-					labels[rdsLabelClusterStorageEncrypted] = model.LabelValue(strconv.FormatBool(*cluster.StorageEncrypted))
-				}
-				if cluster.StorageEncryptionType != "" {
-					labels[rdsLabelClusterStorageEncryptionType] = model.LabelValue(cluster.StorageEncryptionType)
-				}
-				if cluster.StorageThroughput != nil {
-					labels[rdsLabelClusterStorageThroughput] = model.LabelValue(strconv.Itoa(int(*cluster.StorageThroughput)))
-				}
-				if cluster.StorageType != nil {
-					labels[rdsLabelClusterStorageType] = model.LabelValue(*cluster.StorageType)
-				}
-				if cluster.UpgradeRolloutOrder != "" {
-					labels[rdsLabelClusterUpgradeRolloutOrder] = model.LabelValue(cluster.UpgradeRolloutOrder)
-				}
+			// Cluster labels
+			if cluster.DBClusterArn != nil {
+				commonLabels[rdsLabelClusterDBClusterArn] = model.LabelValue(*cluster.DBClusterArn)
+			}
+			if cluster.DBClusterIdentifier != nil {
+				commonLabels[rdsLabelClusterDBClusterIdentifier] = model.LabelValue(*cluster.DBClusterIdentifier)
+			}
+			if cluster.ActivityStreamKinesisStreamName != nil {
+				commonLabels[rdsLabelClusterActivityStreamKinesisStreamName] = model.LabelValue(*cluster.ActivityStreamKinesisStreamName)
+			}
+			if cluster.ActivityStreamKmsKeyId != nil {
+				commonLabels[rdsLabelClusterActivityStreamKMSKeyID] = model.LabelValue(*cluster.ActivityStreamKmsKeyId)
+			}
+			if cluster.ActivityStreamMode != "" {
+				commonLabels[rdsLabelClusterActivityStreamMode] = model.LabelValue(cluster.ActivityStreamMode)
+			}
+			if cluster.ActivityStreamStatus != "" {
+				commonLabels[rdsLabelClusterActivityStreamStatus] = model.LabelValue(cluster.ActivityStreamStatus)
+			}
+			if cluster.AllocatedStorage != nil {
+				commonLabels[rdsLabelClusterAllocatedStorage] = model.LabelValue(strconv.Itoa(int(*cluster.AllocatedStorage)))
+			}
+			if cluster.AutoMinorVersionUpgrade != nil {
+				commonLabels[rdsLabelClusterAutoMinorVersionUpgrade] = model.LabelValue(strconv.FormatBool(*cluster.AutoMinorVersionUpgrade))
+			}
+			if cluster.AutomaticRestartTime != nil {
+				commonLabels[rdsLabelClusterAutomaticRestartTime] = model.LabelValue(cluster.AutomaticRestartTime.Format(time.RFC3339))
+			}
+			if cluster.AwsBackupRecoveryPointArn != nil {
+				commonLabels[rdsLabelClusterAwsBackupRecoveryPointArn] = model.LabelValue(*cluster.AwsBackupRecoveryPointArn)
+			}
+			if cluster.BacktrackConsumedChangeRecords != nil {
+				commonLabels[rdsLabelClusterBacktrackConsumedChangeRecords] = model.LabelValue(strconv.FormatInt(*cluster.BacktrackConsumedChangeRecords, 10))
+			}
+			if cluster.BacktrackWindow != nil {
+				commonLabels[rdsLabelClusterBacktrackWindow] = model.LabelValue(strconv.FormatInt(*cluster.BacktrackWindow, 10))
+			}
+			if cluster.BackupRetentionPeriod != nil {
+				commonLabels[rdsLabelClusterBackupRetentionPeriod] = model.LabelValue(strconv.Itoa(int(*cluster.BackupRetentionPeriod)))
+			}
+			if cluster.Capacity != nil {
+				commonLabels[rdsLabelClusterCapacity] = model.LabelValue(strconv.Itoa(int(*cluster.Capacity)))
+			}
+			if cluster.CharacterSetName != nil {
+				commonLabels[rdsLabelClusterCharacterSetName] = model.LabelValue(*cluster.CharacterSetName)
+			}
+			if cluster.CloneGroupId != nil {
+				commonLabels[rdsLabelClusterCloneGroupID] = model.LabelValue(*cluster.CloneGroupId)
+			}
+			if cluster.ClusterCreateTime != nil {
+				commonLabels[rdsLabelClusterClusterCreateTime] = model.LabelValue(cluster.ClusterCreateTime.Format(time.RFC3339))
+			}
+			if cluster.ClusterScalabilityType != "" {
+				commonLabels[rdsLabelClusterClusterScalabilityType] = model.LabelValue(cluster.ClusterScalabilityType)
+			}
+			if cluster.CopyTagsToSnapshot != nil {
+				commonLabels[rdsLabelClusterCopyTagsToSnapshot] = model.LabelValue(strconv.FormatBool(*cluster.CopyTagsToSnapshot))
+			}
+			if cluster.CrossAccountClone != nil {
+				commonLabels[rdsLabelClusterCrossAccountClone] = model.LabelValue(strconv.FormatBool(*cluster.CrossAccountClone))
+			}
+			if cluster.DBClusterInstanceClass != nil {
+				commonLabels[rdsLabelClusterDBClusterInstanceClass] = model.LabelValue(*cluster.DBClusterInstanceClass)
+			}
+			if cluster.DBClusterParameterGroup != nil {
+				commonLabels[rdsLabelClusterDBClusterParameterGroup] = model.LabelValue(*cluster.DBClusterParameterGroup)
+			}
+			if cluster.DBSubnetGroup != nil {
+				commonLabels[rdsLabelClusterDBSubnetGroup] = model.LabelValue(*cluster.DBSubnetGroup)
+			}
+			if cluster.DBSystemId != nil {
+				commonLabels[rdsLabelClusterDBSystemID] = model.LabelValue(*cluster.DBSystemId)
+			}
+			if cluster.DatabaseInsightsMode != "" {
+				commonLabels[rdsLabelClusterDatabaseInsightsMode] = model.LabelValue(cluster.DatabaseInsightsMode)
+			}
+			if cluster.DatabaseName != nil {
+				commonLabels[rdsLabelClusterDatabaseName] = model.LabelValue(*cluster.DatabaseName)
+			}
+			if cluster.DbClusterResourceId != nil {
+				commonLabels[rdsLabelClusterDBClusterResourceID] = model.LabelValue(*cluster.DbClusterResourceId)
+			}
+			if cluster.DeletionProtection != nil {
+				commonLabels[rdsLabelClusterDeletionProtection] = model.LabelValue(strconv.FormatBool(*cluster.DeletionProtection))
+			}
+			if cluster.EarliestBacktrackTime != nil {
+				commonLabels[rdsLabelClusterEarliestBacktrackTime] = model.LabelValue(cluster.EarliestBacktrackTime.Format(time.RFC3339))
+			}
+			if cluster.EarliestRestorableTime != nil {
+				commonLabels[rdsLabelClusterEarliestRestorableTime] = model.LabelValue(cluster.EarliestRestorableTime.Format(time.RFC3339))
+			}
+			if cluster.Endpoint != nil {
+				commonLabels[rdsLabelClusterEndpoint] = model.LabelValue(*cluster.Endpoint)
+			}
+			if cluster.Engine != nil {
+				commonLabels[rdsLabelClusterEngine] = model.LabelValue(*cluster.Engine)
+			}
+			if cluster.EngineLifecycleSupport != nil {
+				commonLabels[rdsLabelClusterEngineLifecycleSupport] = model.LabelValue(*cluster.EngineLifecycleSupport)
+			}
+			if cluster.EngineMode != nil {
+				commonLabels[rdsLabelClusterEngineMode] = model.LabelValue(*cluster.EngineMode)
+			}
+			if cluster.EngineVersion != nil {
+				commonLabels[rdsLabelClusterEngineVersion] = model.LabelValue(*cluster.EngineVersion)
+			}
+			if cluster.GlobalClusterIdentifier != nil {
+				commonLabels[rdsLabelClusterGlobalClusterIdentifier] = model.LabelValue(*cluster.GlobalClusterIdentifier)
+			}
+			if cluster.GlobalWriteForwardingRequested != nil {
+				commonLabels[rdsLabelClusterGlobalWriteForwardingRequested] = model.LabelValue(strconv.FormatBool(*cluster.GlobalWriteForwardingRequested))
+			}
+			if cluster.GlobalWriteForwardingStatus != "" {
+				commonLabels[rdsLabelClusterGlobalWriteForwardingStatus] = model.LabelValue(cluster.GlobalWriteForwardingStatus)
+			}
+			if cluster.HostedZoneId != nil {
+				commonLabels[rdsLabelClusterHostedZoneID] = model.LabelValue(*cluster.HostedZoneId)
+			}
+			if cluster.HttpEndpointEnabled != nil {
+				commonLabels[rdsLabelClusterHTTPEndpointEnabled] = model.LabelValue(strconv.FormatBool(*cluster.HttpEndpointEnabled))
+			}
+			if cluster.IAMDatabaseAuthenticationEnabled != nil {
+				commonLabels[rdsLabelClusterIAMDatabaseAuthenticationEnabled] = model.LabelValue(strconv.FormatBool(*cluster.IAMDatabaseAuthenticationEnabled))
+			}
+			if cluster.IOOptimizedNextAllowedModificationTime != nil {
+				commonLabels[rdsLabelClusterIOOptimizedNextAllowedModificationTime] = model.LabelValue(cluster.IOOptimizedNextAllowedModificationTime.Format(time.RFC3339))
+			}
+			if cluster.Iops != nil {
+				commonLabels[rdsLabelClusterIops] = model.LabelValue(strconv.Itoa(int(*cluster.Iops)))
+			}
+			if cluster.KmsKeyId != nil {
+				commonLabels[rdsLabelClusterKMSKeyID] = model.LabelValue(*cluster.KmsKeyId)
+			}
+			if cluster.LatestRestorableTime != nil {
+				commonLabels[rdsLabelClusterLatestRestorableTime] = model.LabelValue(cluster.LatestRestorableTime.Format(time.RFC3339))
+			}
+			if cluster.LocalWriteForwardingStatus != "" {
+				commonLabels[rdsLabelClusterLocalWriteForwardingStatus] = model.LabelValue(cluster.LocalWriteForwardingStatus)
+			}
+			if cluster.MasterUsername != nil {
+				commonLabels[rdsLabelClusterMasterUsername] = model.LabelValue(*cluster.MasterUsername)
+			}
+			if cluster.MonitoringInterval != nil {
+				commonLabels[rdsLabelClusterMonitoringInterval] = model.LabelValue(strconv.Itoa(int(*cluster.MonitoringInterval)))
+			}
+			if cluster.MonitoringRoleArn != nil {
+				commonLabels[rdsLabelClusterMonitoringRoleArn] = model.LabelValue(*cluster.MonitoringRoleArn)
+			}
+			if cluster.MultiAZ != nil {
+				commonLabels[rdsLabelClusterMultiAZ] = model.LabelValue(strconv.FormatBool(*cluster.MultiAZ))
+			}
+			if cluster.NetworkType != nil {
+				commonLabels[rdsLabelClusterNetworkType] = model.LabelValue(*cluster.NetworkType)
+			}
+			if cluster.PercentProgress != nil {
+				commonLabels[rdsLabelClusterPercentProgress] = model.LabelValue(*cluster.PercentProgress)
+			}
+			if cluster.PerformanceInsightsEnabled != nil {
+				commonLabels[rdsLabelClusterPerformanceInsightsEnabled] = model.LabelValue(strconv.FormatBool(*cluster.PerformanceInsightsEnabled))
+			}
+			if cluster.PerformanceInsightsKMSKeyId != nil {
+				commonLabels[rdsLabelClusterPerformanceInsightsKMSKeyID] = model.LabelValue(*cluster.PerformanceInsightsKMSKeyId)
+			}
+			if cluster.PerformanceInsightsRetentionPeriod != nil {
+				commonLabels[rdsLabelClusterPerformanceInsightsRetentionPeriod] = model.LabelValue(strconv.Itoa(int(*cluster.PerformanceInsightsRetentionPeriod)))
+			}
+			if cluster.Port != nil {
+				commonLabels[rdsLabelClusterPort] = model.LabelValue(strconv.Itoa(int(*cluster.Port)))
+			}
+			if cluster.PreferredBackupWindow != nil {
+				commonLabels[rdsLabelClusterPreferredBackupWindow] = model.LabelValue(*cluster.PreferredBackupWindow)
+			}
+			if cluster.PreferredMaintenanceWindow != nil {
+				commonLabels[rdsLabelClusterPreferredMaintenanceWindow] = model.LabelValue(*cluster.PreferredMaintenanceWindow)
+			}
+			if cluster.PubliclyAccessible != nil {
+				commonLabels[rdsLabelClusterPubliclyAccessible] = model.LabelValue(strconv.FormatBool(*cluster.PubliclyAccessible))
+			}
+			if cluster.ReaderEndpoint != nil {
+				commonLabels[rdsLabelClusterReaderEndpoint] = model.LabelValue(*cluster.ReaderEndpoint)
+			}
+			if cluster.ReplicationSourceIdentifier != nil {
+				commonLabels[rdsLabelClusterReplicationSourceIdentifier] = model.LabelValue(*cluster.ReplicationSourceIdentifier)
+			}
+			if cluster.ServerlessV2PlatformVersion != nil {
+				commonLabels[rdsLabelClusterServerlessV2PlatformVersion] = model.LabelValue(*cluster.ServerlessV2PlatformVersion)
+			}
+			if cluster.Status != nil {
+				commonLabels[rdsLabelClusterStatus] = model.LabelValue(*cluster.Status)
+			}
+			if cluster.StorageEncrypted != nil {
+				commonLabels[rdsLabelClusterStorageEncrypted] = model.LabelValue(strconv.FormatBool(*cluster.StorageEncrypted))
+			}
+			if cluster.StorageEncryptionType != "" {
+				commonLabels[rdsLabelClusterStorageEncryptionType] = model.LabelValue(cluster.StorageEncryptionType)
+			}
+			if cluster.StorageThroughput != nil {
+				commonLabels[rdsLabelClusterStorageThroughput] = model.LabelValue(strconv.Itoa(int(*cluster.StorageThroughput)))
+			}
+			if cluster.StorageType != nil {
+				commonLabels[rdsLabelClusterStorageType] = model.LabelValue(*cluster.StorageType)
+			}
+			if cluster.UpgradeRolloutOrder != "" {
+				commonLabels[rdsLabelClusterUpgradeRolloutOrder] = model.LabelValue(cluster.UpgradeRolloutOrder)
+			}
 
-				// Cluster tags
-				for _, tag := range cluster.TagList {
-					if tag.Key != nil && tag.Value != nil {
-						labels[model.LabelName(rdsLabelClusterTag+strutil.SanitizeLabelName(*tag.Key))] = model.LabelValue(*tag.Value)
-					}
+			// Cluster tags
+			for _, tag := range cluster.TagList {
+				if tag.Key != nil && tag.Value != nil {
+					commonLabels[model.LabelName(rdsLabelClusterTag+strutil.SanitizeLabelName(*tag.Key))] = model.LabelValue(*tag.Value)
+				}
+			}
+
+			for i, instance := range instances {
+				// The last target takes ownership of commonLabels rather than
+				// copying them, as nothing reads them afterwards.
+				labels := commonLabels
+				if i < len(instances)-1 {
+					labels = make(model.LabelSet, len(commonLabels))
+					maps.Copy(labels, commonLabels)
 				}
 
 				// Instance labels

--- a/discovery/aws/rds_test.go
+++ b/discovery/aws/rds_test.go
@@ -32,6 +32,10 @@ import (
 type mockRDSClient struct {
 	clusters  map[string]types.DBCluster
 	instances map[string][]types.DBInstance
+
+	// onDescribeDBInstances, when set, runs at the start of every
+	// DescribeDBInstances call.
+	onDescribeDBInstances func()
 }
 
 func (m *mockRDSClient) DescribeDBClusters(_ context.Context, input *rds.DescribeDBClustersInput, _ ...func(*rds.Options)) (*rds.DescribeDBClustersOutput, error) {
@@ -55,6 +59,10 @@ func (m *mockRDSClient) DescribeDBClusters(_ context.Context, input *rds.Describ
 }
 
 func (m *mockRDSClient) DescribeDBInstances(_ context.Context, input *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+	if m.onDescribeDBInstances != nil {
+		m.onDescribeDBInstances()
+	}
+
 	var instances []types.DBInstance
 
 	// Check if filtering by cluster
@@ -426,9 +434,9 @@ func TestDescribeAllDBClusters(t *testing.T) {
 	require.Contains(t, clusters, "arn:aws:rds:us-east-1:123456789012:cluster:cluster-2")
 }
 
-// benchmarkRDSFixture builds clusters populated the way the RDS API populates a
+// rdsFixture builds clusters populated the way the RDS API populates a
 // provisioned Aurora PostgreSQL cluster, each with instanceCount instances.
-func benchmarkRDSFixture(clusterCount, instanceCount int) (map[string]types.DBCluster, map[string][]types.DBInstance) {
+func rdsFixture(clusterCount, instanceCount int) (map[string]types.DBCluster, map[string][]types.DBInstance) {
 	createTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	clusters := make(map[string]types.DBCluster, clusterCount)
 	instances := make(map[string][]types.DBInstance, clusterCount)
@@ -550,7 +558,7 @@ func BenchmarkRDSRefresh(b *testing.B) {
 
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			clusters, instances := benchmarkRDSFixture(bm.clusters, bm.instances)
+			clusters, instances := rdsFixture(bm.clusters, bm.instances)
 			d := &RDSDiscovery{
 				logger: promslog.NewNopLogger(),
 				rds:    &mockRDSClient{clusters: clusters, instances: instances},
@@ -572,5 +580,42 @@ func BenchmarkRDSRefresh(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// BenchmarkRDSRefreshAPILatency models the DescribeDBInstances round trip, which
+// dominates a refresh over many clusters and which BenchmarkRDSRefresh cannot
+// show because its client answers instantly. The absolute latency is arbitrary;
+// the ratio between the two benchmarks is what the number says.
+func BenchmarkRDSRefreshAPILatency(b *testing.B) {
+	const (
+		clusterCount = 20
+		roundTrip    = time.Millisecond
+	)
+	clusters, instances := rdsFixture(clusterCount, 2)
+
+	d := &RDSDiscovery{
+		logger: promslog.NewNopLogger(),
+		rds: &mockRDSClient{
+			clusters:              clusters,
+			instances:             instances,
+			onDescribeDBInstances: func() { time.Sleep(roundTrip) },
+		},
+		cfg: &RDSSDConfig{
+			Region:             "us-east-1",
+			Port:               9187,
+			RequestConcurrency: 10,
+		},
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		tgs, err := d.refresh(context.Background())
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(tgs[0].Targets) != clusterCount*2 {
+			b.Fatalf("got %d targets, want %d", len(tgs[0].Targets), clusterCount*2)
+		}
 	}
 }

--- a/discovery/aws/rds_test.go
+++ b/discovery/aws/rds_test.go
@@ -15,9 +15,7 @@ package aws
 
 import (
 	"context"
-	"net"
 	"slices"
-	"strconv"
 	"testing"
 	"time"
 
@@ -25,9 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 // Mock RDS client for testing.
@@ -161,7 +158,7 @@ func TestRDSDiscoveryRefresh(t *testing.T) {
 			},
 			expectedLabels: []model.LabelSet{
 				{
-					model.AddressLabel:                                  model.LabelValue("test-instance-1.xyz.us-east-1.rds.amazonaws.com:5432"),
+					model.AddressLabel:                                  model.LabelValue("test-instance-1.xyz.us-east-1.rds.amazonaws.com:9187"),
 					rdsLabelClusterDBClusterArn:                         model.LabelValue("arn:aws:rds:us-east-1:123456789012:cluster:test-cluster"),
 					rdsLabelClusterDBClusterIdentifier:                  model.LabelValue("test-cluster"),
 					rdsLabelClusterEngine:                               model.LabelValue("aurora-postgresql"),
@@ -238,7 +235,7 @@ func TestRDSDiscoveryRefresh(t *testing.T) {
 			},
 			expectedLabels: []model.LabelSet{
 				{
-					model.AddressLabel:                   model.LabelValue("prod-instance-1.xyz.us-west-2.rds.amazonaws.com:3306"),
+					model.AddressLabel:                   model.LabelValue("prod-instance-1.xyz.us-west-2.rds.amazonaws.com:9187"),
 					rdsLabelClusterDBClusterArn:          model.LabelValue("arn:aws:rds:us-west-2:123456789012:cluster:prod-cluster"),
 					rdsLabelClusterDBClusterIdentifier:   model.LabelValue("prod-cluster"),
 					rdsLabelClusterEngine:                model.LabelValue("aurora-mysql"),
@@ -253,7 +250,7 @@ func TestRDSDiscoveryRefresh(t *testing.T) {
 					rdsLabelInstanceEndpointPort:         model.LabelValue("3306"),
 				},
 				{
-					model.AddressLabel:                   model.LabelValue("prod-instance-2.xyz.us-west-2.rds.amazonaws.com:3306"),
+					model.AddressLabel:                   model.LabelValue("prod-instance-2.xyz.us-west-2.rds.amazonaws.com:9187"),
 					rdsLabelClusterDBClusterArn:          model.LabelValue("arn:aws:rds:us-west-2:123456789012:cluster:prod-cluster"),
 					rdsLabelClusterDBClusterIdentifier:   model.LabelValue("prod-cluster"),
 					rdsLabelClusterEngine:                model.LabelValue("aurora-mysql"),
@@ -321,7 +318,7 @@ func TestRDSDiscoveryRefresh(t *testing.T) {
 			filters: []*Filter{{Name: "engine", Values: []string{"aurora-postgresql"}}},
 			expectedLabels: []model.LabelSet{
 				{
-					model.AddressLabel:                   model.LabelValue("filter-instance-1.rds.amazonaws.com:5432"),
+					model.AddressLabel:                   model.LabelValue("filter-instance-1.rds.amazonaws.com:9187"),
 					rdsLabelClusterDBClusterArn:          model.LabelValue("arn:aws:rds:us-east-1:123456789012:cluster:filter-cluster"),
 					rdsLabelClusterDBClusterIdentifier:   model.LabelValue("filter-cluster"),
 					rdsLabelClusterEngine:                model.LabelValue("aurora-postgresql"),
@@ -366,163 +363,33 @@ func TestRDSDiscoveryRefresh(t *testing.T) {
 			}
 
 			d := &RDSDiscovery{
-				rds: mockClient,
+				logger: promslog.NewNopLogger(),
+				rds:    mockClient,
 				cfg: &RDSSDConfig{
 					Region:             "us-east-1",
+					Port:               9187,
 					RequestConcurrency: 10,
 					Filters:            tt.filters,
 				},
 			}
 
-			tg := &targetgroup.Group{}
-
-			// Get all cluster ARNs
-			var clusterARNs []string
-			for arn := range tt.clusters {
-				clusterARNs = append(clusterARNs, arn)
-			}
-
-			clusters, err := d.describeAllDBClusters(context.Background())
+			tgs, err := d.refresh(context.Background())
 			require.NoError(t, err)
-			require.Len(t, clusters, len(tt.clusters))
-
-			instances := make(map[string][]types.DBInstance)
-			for _, arn := range clusterARNs {
-				clusterInstances, err := d.describeDBInstances(context.Background(), arn)
-				require.NoError(t, err)
-				instances[arn] = clusterInstances
-			}
-
-			// Build targets like the refresh function does
-			for _, cluster := range clusters {
-				writerMap := make(map[string]bool)
-				for _, member := range cluster.DBClusterMembers {
-					if member.DBInstanceIdentifier != nil && member.IsClusterWriter != nil {
-						writerMap[*member.DBInstanceIdentifier] = *member.IsClusterWriter
-					}
-				}
-
-				clusterInstances := instances[*cluster.DBClusterArn]
-				for _, instance := range clusterInstances {
-					labels := model.LabelSet{}
-
-					// Add basic cluster labels
-					if cluster.DBClusterArn != nil {
-						labels[rdsLabelClusterDBClusterArn] = model.LabelValue(*cluster.DBClusterArn)
-					}
-					if cluster.DBClusterIdentifier != nil {
-						labels[rdsLabelClusterDBClusterIdentifier] = model.LabelValue(*cluster.DBClusterIdentifier)
-					}
-					if cluster.Engine != nil {
-						labels[rdsLabelClusterEngine] = model.LabelValue(*cluster.Engine)
-					}
-					if cluster.EngineVersion != nil {
-						labels[rdsLabelClusterEngineVersion] = model.LabelValue(*cluster.EngineVersion)
-					}
-					if cluster.Status != nil {
-						labels[rdsLabelClusterStatus] = model.LabelValue(*cluster.Status)
-					}
-					if cluster.Endpoint != nil {
-						labels[rdsLabelClusterEndpoint] = model.LabelValue(*cluster.Endpoint)
-					}
-					if cluster.Port != nil {
-						labels[rdsLabelClusterPort] = model.LabelValue(strconv.Itoa(int(*cluster.Port)))
-					}
-					if cluster.MasterUsername != nil {
-						labels[rdsLabelClusterMasterUsername] = model.LabelValue(*cluster.MasterUsername)
-					}
-					if cluster.MultiAZ != nil {
-						labels[rdsLabelClusterMultiAZ] = model.LabelValue(strconv.FormatBool(*cluster.MultiAZ))
-					}
-					if cluster.ClusterCreateTime != nil {
-						labels[rdsLabelClusterClusterCreateTime] = model.LabelValue(cluster.ClusterCreateTime.Format(time.RFC3339))
-					}
-
-					// Cluster tags
-					for _, tag := range cluster.TagList {
-						if tag.Key != nil && tag.Value != nil {
-							labels[model.LabelName(rdsLabelClusterTag+*tag.Key)] = model.LabelValue(*tag.Value)
-						}
-					}
-
-					// Add basic instance labels
-					if instance.DBInstanceArn != nil {
-						labels[rdsLabelInstanceDBInstanceArn] = model.LabelValue(*instance.DBInstanceArn)
-					}
-					if instance.DBInstanceIdentifier != nil {
-						labels[rdsLabelInstanceDBInstanceIdentifier] = model.LabelValue(*instance.DBInstanceIdentifier)
-						if isWriter, found := writerMap[*instance.DBInstanceIdentifier]; found {
-							labels[rdsLabelInstanceIsClusterWriter] = model.LabelValue(strconv.FormatBool(isWriter))
-						}
-					}
-					if instance.DBInstanceClass != nil {
-						labels[rdsLabelInstanceDBInstanceClass] = model.LabelValue(*instance.DBInstanceClass)
-					}
-					if instance.DBInstanceStatus != nil {
-						labels[rdsLabelInstanceDBInstanceStatus] = model.LabelValue(*instance.DBInstanceStatus)
-					}
-					if instance.Engine != nil {
-						labels[rdsLabelInstanceEngine] = model.LabelValue(*instance.Engine)
-					}
-					if instance.EngineVersion != nil {
-						labels[rdsLabelInstanceEngineVersion] = model.LabelValue(*instance.EngineVersion)
-					}
-					if instance.AvailabilityZone != nil {
-						labels[rdsLabelInstanceAvailabilityZone] = model.LabelValue(*instance.AvailabilityZone)
-					}
-					if instance.DBClusterIdentifier != nil {
-						labels[rdsLabelInstanceDBClusterIdentifier] = model.LabelValue(*instance.DBClusterIdentifier)
-					}
-					if instance.PubliclyAccessible != nil {
-						labels[rdsLabelInstancePubliclyAccessible] = model.LabelValue(strconv.FormatBool(*instance.PubliclyAccessible))
-					}
-					if instance.InstanceCreateTime != nil {
-						labels[rdsLabelInstanceInstanceCreateTime] = model.LabelValue(instance.InstanceCreateTime.Format(time.RFC3339))
-					}
-					if instance.Endpoint != nil {
-						if instance.Endpoint.Address != nil {
-							labels[rdsLabelInstanceEndpointAddress] = model.LabelValue(*instance.Endpoint.Address)
-						}
-						if instance.Endpoint.Port != nil {
-							labels[rdsLabelInstanceEndpointPort] = model.LabelValue(strconv.Itoa(int(*instance.Endpoint.Port)))
-						}
-						if instance.Endpoint.HostedZoneId != nil {
-							labels[rdsLabelInstanceEndpointHostedZoneID] = model.LabelValue(*instance.Endpoint.HostedZoneId)
-						}
-					}
-
-					// Instance tags
-					for _, tag := range instance.TagList {
-						if tag.Key != nil && tag.Value != nil {
-							labels[model.LabelName(rdsLabelInstanceTag+*tag.Key)] = model.LabelValue(*tag.Value)
-						}
-					}
-
-					// Set address
-					if instance.Endpoint != nil && instance.Endpoint.Address != nil && instance.Endpoint.Port != nil {
-						labels[model.AddressLabel] = model.LabelValue(net.JoinHostPort(*instance.Endpoint.Address, strconv.Itoa(int(*instance.Endpoint.Port))))
-					}
-
-					tg.Targets = append(tg.Targets, labels)
-				}
-			}
+			require.Len(t, tgs, 1)
+			tg := tgs[0]
 
 			require.Len(t, tg.Targets, len(tt.expectedLabels))
 
-			// Verify each expected label set is present
+			// Every expected target must be present with exactly the expected labels.
+			targetsByAddress := make(map[model.LabelValue]model.LabelSet, len(tg.Targets))
+			for _, target := range tg.Targets {
+				targetsByAddress[target[model.AddressLabel]] = target
+			}
 			for _, expectedLabels := range tt.expectedLabels {
-				found := false
-				for _, target := range tg.Targets {
-					if target[model.AddressLabel] == expectedLabels[model.AddressLabel] {
-						found = true
-						// Check all expected labels are present with correct values
-						for key, expectedValue := range expectedLabels {
-							require.Equal(t, expectedValue, target[key], "Label %s mismatch", key)
-						}
-						break
-					}
-				}
-				require.True(t, found, "Expected target with address %s not found", expectedLabels[model.AddressLabel])
+				address := expectedLabels[model.AddressLabel]
+				target, found := targetsByAddress[address]
+				require.True(t, found, "Expected target with address %s not found", address)
+				require.Equal(t, expectedLabels, target)
 			}
 		})
 	}

--- a/discovery/aws/rds_test.go
+++ b/discovery/aws/rds_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"slices"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -618,4 +619,64 @@ func BenchmarkRDSRefreshAPILatency(b *testing.B) {
 			b.Fatalf("got %d targets, want %d", len(tgs[0].Targets), clusterCount*2)
 		}
 	}
+}
+
+func TestRDSDiscoveryDescribesInstancesConcurrently(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterCount = 8
+		concurrency  = 4
+	)
+	clusters, instances := rdsFixture(clusterCount, 1)
+
+	var (
+		mu          sync.Mutex
+		once        sync.Once
+		inFlight    int
+		maxInFlight int
+	)
+	allInFlight := make(chan struct{})
+
+	mockClient := &mockRDSClient{clusters: clusters, instances: instances}
+	mockClient.onDescribeDBInstances = func() {
+		mu.Lock()
+		inFlight++
+		maxInFlight = max(maxInFlight, inFlight)
+		if inFlight == concurrency {
+			once.Do(func() { close(allInFlight) })
+		}
+		mu.Unlock()
+
+		// Hold every call open until RequestConcurrency of them are in flight.
+		// A serial implementation never gets past the first one and falls back
+		// on the timeout, leaving maxInFlight at 1.
+		select {
+		case <-allInFlight:
+		case <-time.After(2 * time.Second):
+		}
+
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+	}
+
+	d := &RDSDiscovery{
+		logger: promslog.NewNopLogger(),
+		rds:    mockClient,
+		cfg: &RDSSDConfig{
+			Region:             "us-east-1",
+			Port:               9187,
+			RequestConcurrency: concurrency,
+		},
+	}
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Len(t, tgs[0].Targets, clusterCount)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, concurrency, maxInFlight, "DescribeDBInstances was not called concurrently")
 }

--- a/discovery/aws/rds_test.go
+++ b/discovery/aws/rds_test.go
@@ -16,6 +16,7 @@ package aws
 import (
 	"context"
 	"slices"
+	"strconv"
 	"testing"
 	"time"
 
@@ -423,4 +424,153 @@ func TestDescribeAllDBClusters(t *testing.T) {
 	require.Len(t, clusters, 2)
 	require.Contains(t, clusters, "arn:aws:rds:us-east-1:123456789012:cluster:cluster-1")
 	require.Contains(t, clusters, "arn:aws:rds:us-east-1:123456789012:cluster:cluster-2")
+}
+
+// benchmarkRDSFixture builds clusters populated the way the RDS API populates a
+// provisioned Aurora PostgreSQL cluster, each with instanceCount instances.
+func benchmarkRDSFixture(clusterCount, instanceCount int) (map[string]types.DBCluster, map[string][]types.DBInstance) {
+	createTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	clusters := make(map[string]types.DBCluster, clusterCount)
+	instances := make(map[string][]types.DBInstance, clusterCount)
+
+	for c := range clusterCount {
+		clusterID := "aurora-cluster-" + strconv.Itoa(c)
+		clusterARN := "arn:aws:rds:us-east-1:123456789012:cluster:" + clusterID
+
+		members := make([]types.DBClusterMember, 0, instanceCount)
+		clusterInstances := make([]types.DBInstance, 0, instanceCount)
+		for i := range instanceCount {
+			instanceID := clusterID + "-instance-" + strconv.Itoa(i)
+			members = append(members, types.DBClusterMember{
+				DBInstanceIdentifier: aws.String(instanceID),
+				IsClusterWriter:      aws.Bool(i == 0),
+				PromotionTier:        aws.Int32(int32(i)),
+			})
+			clusterInstances = append(clusterInstances, types.DBInstance{
+				AutoMinorVersionUpgrade:    aws.Bool(true),
+				AvailabilityZone:           aws.String("us-east-1a"),
+				BackupRetentionPeriod:      aws.Int32(7),
+				CopyTagsToSnapshot:         aws.Bool(true),
+				DBInstanceArn:              aws.String("arn:aws:rds:us-east-1:123456789012:db:" + instanceID),
+				DBInstanceClass:            aws.String("db.r6g.xlarge"),
+				DBInstanceIdentifier:       aws.String(instanceID),
+				DBInstanceStatus:           aws.String("available"),
+				DBClusterIdentifier:        aws.String(clusterID),
+				DbiResourceId:              aws.String("db-ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+				DeletionProtection:         aws.Bool(false),
+				Endpoint:                   &types.Endpoint{Address: aws.String(instanceID + ".xyz.us-east-1.rds.amazonaws.com"), Port: aws.Int32(5432), HostedZoneId: aws.String("Z2R2ITUGPM61AM")},
+				Engine:                     aws.String("aurora-postgresql"),
+				EngineVersion:              aws.String("15.4"),
+				InstanceCreateTime:         aws.Time(createTime),
+				KmsKeyId:                   aws.String("arn:aws:kms:us-east-1:123456789012:key/abcd1234"),
+				MonitoringInterval:         aws.Int32(60),
+				MonitoringRoleArn:          aws.String("arn:aws:iam::123456789012:role/rds-monitoring-role"),
+				MultiAZ:                    aws.Bool(false),
+				NetworkType:                aws.String("IPV4"),
+				PerformanceInsightsEnabled: aws.Bool(true),
+				PreferredBackupWindow:      aws.String("07:00-07:30"),
+				PreferredMaintenanceWindow: aws.String("sun:09:00-sun:09:30"),
+				PromotionTier:              aws.Int32(int32(i)),
+				PubliclyAccessible:         aws.Bool(false),
+				StorageEncrypted:           aws.Bool(true),
+				StorageType:                aws.String("aurora"),
+				TagList: []types.Tag{
+					{Key: aws.String("Name"), Value: aws.String(instanceID)},
+					{Key: aws.String("Environment"), Value: aws.String("production")},
+				},
+			})
+		}
+
+		clusters[clusterARN] = types.DBCluster{
+			ActivityStreamStatus:               types.ActivityStreamStatusStopped,
+			AllocatedStorage:                   aws.Int32(1),
+			AutoMinorVersionUpgrade:            aws.Bool(true),
+			BackupRetentionPeriod:              aws.Int32(7),
+			ClusterCreateTime:                  aws.Time(createTime),
+			CopyTagsToSnapshot:                 aws.Bool(true),
+			CrossAccountClone:                  aws.Bool(false),
+			DatabaseName:                       aws.String("appdb"),
+			DBClusterArn:                       aws.String(clusterARN),
+			DBClusterIdentifier:                aws.String(clusterID),
+			DBClusterMembers:                   members,
+			DBClusterParameterGroup:            aws.String("default.aurora-postgresql15"),
+			DbClusterResourceId:                aws.String("cluster-ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+			DBSubnetGroup:                      aws.String("default-vpc-0123456789abcdef0"),
+			DeletionProtection:                 aws.Bool(false),
+			EarliestRestorableTime:             aws.Time(createTime),
+			Endpoint:                           aws.String(clusterID + ".cluster-xyz.us-east-1.rds.amazonaws.com"),
+			Engine:                             aws.String("aurora-postgresql"),
+			EngineLifecycleSupport:             aws.String("open-source-rds-extended-support"),
+			EngineMode:                         aws.String("provisioned"),
+			EngineVersion:                      aws.String("15.4"),
+			HostedZoneId:                       aws.String("Z2R2ITUGPM61AM"),
+			HttpEndpointEnabled:                aws.Bool(false),
+			IAMDatabaseAuthenticationEnabled:   aws.Bool(false),
+			KmsKeyId:                           aws.String("arn:aws:kms:us-east-1:123456789012:key/abcd1234"),
+			LatestRestorableTime:               aws.Time(createTime),
+			LocalWriteForwardingStatus:         types.LocalWriteForwardingStatusDisabled,
+			MasterUsername:                     aws.String("postgres"),
+			MonitoringInterval:                 aws.Int32(60),
+			MonitoringRoleArn:                  aws.String("arn:aws:iam::123456789012:role/rds-monitoring-role"),
+			MultiAZ:                            aws.Bool(true),
+			NetworkType:                        aws.String("IPV4"),
+			PercentProgress:                    aws.String("100"),
+			PerformanceInsightsEnabled:         aws.Bool(true),
+			PerformanceInsightsRetentionPeriod: aws.Int32(7),
+			Port:                               aws.Int32(5432),
+			PreferredBackupWindow:              aws.String("07:00-07:30"),
+			PreferredMaintenanceWindow:         aws.String("sun:09:00-sun:09:30"),
+			PubliclyAccessible:                 aws.Bool(false),
+			ReaderEndpoint:                     aws.String(clusterID + ".cluster-ro-xyz.us-east-1.rds.amazonaws.com"),
+			Status:                             aws.String("available"),
+			StorageEncrypted:                   aws.Bool(true),
+			StorageType:                        aws.String("aurora"),
+			TagList: []types.Tag{
+				{Key: aws.String("Name"), Value: aws.String(clusterID)},
+				{Key: aws.String("Environment"), Value: aws.String("production")},
+				{Key: aws.String("Team"), Value: aws.String("platform")},
+			},
+		}
+		instances[clusterARN] = clusterInstances
+	}
+
+	return clusters, instances
+}
+
+func BenchmarkRDSRefresh(b *testing.B) {
+	benchmarks := []struct {
+		name      string
+		clusters  int
+		instances int
+	}{
+		{"1Cluster/1Instance", 1, 1},
+		{"1Cluster/16Instances", 1, 16},
+		{"20Clusters/4Instances", 20, 4},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			clusters, instances := benchmarkRDSFixture(bm.clusters, bm.instances)
+			d := &RDSDiscovery{
+				logger: promslog.NewNopLogger(),
+				rds:    &mockRDSClient{clusters: clusters, instances: instances},
+				cfg: &RDSSDConfig{
+					Region:             "us-east-1",
+					Port:               9187,
+					RequestConcurrency: 10,
+				},
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				tgs, err := d.refresh(context.Background())
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(tgs[0].Targets) != bm.clusters*bm.instances {
+					b.Fatalf("got %d targets, want %d", len(tgs[0].Targets), bm.clusters*bm.instances)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Depends on #19504, which this branch is based on. The first three commits belong to that PR; read this one from `perf(discovery/aws): add a benchmark modelling RDS API latency` onwards. The diff will shrink to those three commits once #19504 lands.

`describeDBInstances` was called synchronously in the loop over clusters, so a refresh over N clusters made N round trips one after another, while `request_concurrency` was only ever applied to `DescribeDBClusters`. The per-cluster work now runs in an `errgroup` bounded by `RequestConcurrency`, like `describeDBClusters` already does.

This also drops the `wg.Add(1)` that was executed before a call that could return early, which left already started goroutines appending to a target group nothing waited for.

## Benchmarks

`BenchmarkRDSRefresh` answers every call instantly, so it cannot show this at all. `BenchmarkRDSRefreshAPILatency` holds `DescribeDBInstances` open for a round trip instead. 20 clusters, `request_concurrency: 10`, 1ms per call:

```
                        │    before    │                after                │
                        │    sec/op    │   sec/op     vs base                │
RDSRefreshAPILatency-12   22.846m ± 2%   2.407m ± 1%  -89.47% (p=0.002 n=6)

                        │     B/op     │                B/op                 │
RDSRefreshAPILatency-12   560.8Ki ± 1%   593.3Ki ± 1%  +5.80% (p=0.002 n=6)

                        │  allocs/op   │              allocs/op              │
RDSRefreshAPILatency-12    1.410k ± 0%    1.437k ± 0%  +1.91% (p=0.002 n=6)
```

The absolute latency is arbitrary; the ratio is the point, and it tracks `request_concurrency`.

The CPU-only benchmark regresses, `-count=10`:

```
                                    │    sec/op    vs base                │
RDSRefresh/1Cluster/1Instance-12        9.160µ ± 1%  +1.11% (p=0.000 n=10)
RDSRefresh/1Cluster/16Instances-12      70.99µ ± 1%  +1.97% (p=0.000 n=10)
RDSRefresh/20Clusters/4Instances-12     283.3µ ± 1%  +4.82% (p=0.000 n=10)

                                    │  allocs/op   vs base                │
RDSRefresh/1Cluster/1Instance-12         65.00 ± 0%  +4.84% (p=0.000 n=10)
RDSRefresh/1Cluster/16Instances-12       344.0 ± 0%  +0.88% (p=0.000 n=10)
RDSRefresh/20Clusters/4Instances-12     2.141k ± 0%  +0.23% (p=0.000 n=10)
```

That is the `errgroup`, its derived context and goroutine scheduling: three allocations per refresh, fixed rather than per cluster or per instance. It buys the number above, and a refresh against the real API is bound by round trips, not by this.

## Tests

`TestRDSDiscoveryDescribesInstancesConcurrently` holds every `DescribeDBInstances` call open until `request_concurrency` of them are in flight. Against the previous serial code it fails with one call in flight. The commit that adds it is the one commit here that does not pass on its own; the next one fixes it.

```release-notes
[PERF] AWS SD: Describe RDS instances of different clusters concurrently, bounded by `request_concurrency`.
```
