### PR TITLE
config: support YAML merge keys in strict decoding

### DIFF
--- a/cmd/promtool/testdata/yaml-merge-key.yml
+++ b/cmd/promtool/testdata/yaml-merge-key.yml
@@ -1,0 +1,12 @@
+# Copyright The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+tests:
+  - name: defaults
+    external_labels: &default_labels
+      severity: warning
+      team: operations
+  - name: overrides
+    external_labels:
+      <<: *default_labels
+      severity: critical

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -33,7 +33,6 @@ import (
 	"github.com/nsf/jsondiff"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -43,6 +42,7 @@ import (
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/junitxml"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 // RulesUnitTest does unit testing of rules based on the unit testing files provided.
@@ -91,7 +91,7 @@ func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser
 	}
 
 	var unitTestInp unitTestFile
-	if err := yaml.UnmarshalStrict(b, &unitTestInp); err != nil {
+	if err := yamlutil.UnmarshalStrict(b, &unitTestInp); err != nil {
 		ts.Abort(err)
 		return []error{err}
 	}

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,18 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/util/junitxml"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
+
+func TestRulesUnitTestYAMLMergeKey(t *testing.T) {
+	content, err := os.ReadFile("./testdata/yaml-merge-key.yml")
+	require.NoError(t, err)
+
+	var input unitTestFile
+	require.NoError(t, yamlutil.UnmarshalStrict(content, &input))
+	require.Equal(t, "critical", input.Tests[1].ExternalLabels.Get("severity"))
+	require.Equal(t, "operations", input.Tests[1].ExternalLabels.Get("team"))
+}
 
 func TestRulesUnitTest(t *testing.T) {
 	t.Parallel()
@@ -41,6 +53,13 @@ func TestRulesUnitTest(t *testing.T) {
 			name: "Passing Unit Tests",
 			args: args{
 				files: []string{"./testdata/unittest.yml"},
+			},
+			want: 0,
+		},
+		{
+			name: "YAML merge key",
+			args: args{
+				files: []string{"./testdata/yaml-merge-key.yml"},
 			},
 			want: 0,
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage/remote/azuread"
 	"github.com/prometheus/prometheus/storage/remote/googleiam"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 var (
@@ -78,7 +79,7 @@ func Load(s string, logger *slog.Logger) (*Config, error) {
 	// point as well.
 	*cfg = DefaultConfig
 
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
+	err := yamlutil.UnmarshalStrict([]byte(s), cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +370,7 @@ func (c *Config) GetScrapeConfigs() ([]*ScrapeConfig, error) {
 			if err != nil {
 				return nil, fileErr(filename, err)
 			}
-			err = yaml.UnmarshalStrict(content, &cfg)
+			err = yamlutil.UnmarshalStrict(content, &cfg)
 			if err != nil {
 				return nil, fileErr(filename, err)
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2200,6 +2200,51 @@ func TestLoadConfig(t *testing.T) {
 	})
 }
 
+func TestLoadConfigWithYAMLMergeKey(t *testing.T) {
+	cfg, err := Load(`
+scrape_configs:
+- job_name: first
+  static_configs:
+  - targets: [localhost:9090]
+    labels: &default_labels
+      severity: warning
+      team: operations
+- job_name: second
+  static_configs:
+  - targets: [localhost:9091]
+    labels:
+      <<: *default_labels
+      severity: critical
+`, promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.Len(t, cfg.ScrapeConfigs, 2)
+
+	staticConfigs, ok := cfg.ScrapeConfigs[1].ServiceDiscoveryConfigs[0].(discovery.StaticConfig)
+	require.True(t, ok)
+	require.Equal(t, model.LabelValue("critical"), staticConfigs[0].Labels["severity"])
+	require.Equal(t, model.LabelValue("operations"), staticConfigs[0].Labels["team"])
+
+	_, err = Load(`
+scrape_configs:
+- &defaults
+  job_name: first
+  unknown_option: true
+- <<: *defaults
+  job_name: second
+`, promslog.NewNopLogger())
+	require.ErrorContains(t, err, "field unknown_option not found")
+
+	_, err = Load(`
+scrape_configs:
+- &defaults
+  job_name: first
+- <<: *defaults
+  job_name: second
+  job_name: duplicate
+`, promslog.NewNopLogger())
+	require.ErrorContains(t, err, "field job_name already set")
+}
+
 func TestScrapeIntervalLarger(t *testing.T) {
 	c, err := LoadFile("testdata/scrape_interval_larger.good.yml", false, promslog.NewNopLogger())
 	require.NoError(t, err)

--- a/util/yamlutil/yaml.go
+++ b/util/yamlutil/yaml.go
@@ -1,0 +1,141 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yamlutil
+
+import (
+	"errors"
+	"fmt"
+
+	yamlv2 "go.yaml.in/yaml/v2"
+	yamlv3 "go.yaml.in/yaml/v3"
+)
+
+// UnmarshalStrict unmarshals a YAML document while rejecting unknown fields.
+// YAML merge keys are expanded before strict decoding so that explicit keys can
+// override values inherited from an anchor without being reported as duplicates.
+func UnmarshalStrict(in []byte, out any) error {
+	normalized, err := resolveMergeKeys(in)
+	if err != nil {
+		return err
+	}
+	return yamlv2.UnmarshalStrict(normalized, out)
+}
+
+func resolveMergeKeys(in []byte) ([]byte, error) {
+	var document yamlv3.Node
+	if err := yamlv3.Unmarshal(in, &document); err != nil {
+		return nil, err
+	}
+
+	changed, err := resolveNode(&document, map[*yamlv3.Node]bool{})
+	if err != nil || !changed {
+		return in, err
+	}
+	return yamlv3.Marshal(&document)
+}
+
+func resolveNode(node *yamlv3.Node, visiting map[*yamlv3.Node]bool) (bool, error) {
+	if node == nil {
+		return false, nil
+	}
+	if node.Kind == yamlv3.AliasNode {
+		if visiting[node] {
+			return false, fmt.Errorf("yaml: anchor %q contains itself", node.Value)
+		}
+		visiting[node] = true
+		changed, err := resolveNode(node.Alias, visiting)
+		delete(visiting, node)
+		return changed, err
+	}
+
+	changed := false
+	for _, child := range node.Content {
+		childChanged, err := resolveNode(child, visiting)
+		if err != nil {
+			return false, err
+		}
+		changed = changed || childChanged
+	}
+	if node.Kind != yamlv3.MappingNode {
+		return changed, nil
+	}
+
+	explicitKeys := map[string]struct{}{}
+	var explicitContent []*yamlv3.Node
+	var mergeValues []*yamlv3.Node
+	for i := 0; i < len(node.Content); i += 2 {
+		key, value := node.Content[i], node.Content[i+1]
+		if key.Tag == "!!merge" {
+			mergeValues = append(mergeValues, value)
+			continue
+		}
+		explicitKeys[nodeKey(key)] = struct{}{}
+		explicitContent = append(explicitContent, key, value)
+	}
+	if len(mergeValues) == 0 {
+		return changed, nil
+	}
+
+	mergedKeys := map[string]struct{}{}
+	var mergedContent []*yamlv3.Node
+	for _, value := range mergeValues {
+		mappings, err := mergeMappings(value)
+		if err != nil {
+			return false, err
+		}
+		for _, mapping := range mappings {
+			for i := 0; i < len(mapping.Content); i += 2 {
+				key := nodeKey(mapping.Content[i])
+				if _, ok := explicitKeys[key]; ok {
+					continue
+				}
+				if _, ok := mergedKeys[key]; ok {
+					continue
+				}
+				mergedKeys[key] = struct{}{}
+				mergedContent = append(mergedContent, mapping.Content[i], mapping.Content[i+1])
+			}
+		}
+	}
+	node.Content = append(mergedContent, explicitContent...)
+	return true, nil
+}
+
+func mergeMappings(node *yamlv3.Node) ([]*yamlv3.Node, error) {
+	if node.Kind == yamlv3.AliasNode {
+		node = node.Alias
+	}
+	switch node.Kind {
+	case yamlv3.MappingNode:
+		return []*yamlv3.Node{node}, nil
+	case yamlv3.SequenceNode:
+		mappings := make([]*yamlv3.Node, 0, len(node.Content))
+		for _, child := range node.Content {
+			if child.Kind == yamlv3.AliasNode {
+				child = child.Alias
+			}
+			if child.Kind != yamlv3.MappingNode {
+				return nil, errors.New("yaml: map merge requires a map or sequence of maps")
+			}
+			mappings = append(mappings, child)
+		}
+		return mappings, nil
+	default:
+		return nil, errors.New("yaml: map merge requires a map or sequence of maps")
+	}
+}
+
+func nodeKey(node *yamlv3.Node) string {
+	return node.Tag + "\x00" + node.Value
+}

--- a/util/yamlutil/yaml_test.go
+++ b/util/yamlutil/yaml_test.go
@@ -1,0 +1,78 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yamlutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testDocument struct {
+	Items []map[string]string `yaml:"items"`
+}
+
+func TestUnmarshalStrict(t *testing.T) {
+	t.Run("merge key override", func(t *testing.T) {
+		input := []byte(`items:
+- &defaults
+  severity: warning
+  team: operations
+- <<: *defaults
+  severity: critical
+`)
+		var got testDocument
+		require.NoError(t, UnmarshalStrict(input, &got))
+		require.Equal(t, []map[string]string{
+			{"severity": "warning", "team": "operations"},
+			{"severity": "critical", "team": "operations"},
+		}, got.Items)
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		var got testDocument
+		err := UnmarshalStrict([]byte("unknown: value\n"), &got)
+		require.ErrorContains(t, err, "field unknown not found")
+	})
+
+	t.Run("merge sequence precedence", func(t *testing.T) {
+		input := []byte(`items:
+- &first
+  severity: critical
+  team: operations
+- &second
+  severity: warning
+  region: us-east
+- <<: [*first, *second]
+`)
+		var got testDocument
+		require.NoError(t, UnmarshalStrict(input, &got))
+		require.Equal(t, map[string]string{
+			"severity": "critical",
+			"team":     "operations",
+			"region":   "us-east",
+		}, got.Items[2])
+	})
+
+	t.Run("duplicate key", func(t *testing.T) {
+		var got testDocument
+		err := UnmarshalStrict([]byte("items: []\nitems: []\n"), &got)
+		require.ErrorContains(t, err, "field items already set")
+	})
+
+	t.Run("empty document", func(t *testing.T) {
+		var got testDocument
+		require.NoError(t, UnmarshalStrict(nil, &got))
+	})
+}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #2347.

Prometheus configuration and `promtool test rules` now support YAML merge keys while retaining the existing strict decoder behavior.

The implementation expands merge keys at the YAML-node layer and then delegates to the existing strict YAML v2 decoder. This keeps unknown-field and explicit duplicate-key validation intact, while allowing an explicit mapping value to override an inherited value. Merge sequences preserve YAML precedence.

Focused tests cover map overrides, merge-sequence precedence, unknown and duplicate keys, Prometheus static target labels, and promtool rule-test input.

Validation:
- `go test ./util/yamlutil ./config ./cmd/promtool -count=1`
- `make lint`

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[ENHANCEMENT] Configuration: Support YAML merge keys in Prometheus configuration and promtool rule-test files.
```
