### PR TITLE
build: add current-architecture Docker target

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -247,6 +247,11 @@ common-docker-repo-name:
 
 .PHONY: common-docker $(BUILD_DOCKER_ARCHS)
 common-docker: $(BUILD_DOCKER_ARCHS)
+
+.PHONY: common-docker-current-arch
+common-docker-current-arch:
+	$(MAKE) common-docker-$(GOHOSTARCH)
+
 # DOCKER_ARCHS holds promu architecture names, which are not OCI platform strings.
 $(BUILD_DOCKER_ARCHS): common-docker-%:
 	@for variant in $(DOCKERFILE_VARIANTS_WITH_NAMES); do \

--- a/README.md
+++ b/README.md
@@ -148,9 +148,13 @@ You can build a docker image locally with the following commands:
 
 ```bash
 make promu
-promu crossbuild -p linux/amd64
-make common-docker-amd64
+promu crossbuild -p linux/$(go env GOHOSTARCH)
+make common-docker-current-arch
 ```
+
+To build for a different architecture, replace `$(go env GOHOSTARCH)` with one
+of the architectures in `DOCKER_ARCHS` from Makefile.common, such as `amd64`, and run the corresponding
+`make common-docker-<architecture>` target.
 
 The `make docker` target is intended only for use in our CI system and will not
 produce a fully working image when run locally.


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #12644.

This adds a `common-docker-current-arch` target that delegates only to the existing architecture-specific Docker target, as suggested in the previous review. The local image build instructions now derive the host architecture and document the existing explicit architecture targets.

Validation:
- `GOHOSTARCH=arm64 make -n common-docker-current-arch`
- `GOHOSTARCH=amd64 make -n common-docker-current-arch`
- Built native `linux/arm64` `prometheus` and `promtool` artifacts.
- `make common-docker-current-arch`
- Inspected both generated images: busybox and distroless are `arm64`.
- Ran the busybox image with `--version`; it reports `linux/arm64`.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```
