### PR TITLE
docs: document NaN behavior for clamp_max() and clamp_min()

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -97,11 +97,19 @@ Special cases:
 samples in `v` to have an upper limit of `max`. Histogram samples in the input
 vector are ignored silently.
 
+Special cases:
+
+* Float samples are clamped to `NaN` if `max` is `NaN`
+
 ## `clamp_min()`
 
 `clamp_min(v instant-vector, min scalar)` clamps the values of all float
 samples in `v` to have a lower limit of `min`. Histogram samples in the input
 vector are ignored silently.
+
+Special cases:
+
+* Float samples are clamped to `NaN` if `min` is `NaN`
 
 ## `day_of_month()`
 

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -649,6 +649,16 @@ eval instant at 0m clamp(test_clamp, NaN, 0)
 	{src="clamp-b"}	NaN
 	{src="clamp-c"}	NaN
 
+eval instant at 0m clamp_max(test_clamp, NaN)
+	{src="clamp-a"}	NaN
+	{src="clamp-b"}	NaN
+	{src="clamp-c"}	NaN
+
+eval instant at 0m clamp_min(test_clamp, NaN)
+	{src="clamp-a"}	NaN
+	{src="clamp-b"}	NaN
+	{src="clamp-c"}	NaN
+
 eval instant at 0m clamp(test_clamp, 5, -5)
 
 clear

--- a/web/ui/mantine-ui/src/promql/functionDocs.tsx
+++ b/web/ui/mantine-ui/src/promql/functionDocs.tsx
@@ -653,6 +653,14 @@ const funcDocs: Record<string, React.ReactNode> = {
         <code>clamp_max(v instant-vector, max scalar)</code> clamps the values of all float samples in <code>v</code> to
         have an upper limit of <code>max</code>. Histogram samples in the input vector are ignored silently.
       </p>
+
+      <p>Special cases:</p>
+
+      <ul>
+        <li>
+          Float samples are clamped to <code>NaN</code> if <code>max</code> is <code>NaN</code>
+        </li>
+      </ul>
     </>
   ),
   clamp_min: (
@@ -661,6 +669,14 @@ const funcDocs: Record<string, React.ReactNode> = {
         <code>clamp_min(v instant-vector, min scalar)</code> clamps the values of all float samples in <code>v</code> to
         have a lower limit of <code>min</code>. Histogram samples in the input vector are ignored silently.
       </p>
+
+      <p>Special cases:</p>
+
+      <ul>
+        <li>
+          Float samples are clamped to <code>NaN</code> if <code>min</code> is <code>NaN</code>
+        </li>
+      </ul>
     </>
   ),
   cos: (


### PR DESCRIPTION
Add documentation for NaN behavior of clamp_max() and clamp_min() functions
to match the existing documentation for clamp(). Both functions clamp float
samples to NaN when their bound argument is NaN, as they internally use the
same clamp() helper function.

Also add missing test cases for NaN behavior to functions.test to ensure
this behavior is properly tested and documented.

Fixes #19273

```release-notes
NONE