### PR TITLE
config: make log level reloadable

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -674,7 +674,7 @@ func main() {
 	logger := promslog.New(&cfg.promslogConfig)
 	slog.SetDefault(logger)
 	if cfg.logLevelFlagSet {
-		logger.Warn("The flag --log.level is deprecated. Set runtime.log_level in the configuration file instead.")
+		logger.Warn("The flag --log.level is deprecated. Set runtime.log_level in the configuration file instead. This flag will be removed in the next version.")
 	}
 
 	// The CLI log level controls startup logging and supplies the default when

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -225,8 +225,7 @@ type flagConfig struct {
 
 	parserOpts parser.Options
 
-	promslogConfig  promslog.Config
-	logLevelFlagSet bool
+	promslogConfig promslog.Config
 }
 
 // setFeatureListOptions sets the corresponding options from the featureList.
@@ -652,7 +651,6 @@ func main() {
 
 	promslogflag.AddFlags(a, &cfg.promslogConfig)
 	a.GetFlag(promslogflag.LevelFlagName).
-		IsSetByUser(&cfg.logLevelFlagSet).
 		Help(promslogflag.LevelFlagHelp + " Deprecated: set runtime.log_level in the configuration file instead.")
 
 	a.Flag("write-documentation", "Generate command line documentation. Internal use.").Hidden().Action(func(*kingpin.ParseContext) error {
@@ -673,9 +671,6 @@ func main() {
 
 	logger := promslog.New(&cfg.promslogConfig)
 	slog.SetDefault(logger)
-	if cfg.logLevelFlagSet {
-		logger.Warn("The flag --log.level is deprecated. Set runtime.log_level in the configuration file instead. This flag will be removed in the next version.")
-	}
 
 	// The CLI log level controls startup logging and supplies the default when
 	// runtime.log_level is absent from the configuration file.

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -225,7 +225,8 @@ type flagConfig struct {
 
 	parserOpts parser.Options
 
-	promslogConfig promslog.Config
+	promslogConfig  promslog.Config
+	logLevelFlagSet bool
 }
 
 // setFeatureListOptions sets the corresponding options from the featureList.
@@ -650,6 +651,9 @@ func main() {
 	a.Flag("agent", "Run Prometheus in 'Agent mode'.").BoolVar(&agentMode)
 
 	promslogflag.AddFlags(a, &cfg.promslogConfig)
+	a.GetFlag(promslogflag.LevelFlagName).
+		IsSetByUser(&cfg.logLevelFlagSet).
+		Help(promslogflag.LevelFlagHelp + " Deprecated: set runtime.log_level in the configuration file instead.")
 
 	a.Flag("write-documentation", "Generate command line documentation. Internal use.").Hidden().Action(func(*kingpin.ParseContext) error {
 		if err := documentcli.GenerateMarkdown(a.Model(), os.Stdout); err != nil {
@@ -669,6 +673,14 @@ func main() {
 
 	logger := promslog.New(&cfg.promslogConfig)
 	slog.SetDefault(logger)
+	if cfg.logLevelFlagSet {
+		logger.Warn("The flag --log.level is deprecated. Set runtime.log_level in the configuration file instead.")
+	}
+
+	// The CLI log level controls startup logging and supplies the default when
+	// runtime.log_level is absent from the configuration file.
+	config.DefaultRuntimeConfig.LogLevel = config.LogLevel(cfg.promslogConfig.Level.String())
+	config.DefaultConfig.Runtime = config.DefaultRuntimeConfig
 
 	notifs := notifications.NewNotifications(cfg.maxNotificationsSubscribers, prometheus.DefaultRegisterer)
 	cfg.web.NotificationsSub = notifs.Sub
@@ -1389,7 +1401,7 @@ func main() {
 				for {
 					select {
 					case <-hup:
-						if err := reloadConfig(cfg.configFile, cfg.tsdb.EnableExemplarStorage, logger, noStepSubqueryInterval, callback, reloaders...); err != nil {
+						if err := reloadConfig(cfg.configFile, cfg.tsdb.EnableExemplarStorage, logger, noStepSubqueryInterval, cfg.promslogConfig.Level, callback, reloaders...); err != nil {
 							logger.Error("Error reloading config", "err", err)
 						} else if cfg.enableAutoReload {
 							checksum, err = config.GenerateChecksum(cfg.configFile)
@@ -1398,7 +1410,7 @@ func main() {
 							}
 						}
 					case rc := <-webHandler.Reload():
-						if err := reloadConfig(cfg.configFile, cfg.tsdb.EnableExemplarStorage, logger, noStepSubqueryInterval, callback, reloaders...); err != nil {
+						if err := reloadConfig(cfg.configFile, cfg.tsdb.EnableExemplarStorage, logger, noStepSubqueryInterval, cfg.promslogConfig.Level, callback, reloaders...); err != nil {
 							logger.Error("Error reloading config", "err", err)
 							rc <- err
 						} else {
@@ -1423,7 +1435,7 @@ func main() {
 						}
 						logger.Info("Configuration file change detected, reloading the configuration.")
 
-						if err := reloadConfig(cfg.configFile, cfg.tsdb.EnableExemplarStorage, logger, noStepSubqueryInterval, callback, reloaders...); err != nil {
+						if err := reloadConfig(cfg.configFile, cfg.tsdb.EnableExemplarStorage, logger, noStepSubqueryInterval, cfg.promslogConfig.Level, callback, reloaders...); err != nil {
 							logger.Error("Error reloading config", "err", err)
 						} else {
 							checksum = currentChecksum
@@ -1455,7 +1467,7 @@ func main() {
 					return nil
 				}
 
-				if err := reloadConfig(cfg.configFile, cfg.tsdb.EnableExemplarStorage, logger, noStepSubqueryInterval, func(bool) {}, reloaders...); err != nil {
+				if err := reloadConfig(cfg.configFile, cfg.tsdb.EnableExemplarStorage, logger, noStepSubqueryInterval, cfg.promslogConfig.Level, func(bool) {}, reloaders...); err != nil {
 					return fmt.Errorf("error loading config from %q: %w", cfg.configFile, err)
 				}
 
@@ -1697,7 +1709,7 @@ type reloader struct {
 	reloader func(*config.Config) error
 }
 
-func reloadConfig(filename string, enableExemplarStorage bool, logger *slog.Logger, noStepSubqueryInterval *safePromQLNoStepSubqueryInterval, callback func(bool), rls ...reloader) (err error) {
+func reloadConfig(filename string, enableExemplarStorage bool, logger *slog.Logger, noStepSubqueryInterval *safePromQLNoStepSubqueryInterval, logLevel *promslog.Level, callback func(bool), rls ...reloader) (err error) {
 	start := time.Now()
 	timingsLogger := logger
 	logger.Info("Loading configuration file", "filename", filename)
@@ -1735,6 +1747,9 @@ func reloadConfig(filename string, enableExemplarStorage bool, logger *slog.Logg
 	}
 	if failed {
 		return fmt.Errorf("one or more errors occurred while applying the new configuration (--config.file=%q)", filename)
+	}
+	if err := logLevel.Set(string(conf.Runtime.LogLevel)); err != nil {
+		return fmt.Errorf("applying log level: %w", err)
 	}
 
 	updateGoGC(conf, logger)

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/rules"
@@ -972,6 +973,49 @@ runtime:
 			ensureGOGCValue(99.0)
 		})
 	}
+}
+
+func TestReloadConfigLogLevel(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "prometheus.yml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`runtime:
+  log_level: debug
+`), 0o600))
+
+	level := promslog.NewLevel()
+	require.NoError(t, level.Set("info"))
+	var output bytes.Buffer
+	logger := promslog.New(&promslog.Config{Level: level, Writer: &output})
+	interval := &safePromQLNoStepSubqueryInterval{}
+
+	require.NoError(t, reloadConfig(configFile, false, logger, interval, level, func(bool) {}))
+	require.Equal(t, "debug", level.String())
+	output.Reset()
+	logger.Debug("debug message")
+	require.Contains(t, output.String(), "debug message")
+
+	require.NoError(t, os.WriteFile(configFile, []byte(`runtime:
+  log_level: error
+`), 0o600))
+	err := reloadConfig(configFile, false, logger, interval, level, func(bool) {}, reloader{
+		name: "failing",
+		reloader: func(*config.Config) error {
+			return errors.New("failed to apply")
+		},
+	})
+	require.Error(t, err)
+	require.Equal(t, "debug", level.String())
+	output.Reset()
+	logger.Debug("still visible")
+	require.Contains(t, output.String(), "still visible")
+
+	require.NoError(t, reloadConfig(configFile, false, logger, interval, level, func(bool) {}))
+	require.Equal(t, "error", level.String())
+	output.Reset()
+	logger.Warn("hidden warning")
+	require.Empty(t, output.String())
+	logger.Error("visible error")
+	require.Contains(t, output.String(), "visible error")
 }
 
 // TestHeadCompactionWhileScraping verifies that running a head compaction

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -1016,6 +1016,13 @@ func TestReloadConfigLogLevel(t *testing.T) {
 	require.Empty(t, output.String())
 	logger.Error("visible error")
 	require.Contains(t, output.String(), "visible error")
+
+	require.NoError(t, os.WriteFile(configFile, []byte("{}\n"), 0o600))
+	require.NoError(t, reloadConfig(configFile, false, logger, interval, level, func(bool) {}))
+	require.Equal(t, "info", level.String())
+	output.Reset()
+	logger.Info("visible info")
+	require.Contains(t, output.String(), "visible info")
 }
 
 // TestHeadCompactionWhileScraping verifies that running a head compaction

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ import (
 	remoteapi "github.com/prometheus/client_golang/exp/api/remote"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/otlptranslator"
 	"github.com/prometheus/sigv4"
 	"go.yaml.in/yaml/v2"
@@ -193,7 +194,8 @@ var (
 
 	DefaultRuntimeConfig = RuntimeConfig{
 		// Go runtime tuning.
-		GoGC: getGoGC(),
+		GoGC:     getGoGC(),
+		LogLevel: LogLevel("info"),
 	}
 
 	// DefaultScrapeConfig is the default scrape configuration. Users of this
@@ -730,10 +732,25 @@ func (c *GlobalConfig) isZero() bool {
 
 const DefaultGoGCPercentage = 75
 
+// LogLevel is a YAML representation of a promslog logging level.
+type LogLevel string
+
+// UnmarshalYAML validates and normalizes a log level.
+func (l *LogLevel) UnmarshalYAML(unmarshal func(any) error) error {
+	level := promslog.NewLevel()
+	if err := level.UnmarshalYAML(unmarshal); err != nil {
+		return err
+	}
+	*l = LogLevel(level.String())
+	return nil
+}
+
 // RuntimeConfig configures the values for the process behavior.
 type RuntimeConfig struct {
 	// The Go garbage collection target percentage.
 	GoGC int `yaml:"gogc,omitempty"`
+	// The minimum severity emitted by the process logger.
+	LogLevel LogLevel `yaml:"log_level,omitempty"`
 
 	// Below are guidelines for adding a new field:
 	//
@@ -753,7 +770,7 @@ type RuntimeConfig struct {
 
 // isZero returns true iff the global config is the zero value.
 func (c *RuntimeConfig) isZero() bool {
-	return c.GoGC == 0
+	return c.GoGC == 0 && c.LogLevel == ""
 }
 
 type ScrapeConfigs struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -113,7 +113,8 @@ var expectedConf = &Config{
 	},
 
 	Runtime: RuntimeConfig{
-		GoGC: globalGoGC,
+		GoGC:     globalGoGC,
+		LogLevel: LogLevel("info"),
 	},
 
 	RuleFiles: []string{
@@ -2858,6 +2859,67 @@ func TestEmptyConfig(t *testing.T) {
 	exp.StorageConfig.TSDBConfig = &TSDBConfig{Retention: &retention}
 	require.Equal(t, exp, *c)
 	require.Equal(t, 75, c.Runtime.GoGC)
+	require.Equal(t, LogLevel("info"), c.Runtime.LogLevel)
+}
+
+func TestRuntimeLogLevelConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		config    string
+		expected  LogLevel
+		errString string
+	}{
+		{
+			name:     "default",
+			expected: LogLevel("info"),
+		},
+		{
+			name: "configured",
+			config: `runtime:
+  log_level: warn
+`,
+			expected: LogLevel("warn"),
+		},
+		{
+			name: "normalized",
+			config: `runtime:
+  log_level: DEBUG
+`,
+			expected: LogLevel("debug"),
+		},
+		{
+			name: "invalid",
+			config: `runtime:
+  log_level: verbose
+`,
+			errString: "unrecognized log level verbose",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := Load(tc.config, promslog.NewNopLogger())
+			if tc.errString != "" {
+				require.ErrorContains(t, err, tc.errString)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, cfg.Runtime.LogLevel)
+		})
+	}
+
+	t.Run("configured process default", func(t *testing.T) {
+		previousRuntimeDefault := DefaultRuntimeConfig
+		previousConfigRuntime := DefaultConfig.Runtime
+		t.Cleanup(func() {
+			DefaultRuntimeConfig = previousRuntimeDefault
+			DefaultConfig.Runtime = previousConfigRuntime
+		})
+
+		DefaultRuntimeConfig.LogLevel = LogLevel("debug")
+		DefaultConfig.Runtime = DefaultRuntimeConfig
+		cfg, err := Load("runtime:\n  gogc: 77\n", promslog.NewNopLogger())
+		require.NoError(t, err)
+		require.Equal(t, LogLevel("debug"), cfg.Runtime.LogLevel)
+	})
 }
 
 func TestExpandExternalLabels(t *testing.T) {

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -66,7 +66,7 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--query.max-samples</code> | Maximum number of samples a single query can load into memory. Note that queries will fail if they try to load more samples than this into memory, so this also limits the number of samples a query can return. Use with server mode only. | `50000000` |
 | <code class="text-nowrap">--enable-feature</code> <code class="text-nowrap">...</code> | Comma separated feature names to enable. Valid options: concurrent-rule-eval, created-timestamp-zero-ingestion, delayed-compaction, exemplar-storage, extra-scrape-metrics, histograms-st-encoding, memory-snapshot-on-shutdown, metadata-wal-records, old-ui, otlp-deltatocumulative, otlp-native-delta-ingestion, promql-binop-fill-modifiers, promql-delayed-name-removal, promql-experimental-functions, promql-extended-range-selectors, promql-per-step-stats, search-api, st-storage, st-synthesis, type-and-unit-labels, use-start-timestamps, use-uncached-io, xor2-encoding. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details. |  |
 | <code class="text-nowrap">--agent</code> | Run Prometheus in 'Agent mode'. |  |
-| <code class="text-nowrap">--log.level</code> | Only log messages with the given severity or above. One of: [debug, info, warn, error] | `info` |
+| <code class="text-nowrap">--log.level</code> | Only log messages with the given severity or above. One of: [debug, info, warn, error] Deprecated: set runtime.log_level in the configuration file instead. | `info` |
 | <code class="text-nowrap">--log.format</code> | Output format of log messages. One of: [logfmt, json] | `logfmt` |
 
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -202,6 +202,10 @@ global:
   [ extra_scrape_metrics: <boolean> | default = false ]
 
 runtime:
+  # The minimum severity of messages emitted by the process logger.
+  # This setting can be changed by reloading the configuration.
+  [ log_level: <string> | default = info ]
+
   # Configure the Go garbage collector GOGC parameter
   # See: https://tip.golang.org/doc/gc-guide#GOGC
   # Lowering this number increases CPU usage.


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #10352.

Adds reloadable `runtime.log_level` configuration with `info` as the default. The existing `--log.level` flag still controls startup logging and becomes the default when the configuration omits `runtime.log_level`, but is now deprecated with both help text and a runtime warning.

The live `promslog.Level` is updated only after every component reloader succeeds, so parse or apply failures preserve the previous filtering level.

Validation:
- `go test ./config ./cmd/prometheus -count=1`
- `make lint`
- `make cli-documentation`
- Built and ran a Prometheus binary, observed the deprecation warning, successfully reloaded `debug` to `error`, and confirmed an invalid subsequent reload returned HTTP 500 while the previous `error` filtering remained active.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[FEATURE] Configuration: Allow changing the process log level through `runtime.log_level` on configuration reload.
[CHANGE] Logging: Deprecate `--log.level`; it now supplies the startup and configuration-default level.
```
