### PR TITLE
discovery/aws: don't panic on EC2 instances with absent optional fields

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -353,9 +353,16 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					continue
 				}
 
+				// Every instance field below is optional in the EC2 API. Omit
+				// the label when the field is absent rather than dereferencing
+				// a nil pointer, which would panic and take down the whole
+				// Prometheus process.
 				labels := model.LabelSet{
-					ec2LabelInstanceID: model.LabelValue(*inst.InstanceId),
-					ec2LabelRegion:     model.LabelValue(d.region),
+					ec2LabelRegion: model.LabelValue(d.region),
+				}
+
+				if inst.InstanceId != nil {
+					labels[ec2LabelInstanceID] = model.LabelValue(*inst.InstanceId)
 				}
 
 				if r.OwnerId != nil {
@@ -383,7 +390,9 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 
 				if inst.PublicIpAddress != nil {
 					labels[ec2LabelPublicIP] = model.LabelValue(*inst.PublicIpAddress)
-					labels[ec2LabelPublicDNS] = model.LabelValue(*inst.PublicDnsName)
+					if inst.PublicDnsName != nil {
+						labels[ec2LabelPublicDNS] = model.LabelValue(*inst.PublicDnsName)
+					}
 				}
 
 				if primaryIPv6Addrs != nil {
@@ -400,16 +409,27 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 							ec2LabelSeparator)
 				}
 
-				labels[ec2LabelAMI] = model.LabelValue(*inst.ImageId)
-				labels[ec2LabelAZ] = model.LabelValue(*inst.Placement.AvailabilityZone)
-				azID, ok := d.azToAZID[*inst.Placement.AvailabilityZone]
-				if !ok && d.azToAZID != nil {
-					d.logger.Debug(
-						"Availability zone ID not found",
-						"az", *inst.Placement.AvailabilityZone)
+				if inst.ImageId != nil {
+					labels[ec2LabelAMI] = model.LabelValue(*inst.ImageId)
 				}
-				labels[ec2LabelAZID] = model.LabelValue(azID)
-				labels[ec2LabelInstanceState] = model.LabelValue(inst.State.Name)
+
+				// The availability zone ID is looked up by zone name, so both
+				// labels are omitted when the placement is absent.
+				if inst.Placement != nil && inst.Placement.AvailabilityZone != nil {
+					az := *inst.Placement.AvailabilityZone
+					labels[ec2LabelAZ] = model.LabelValue(az)
+					azID, ok := d.azToAZID[az]
+					if !ok && d.azToAZID != nil {
+						d.logger.Debug(
+							"Availability zone ID not found",
+							"az", az)
+					}
+					labels[ec2LabelAZID] = model.LabelValue(azID)
+				}
+
+				if inst.State != nil {
+					labels[ec2LabelInstanceState] = model.LabelValue(inst.State.Name)
+				}
 				labels[ec2LabelInstanceType] = model.LabelValue(inst.InstanceType)
 
 				if inst.InstanceLifecycle != "" {
@@ -422,7 +442,9 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 
 				if inst.VpcId != nil {
 					labels[ec2LabelVPCID] = model.LabelValue(*inst.VpcId)
-					labels[ec2LabelPrimarySubnetID] = model.LabelValue(*inst.SubnetId)
+					if inst.SubnetId != nil {
+						labels[ec2LabelPrimarySubnetID] = model.LabelValue(*inst.SubnetId)
+					}
 
 					var subnets []string
 					subnetsMap := make(map[string]struct{})
@@ -468,16 +490,33 @@ func getInstanceIPv6Addresses(i *ec2Types.Instance) (*string, []string, []string
 			}
 
 			for _, ipv6addr := range eni.Ipv6Addresses {
-				ipv6Addrs = append(ipv6Addrs, *ipv6addr.Ipv6Address)
-				if *ipv6addr.IsPrimaryIpv6 {
-					// we might have to extend the slice with more than one element
-					// that could leave empty strings in the list which is intentional
-					// to keep the position/device index information
-					for int32(len(primaryIPv6Addrs)) <= *eni.Attachment.DeviceIndex {
-						primaryIPv6Addrs = append(primaryIPv6Addrs, "")
-					}
-					primaryIPv6Addrs[*eni.Attachment.DeviceIndex] = *ipv6addr.Ipv6Address
+				// Nothing identifies an address without a value, so skip the
+				// entry rather than dereferencing nil.
+				if ipv6addr.Ipv6Address == nil {
+					continue
 				}
+				ipv6Addrs = append(ipv6Addrs, *ipv6addr.Ipv6Address)
+
+				// IsPrimaryIpv6 is only populated once a primary IPv6 address
+				// has been enabled on the interface, so an absent flag means
+				// the address is not primary.
+				if !aws.ToBool(ipv6addr.IsPrimaryIpv6) {
+					continue
+				}
+
+				// The device index gives the position to record the primary
+				// address at; without a usable one there is no slot for it.
+				if eni.Attachment == nil || eni.Attachment.DeviceIndex == nil || *eni.Attachment.DeviceIndex < 0 {
+					continue
+				}
+
+				// we might have to extend the slice with more than one element
+				// that could leave empty strings in the list which is intentional
+				// to keep the position/device index information
+				for int32(len(primaryIPv6Addrs)) <= *eni.Attachment.DeviceIndex {
+					primaryIPv6Addrs = append(primaryIPv6Addrs, "")
+				}
+				primaryIPv6Addrs[*eni.Attachment.DeviceIndex] = *ipv6addr.Ipv6Address
 			}
 		}
 

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -557,6 +558,276 @@ func (m *mockEC2Client) DescribeAvailabilityZones(context.Context, *ec2.Describe
 	return &ec2.DescribeAvailabilityZonesOutput{
 		AvailabilityZones: azs,
 	}, nil
+}
+
+// ec2TestDiscovery returns a discovery backed by the mock client, so refresh()
+// can be exercised without reaching AWS. ec2Client returns early when ec2 is
+// already set, which also leaves region unset, so it is populated here.
+func ec2TestDiscovery(data *ec2DataStore) *EC2Discovery {
+	return &EC2Discovery{
+		logger: promslog.NewNopLogger(),
+		ec2:    newMockEC2Client(data),
+		cfg: &EC2SDConfig{
+			Port:   4242,
+			Region: data.region,
+		},
+		region: data.region,
+	}
+}
+
+// fullyPopulatedEC2Instance is the shape the AWS API returns when every
+// optional field happens to be set. Each subtest below blanks exactly one of
+// them.
+func fullyPopulatedEC2Instance() ec2Types.Instance {
+	return ec2Types.Instance{
+		Architecture:      "x86_64",
+		ImageId:           strptr("ami-full"),
+		InstanceId:        strptr("i-full"),
+		InstanceLifecycle: "spot",
+		InstanceType:      "t3.micro",
+		Placement:         &ec2Types.Placement{AvailabilityZone: strptr("azname-a")},
+		Platform:          "windows",
+		PrivateDnsName:    strptr("ip-10-0-0-1.ec2.internal"),
+		PrivateIpAddress:  strptr("10.0.0.1"),
+		PublicDnsName:     strptr("ec2-42-42-42-42.compute-1.amazonaws.com"),
+		PublicIpAddress:   strptr("42.42.42.42"),
+		State:             &ec2Types.InstanceState{Name: "running"},
+		SubnetId:          strptr("subnet-full"),
+		VpcId:             strptr("vpc-full"),
+		NetworkInterfaces: []ec2Types.InstanceNetworkInterface{
+			{
+				Attachment: &ec2Types.InstanceNetworkInterfaceAttachment{
+					DeviceIndex: aws.Int32(0),
+				},
+				Ipv6Addresses: []ec2Types.InstanceIpv6Address{
+					{
+						Ipv6Address:   strptr("2001:db8::1"),
+						IsPrimaryIpv6: boolptr(true),
+					},
+				},
+				SubnetId: strptr("subnet-full"),
+			},
+		},
+	}
+}
+
+// fullyPopulatedEC2DataStore backs the instance above with the region, AZ map
+// and owner ID the mock client needs.
+func fullyPopulatedEC2DataStore() *ec2DataStore {
+	return &ec2DataStore{
+		region:    "region-full",
+		azToAZID:  map[string]string{"azname-a": "azid-1"},
+		ownerID:   "owner-id-full",
+		instances: []ec2Types.Instance{fullyPopulatedEC2Instance()},
+	}
+}
+
+// TestEC2DiscoveryRefreshFullyPopulated pins the happy path so the nil handling
+// added for the cases below cannot silently drop labels that used to be set.
+func TestEC2DiscoveryRefreshFullyPopulated(t *testing.T) {
+	t.Parallel()
+
+	tgs, err := ec2TestDiscovery(fullyPopulatedEC2DataStore()).refresh(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []*targetgroup.Group{
+		{
+			Source: "region-full",
+			Targets: []model.LabelSet{
+				{
+					"__address__":                       model.LabelValue("10.0.0.1:4242"),
+					"__meta_ec2_ami":                    model.LabelValue("ami-full"),
+					"__meta_ec2_architecture":           model.LabelValue("x86_64"),
+					"__meta_ec2_availability_zone":      model.LabelValue("azname-a"),
+					"__meta_ec2_availability_zone_id":   model.LabelValue("azid-1"),
+					"__meta_ec2_default_ipv6_address":   model.LabelValue("2001:db8::1"),
+					"__meta_ec2_instance_id":            model.LabelValue("i-full"),
+					"__meta_ec2_instance_lifecycle":     model.LabelValue("spot"),
+					"__meta_ec2_instance_state":         model.LabelValue("running"),
+					"__meta_ec2_instance_type":          model.LabelValue("t3.micro"),
+					"__meta_ec2_ipv6_addresses":         model.LabelValue(",2001:db8::1,"),
+					"__meta_ec2_owner_id":               model.LabelValue("owner-id-full"),
+					"__meta_ec2_platform":               model.LabelValue("windows"),
+					"__meta_ec2_primary_ipv6_addresses": model.LabelValue(",2001:db8::1,"),
+					"__meta_ec2_primary_subnet_id":      model.LabelValue("subnet-full"),
+					"__meta_ec2_private_dns_name":       model.LabelValue("ip-10-0-0-1.ec2.internal"),
+					"__meta_ec2_private_ip":             model.LabelValue("10.0.0.1"),
+					"__meta_ec2_public_dns_name":        model.LabelValue("ec2-42-42-42-42.compute-1.amazonaws.com"),
+					"__meta_ec2_public_ip":              model.LabelValue("42.42.42.42"),
+					"__meta_ec2_region":                 model.LabelValue("region-full"),
+					"__meta_ec2_subnet_id":              model.LabelValue(",subnet-full,"),
+					"__meta_ec2_vpc_id":                 model.LabelValue("vpc-full"),
+				},
+			},
+		},
+	}, tgs)
+}
+
+// TestEC2DiscoveryRefreshInstanceNilOptionalFields covers instances where the
+// AWS API omitted an optional field. None of these members are marked required
+// by the SDK, yet refresh() dereferenced them without a nil check, so a single
+// missing field panicked the whole Prometheus process during service discovery
+// rather than degrading the target.
+func TestEC2DiscoveryRefreshInstanceNilOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*ec2Types.Instance)
+		absent []model.LabelName
+	}{
+		{
+			name:   "NilImageId",
+			mutate: func(i *ec2Types.Instance) { i.ImageId = nil },
+			absent: []model.LabelName{ec2LabelAMI},
+		},
+		{
+			name:   "NilInstanceId",
+			mutate: func(i *ec2Types.Instance) { i.InstanceId = nil },
+			absent: []model.LabelName{ec2LabelInstanceID},
+		},
+		{
+			name:   "NilPlacement",
+			mutate: func(i *ec2Types.Instance) { i.Placement = nil },
+			absent: []model.LabelName{ec2LabelAZ, ec2LabelAZID},
+		},
+		{
+			name:   "NilAvailabilityZone",
+			mutate: func(i *ec2Types.Instance) { i.Placement.AvailabilityZone = nil },
+			absent: []model.LabelName{ec2LabelAZ, ec2LabelAZID},
+		},
+		{
+			name:   "NilState",
+			mutate: func(i *ec2Types.Instance) { i.State = nil },
+			absent: []model.LabelName{ec2LabelInstanceState},
+		},
+		{
+			name:   "NilSubnetId",
+			mutate: func(i *ec2Types.Instance) { i.SubnetId = nil },
+			absent: []model.LabelName{ec2LabelPrimarySubnetID},
+		},
+		{
+			name:   "NilPublicDnsName",
+			mutate: func(i *ec2Types.Instance) { i.PublicDnsName = nil },
+			absent: []model.LabelName{ec2LabelPublicDNS},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := fullyPopulatedEC2DataStore()
+			tc.mutate(&data.instances[0])
+
+			tgs, err := ec2TestDiscovery(data).refresh(context.Background())
+			require.NoError(t, err)
+			require.Len(t, tgs, 1)
+			require.Len(t, tgs[0].Targets, 1,
+				"instance must still be discovered when an optional field is absent")
+
+			target := tgs[0].Targets[0]
+			for _, label := range tc.absent {
+				require.NotContains(t, target, label,
+					"label sourced from the absent field should be omitted")
+			}
+			// The instance is still usable: the address is what makes it a target.
+			require.Equal(t, model.LabelValue("10.0.0.1:4242"), target[model.AddressLabel])
+		})
+	}
+}
+
+// TestEC2DiscoveryRefreshIPv6NilOptionalFields covers the IPv6 fields
+// getInstanceIPv6Addresses dereferenced without a nil check. IsPrimaryIpv6 is
+// only populated once a primary IPv6 address has been enabled on the interface,
+// and the attachment device index is optional too, so an instance holding a
+// plain IPv6 address was enough to panic the process.
+func TestEC2DiscoveryRefreshIPv6NilOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		// mutate operates on the single fully populated network interface.
+		mutate func(*ec2Types.InstanceNetworkInterface)
+		// expected holds the IPv6 labels left once the absent field is handled;
+		// a label missing from the map must be absent from the target.
+		expected model.LabelSet
+	}{
+		{
+			name: "NilIpv6Address",
+			mutate: func(eni *ec2Types.InstanceNetworkInterface) {
+				eni.Ipv6Addresses[0].Ipv6Address = nil
+			},
+			// Nothing identifies the address, so it drops out entirely.
+			expected: model.LabelSet{},
+		},
+		{
+			name: "NilIsPrimaryIpv6",
+			mutate: func(eni *ec2Types.InstanceNetworkInterface) {
+				eni.Ipv6Addresses[0].IsPrimaryIpv6 = nil
+			},
+			// An absent flag means the address is not primary.
+			expected: model.LabelSet{
+				ec2LabelIPv6Addresses:      model.LabelValue(",2001:db8::1,"),
+				ec2LabelDefaultIPv6Address: model.LabelValue("2001:db8::1"),
+			},
+		},
+		{
+			name: "NilAttachment",
+			mutate: func(eni *ec2Types.InstanceNetworkInterface) {
+				eni.Attachment = nil
+			},
+			// Without an attachment there is no device index to record the
+			// primary address at, but the address itself is still discovered.
+			expected: model.LabelSet{
+				ec2LabelIPv6Addresses:      model.LabelValue(",2001:db8::1,"),
+				ec2LabelDefaultIPv6Address: model.LabelValue("2001:db8::1"),
+			},
+		},
+		{
+			name: "NilDeviceIndex",
+			mutate: func(eni *ec2Types.InstanceNetworkInterface) {
+				eni.Attachment.DeviceIndex = nil
+			},
+			expected: model.LabelSet{
+				ec2LabelIPv6Addresses:      model.LabelValue(",2001:db8::1,"),
+				ec2LabelDefaultIPv6Address: model.LabelValue("2001:db8::1"),
+			},
+		},
+		{
+			name: "NegativeDeviceIndex",
+			mutate: func(eni *ec2Types.InstanceNetworkInterface) {
+				eni.Attachment.DeviceIndex = aws.Int32(-1)
+			},
+			// A negative index has no slot in the positional list.
+			expected: model.LabelSet{
+				ec2LabelIPv6Addresses:      model.LabelValue(",2001:db8::1,"),
+				ec2LabelDefaultIPv6Address: model.LabelValue("2001:db8::1"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := fullyPopulatedEC2DataStore()
+			tc.mutate(&data.instances[0].NetworkInterfaces[0])
+
+			tgs, err := ec2TestDiscovery(data).refresh(context.Background())
+			require.NoError(t, err)
+			require.Len(t, tgs, 1)
+			require.Len(t, tgs[0].Targets, 1,
+				"instance must still be discovered when an optional field is absent")
+
+			target := tgs[0].Targets[0]
+			for _, label := range []model.LabelName{ec2LabelIPv6Addresses, ec2LabelPrimaryIPv6Addresses, ec2LabelDefaultIPv6Address} {
+				if want, ok := tc.expected[label]; ok {
+					require.Equal(t, want, target[label])
+					continue
+				}
+				require.NotContains(t, target, label,
+					"label sourced from the absent field should be omitted")
+			}
+			// The instance keeps its IPv4 address either way.
+			require.Equal(t, model.LabelValue("10.0.0.1:4242"), target[model.AddressLabel])
+		})
+	}
 }
 
 func (m *mockEC2Client) DescribeInstances(_ context.Context, input *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {


### PR DESCRIPTION
None of the `Instance` members `refresh()` dereferences are marked required by the SDK, and `getInstanceIPv6Addresses` dereferences the IPv6 address, the primary IPv6 flag and the attachment device index just as freely. An instance returned without one of them panics inside service discovery, and since nothing in `discovery/` recovers, that takes down the whole Prometheus process.

`IsPrimaryIpv6` is the most reachable of these: the SDK documents it as describing an enabled primary IPv6 GUA address, so an instance holding a plain IPv6 address is enough to hit it.

The label is omitted when the field is absent instead of panicking.

- The availability zone ID is looked up by zone name, so it is omitted along with the zone label when the placement is absent.
- In `getInstanceIPv6Addresses` an address without a value is skipped, an absent `IsPrimaryIpv6` is read as not primary via `aws.ToBool`, and a primary address whose attachment carries no usable device index is recorded in the plain address list only. The device index also indexes the positional primary list, so a negative one is rejected rather than indexing out of range.

The first commit adds the tests and panics on every field; the second adds the guards. A fully populated instance is pinned first so the guards cannot silently drop labels that used to be set.

```release-notes
[BUGFIX] discovery/aws: Do not panic when the EC2 API omits optional instance fields.
```