### PR TITLE
test: smoke test Go benchmarks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           # Keep them available for targeted performance runs, but out of the CI smoke test.
           skip='^(BenchmarkCompaction|BenchmarkCompactionFromHead|BenchmarkCompactionFromOOOHead|BenchmarkCompactSelectedSeries|BenchmarkLoadWLs|BenchmarkLabelValues_SlowPath|BenchmarkQuerier|BenchmarkQuerierSelect|BenchmarkQuerierSelectWithOutOfOrder|BenchmarkQueryIterator|BenchmarkQuerySeek|BenchmarkQueries)$'
           go test -p=1 -run '^$' -bench . -benchtime=1x -skip "$skip" -timeout=10m ./... | grep -v '^Benchmark'
+        shell: bash
       - run: go test ./tsdb/ -test.tsdb-isolation=false
       - run: make -C documentation/examples/remote_storage
       - run: make -C documentation/examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,13 @@ jobs:
           enable_npm: true
           cache_key_suffix: race
       - run: make GO_ONLY=1 SKIP_GOLANGCI_LINT=1
+      - name: Smoke test Go benchmarks
+        run: |
+          set -o pipefail
+          # These TSDB benchmarks have multi-minute fixed setup or very large datasets.
+          # Keep them available for targeted performance runs, but out of the CI smoke test.
+          skip='^(BenchmarkCompaction|BenchmarkCompactionFromHead|BenchmarkCompactionFromOOOHead|BenchmarkCompactSelectedSeries|BenchmarkLoadWLs|BenchmarkLabelValues_SlowPath|BenchmarkQuerier|BenchmarkQuerierSelect|BenchmarkQuerierSelectWithOutOfOrder|BenchmarkQueryIterator|BenchmarkQuerySeek|BenchmarkQueries)$'
+          go test -p=1 -run '^$' -bench . -benchtime=1x -skip "$skip" -timeout=10m ./... | grep -v '^Benchmark'
       - run: go test ./tsdb/ -test.tsdb-isolation=false
       - run: make -C documentation/examples/remote_storage
       - run: make -C documentation/examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,7 @@ jobs:
       - name: Smoke test Go benchmarks
         run: |
           set -o pipefail
-          # These TSDB benchmarks have multi-minute fixed setup or very large datasets.
-          # Keep them available for targeted performance runs, but out of the CI smoke test.
-          skip='^(BenchmarkCompaction|BenchmarkCompactionFromHead|BenchmarkCompactionFromOOOHead|BenchmarkCompactSelectedSeries|BenchmarkLoadWLs|BenchmarkLabelValues_SlowPath|BenchmarkQuerier|BenchmarkQuerierSelect|BenchmarkQuerierSelectWithOutOfOrder|BenchmarkQueryIterator|BenchmarkQuerySeek|BenchmarkQueries)$'
-          go test -p=1 -run '^$' -bench . -benchtime=1x -skip "$skip" -timeout=10m ./... | grep -v '^Benchmark'
+          go test -p=1 -short -run '^$' -bench . -benchtime=1x -timeout=10m ./... | grep -v '^Benchmark'
         shell: bash
       - run: go test ./tsdb/ -test.tsdb-isolation=false
       - run: make -C documentation/examples/remote_storage

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -1064,6 +1064,9 @@ func BenchmarkRelabel(b *testing.B) {
 	for i := range tests {
 		err := yaml.UnmarshalStrict([]byte(tests[i].config), &tests[i].cfgs)
 		require.NoError(b, err)
+		for _, cfg := range tests[i].cfgs {
+			require.NoError(b, cfg.Validate(model.UTF8Validation))
+		}
 	}
 	for _, tt := range tests {
 		lb := labels.NewBuilder(labels.EmptyLabels())

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -6997,6 +6997,7 @@ func BenchmarkTargetScraperGzip(b *testing.B) {
 	if err != nil {
 		panic(err)
 	}
+	defer client.CloseIdleConnections()
 
 	for _, scenario := range scenarios {
 		b.Run(fmt.Sprintf("metrics=%d", scenario.metricsCount), func(b *testing.B) {
@@ -7017,8 +7018,9 @@ func BenchmarkTargetScraperGzip(b *testing.B) {
 			}
 			b.ResetTimer()
 			for b.Loop() {
-				_, err = ts.scrape(context.Background())
+				resp, err := ts.scrape(context.Background())
 				require.NoError(b, err)
+				require.NoError(b, resp.Body.Close())
 			}
 		})
 	}

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -109,7 +109,11 @@ func TestCreateBlock(t *testing.T) {
 
 func BenchmarkOpenBlock(b *testing.B) {
 	tmpdir := b.TempDir()
-	blockDir := createBlock(b, tmpdir, genSeries(1e6, 20, 0, 10))
+	seriesCount := 1000000
+	if testing.Short() {
+		seriesCount = 100
+	}
+	blockDir := createBlock(b, tmpdir, genSeries(seriesCount, 20, 0, 10))
 	b.Run("benchmark", func(b *testing.B) {
 		for b.Loop() {
 			block, err := OpenBlock(nil, blockDir, nil, nil)
@@ -457,6 +461,9 @@ func BenchmarkLabelValuesWithMatchers(b *testing.B) {
 
 	var seriesEntries []storage.Series
 	metricCount := 1000000
+	if testing.Short() {
+		metricCount = 1000
+	}
 	for i := range metricCount {
 		// Note these series are not created in sort order: 'value2' sorts after 'value10'.
 		// This makes a big difference to the benchmark timing.
@@ -765,7 +772,7 @@ func createHeadWithOOOSamples(tb testing.TB, w *wlog.WL, series []storage.Series
 	require.NoError(tb, app.Commit())
 
 	oooSamplesAppended := 0
-	require.Equal(tb, float64(0), prom_testutil.ToFloat64(head.metrics.outOfOrderSamplesAppended))
+	require.Equal(tb, float64(0), prom_testutil.ToFloat64(head.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeFloat)))
 
 	app = head.Appender(context.Background())
 	for i, lset := range oooSampleLabels {
@@ -778,11 +785,11 @@ func createHeadWithOOOSamples(tb testing.TB, w *wlog.WL, series []storage.Series
 	}
 	require.NoError(tb, app.Commit())
 
-	actOOOAppended := prom_testutil.ToFloat64(head.metrics.outOfOrderSamplesAppended)
+	actOOOAppended := prom_testutil.ToFloat64(head.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeFloat))
 	require.GreaterOrEqual(tb, actOOOAppended, float64(oooSamplesAppended-len(series)))
 	require.LessOrEqual(tb, actOOOAppended, float64(oooSamplesAppended))
 
-	require.Equal(tb, float64(totalSamples), prom_testutil.ToFloat64(head.metrics.samplesAppended))
+	require.Equal(tb, float64(totalSamples), prom_testutil.ToFloat64(head.metrics.samplesAppended.WithLabelValues(sampleMetricTypeFloat)))
 
 	return head
 }

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1287,6 +1287,9 @@ func BenchmarkCompaction(b *testing.B) {
 	}
 
 	nSeries := 10000
+	if testing.Short() {
+		nSeries = 10
+	}
 	for _, c := range cases {
 		nBlocks := len(c.ranges)
 		b.Run(fmt.Sprintf("type=%s,blocks=%d,series=%d,samplesPerSeriesPerBlock=%d", c.compactionType, nBlocks, nSeries, c.ranges[0][1]-c.ranges[0][0]+1), func(b *testing.B) {
@@ -1319,6 +1322,9 @@ func BenchmarkCompaction(b *testing.B) {
 func BenchmarkCompactionFromHead(b *testing.B) {
 	dir := b.TempDir()
 	totalSeries := 100000
+	if testing.Short() {
+		totalSeries = 100
+	}
 	for labelNames := 1; labelNames < totalSeries; labelNames *= 10 {
 		labelValues := totalSeries / labelNames
 		b.Run(fmt.Sprintf("labelnames=%d,labelvalues=%d", labelNames, labelValues), func(b *testing.B) {
@@ -1349,12 +1355,17 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 	// native histograms that trigger a counter reset on every sample. This
 	// stresses the linked-list traversal in s.chunk() and exercises the
 	// head-chunk cache.
-	for _, tc := range []struct{ series, chunks int }{
+	manyHeadChunksCases := []struct{ series, chunks int }{
 		{100000, 1},  // Baseline: cache skipped (prev==nil).
 		{100000, 10}, // Realistic: cache active, but improvement negligible vs total compaction cost.
 		{10, 100},    // Moderate pathological case.
 		{10, 1000},   // Heavy pathological case.
-	} {
+	}
+	if testing.Short() {
+		manyHeadChunksCases[0].series = 100
+		manyHeadChunksCases[1].series = 100
+	}
+	for _, tc := range manyHeadChunksCases {
 		nSeries, nChunks := tc.series, tc.chunks
 		b.Run(fmt.Sprintf("many head chunks/series=%d,chunks=%d", nSeries, nChunks), func(b *testing.B) {
 			dir := b.TempDir()
@@ -1462,6 +1473,10 @@ func BenchmarkCompactionFromOOOHead(b *testing.B) {
 	dir := b.TempDir()
 	totalSeries := 100000
 	totalSamples := 100
+	if testing.Short() {
+		totalSeries = 100
+		totalSamples = 10
+	}
 	for labelNames := 1; labelNames < totalSeries; labelNames *= 10 {
 		labelValues := totalSeries / labelNames
 		b.Run(fmt.Sprintf("labelnames=%d,labelvalues=%d", labelNames, labelValues), func(b *testing.B) {
@@ -1575,10 +1590,12 @@ func pickRefsEvenly(refs []storage.SeriesRef, count int) []storage.SeriesRef {
 // target chunk size so chunk-writing costs are representative of production
 // workloads rather than degenerate single-sample chunks.
 func BenchmarkCompactSelectedSeries(b *testing.B) {
-	const (
-		totalSeries      = 100_000
-		samplesPerSeries = DefaultSamplesPerChunk
-	)
+	totalSeries := 100_000
+	samplesPerSeries := DefaultSamplesPerChunk
+	if testing.Short() {
+		totalSeries = 100
+		samplesPerSeries = 10
+	}
 	fractions := []float64{1.0, 0.5, 0.3, 0.1, 0.01, 0.001}
 
 	for _, fraction := range fractions {

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -1122,8 +1122,9 @@ func BenchmarkAddExemplar_OutOfOrder(b *testing.B) {
 
 	multipleSeries := func(f func(*int64, *labels.Labels)) func(*int64, *labels.Labels) {
 		return func(ts *int64, l *labels.Labels) {
+			series := *ts
 			f(ts, l)
-			*l = labels.FromStrings("service", strconv.Itoa(int(*ts)))
+			*l = labels.FromStrings("service", strconv.Itoa(int(series)))
 		}
 	}
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -284,15 +284,25 @@ func BenchmarkLoadWLs(b *testing.B) {
 			bucketsPerHistogram: 8,
 		},
 	}
+	if testing.Short() {
+		for i := range cases {
+			cases[i].batches = min(cases[i].batches, 2)
+			cases[i].seriesPerBatch = min(cases[i].seriesPerBatch, 10)
+			cases[i].samplesPerSeries = min(cases[i].samplesPerSeries, 100)
+			if cases[i].mmappedChunkT > 0 {
+				cases[i].mmappedChunkT = 500
+			}
+		}
+	}
 
 	labelsPerSeries := 5
 	// Rough estimates of most common % of samples that have an exemplar for each scrape.
 	exemplarsPercentages := []float64{0, 0.5, 1, 5}
-	lastExemplarsPerSeries := -1
 	for _, enableSTStorage := range []bool{false, true} {
 		for _, c := range cases {
 			missingSeriesPercentages := []float64{0, 0.1}
 			for _, missingSeriesPct := range missingSeriesPercentages {
+				lastExemplarsPerSeries := -1
 				for _, p := range exemplarsPercentages {
 					exemplarsPerSeries := int(math.RoundToEven(float64(c.samplesPerSeries) * p / 100))
 					// For tests with low samplesPerSeries we could end up testing with 0 exemplarsPerSeries
@@ -495,6 +505,7 @@ func BenchmarkLoadWLs(b *testing.B) {
 							b.ResetTimer()
 
 							// Load the WAL.
+							var heads []*Head
 							for b.Loop() {
 								opts := DefaultHeadOptions()
 								opts.ChunkRange = 1000
@@ -504,9 +515,17 @@ func BenchmarkLoadWLs(b *testing.B) {
 								}
 								h, err := NewHead(nil, nil, wal, wbl, opts, nil)
 								require.NoError(b, err)
-								h.Init(0)
+								require.NoError(b, h.Init(0))
+								heads = append(heads, h)
 							}
 							b.StopTimer()
+							for _, h := range heads {
+								// Each iteration replays the same logs, which are owned by the
+								// benchmark and closed after all Heads are cleaned up.
+								h.wal = nil
+								h.wbl = nil
+								require.NoError(b, h.Close())
+							}
 							wal.Close()
 							if wbl != nil {
 								wbl.Close()
@@ -1472,7 +1491,10 @@ func TestHead_UnknownWALRecord(t *testing.T) {
 // BenchmarkHead_Truncate is quite heavy, so consider running it with
 // -benchtime=10x or similar to get more stable and comparable results.
 func BenchmarkHead_Truncate(b *testing.B) {
-	const total = 1e6
+	total := 1000000
+	if testing.Short() {
+		total = 1000
+	}
 
 	prepare := func(b *testing.B, churn int) *Head {
 		h, _ := newTestHead(b, 1000, compression.None, false)
@@ -1495,9 +1517,9 @@ func BenchmarkHead_Truncate(b *testing.B) {
 			return s
 		}
 
-		allSeries := [total]labels.Labels{}
+		allSeries := make([]labels.Labels, total)
 		nameValues := make([]string, 0, 100)
-		for i := range int(total) {
+		for i := range total {
 			nameValues = nameValues[:0]
 
 			// A thousand labels like lbl_x_of_1000, each with total/1000 values
@@ -4014,6 +4036,9 @@ func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {
 	app := head.Appender(context.Background())
 
 	metricCount := 1000000
+	if testing.Short() {
+		metricCount = 1000
+	}
 	for i := range metricCount {
 		_, err := app.Append(0, labels.FromStrings(
 			"a_unique", fmt.Sprintf("value%d", i),

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1017,10 +1017,15 @@ func BenchmarkMemPostings_Delete(b *testing.B) {
 		return s
 	}
 
-	const total = 1e6
-	allSeries := [total]labels.Labels{}
+	total := 1000000
+	refsCases := []int{1, 100, 10_000}
+	if testing.Short() {
+		total = 1000
+		refsCases = []int{1, 10, 100}
+	}
+	allSeries := make([]labels.Labels, total)
 	nameValues := make([]string, 0, 100)
-	for i := range int(total) {
+	for i := range total {
 		nameValues = nameValues[:0]
 
 		// A thousand labels like lbl_x_of_1000, each with total/1000 values
@@ -1037,7 +1042,7 @@ func BenchmarkMemPostings_Delete(b *testing.B) {
 		allSeries[i] = labels.FromStrings(append(nameValues, "first", "a", "second", "a", "third", "a")...)
 	}
 
-	for _, refs := range []int{1, 100, 10_000} {
+	for _, refs := range refsCases {
 		b.Run(fmt.Sprintf("refs=%d", refs), func(b *testing.B) {
 			for _, reads := range []int{0, 1, 10} {
 				b.Run(fmt.Sprintf("readers=%d", reads), func(b *testing.B) {

--- a/tsdb/isolation_test.go
+++ b/tsdb/isolation_test.go
@@ -165,6 +165,7 @@ func BenchmarkIsolation(b *testing.B) {
 	for _, goroutines := range []int{10, 100, 1000, 10000} {
 		b.Run(strconv.Itoa(goroutines), func(b *testing.B) {
 			iso := newIsolation(false)
+			iterations := b.N
 
 			wg := sync.WaitGroup{}
 			start := make(chan struct{})
@@ -173,7 +174,7 @@ func BenchmarkIsolation(b *testing.B) {
 				wg.Go(func() {
 					<-start
 
-					for b.Loop() {
+					for range iterations {
 						appendID, _ := iso.newAppendID(0)
 
 						iso.closeAppend(appendID)
@@ -192,6 +193,7 @@ func BenchmarkIsolationWithState(b *testing.B) {
 	for _, goroutines := range []int{10, 100, 1000, 10000} {
 		b.Run(strconv.Itoa(goroutines), func(b *testing.B) {
 			iso := newIsolation(false)
+			iterations := b.N
 
 			wg := sync.WaitGroup{}
 			start := make(chan struct{})
@@ -200,7 +202,7 @@ func BenchmarkIsolationWithState(b *testing.B) {
 				wg.Go(func() {
 					<-start
 
-					for b.Loop() {
+					for range iterations {
 						appendID, _ := iso.newAppendID(0)
 
 						iso.closeAppend(appendID)
@@ -217,7 +219,7 @@ func BenchmarkIsolationWithState(b *testing.B) {
 				wg.Go(func() {
 					<-start
 
-					for b.Loop() {
+					for range iterations {
 						s := iso.State(math.MinInt64, math.MaxInt64)
 						s.Close()
 					}

--- a/tsdb/label_values_bench_test.go
+++ b/tsdb/label_values_bench_test.go
@@ -51,7 +51,11 @@ func BenchmarkLabelValues_SlowPath(b *testing.B) {
 
 	// Create 100k series with the same label value ("common") but without the matcher label.
 	// This results in a single large posting list for that value, simulating a dense candidate.
-	for i := range 100000 {
+	seriesCount := 100000
+	if testing.Short() {
+		seriesCount = 100
+	}
+	for i := range seriesCount {
 		_, err := app.Append(0, labels.FromStrings("val1", "common", "extra", strconv.Itoa(i)), time.Now().UnixMilli(), 1)
 		require.NoError(b, err)
 	}

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -45,10 +45,14 @@ func BenchmarkQuerier(b *testing.B) {
 	addSeries := func(l labels.Labels) {
 		app.Append(0, l, 0, 0)
 	}
+	seriesPerValue := 100000
+	if testing.Short() {
+		seriesPerValue = 100
+	}
 
 	for n := range 10 {
 		addSeries(labels.FromStrings("a", strconv.Itoa(n)+postingsBenchSuffix))
-		for i := range 100000 {
+		for i := range seriesPerValue {
 			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", strconv.Itoa(n)+postingsBenchSuffix, "j", "foo"))
 			// Have some series that won't be matched, to properly test inverted matches.
 			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", strconv.Itoa(n)+postingsBenchSuffix, "j", "bar"))
@@ -311,6 +315,9 @@ func benchmarkSelect(b *testing.B, queryable storage.Queryable, numSeries int, s
 
 func BenchmarkQuerierSelect(b *testing.B) {
 	numSeries := 1000000
+	if testing.Short() {
+		numSeries = 100
+	}
 	h, db := createHeadForBenchmarkSelect(b, numSeries, func(app storage.Appender, i int) {
 		_, err := app.Append(0, labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%d%s", i, postingsBenchSuffix)), int64(i), 0)
 		if err != nil {
@@ -348,6 +355,9 @@ func (pb *queryableBlock) Querier(mint, maxt int64) (storage.Querier, error) {
 
 func BenchmarkQuerierSelectWithOutOfOrder(b *testing.B) {
 	numSeries := 1000000
+	if testing.Short() {
+		numSeries = 100
+	}
 	_, db := createHeadForBenchmarkSelect(b, numSeries, func(app storage.Appender, i int) {
 		l := labels.FromStrings("foo", "bar", "i", fmt.Sprintf("%d%s", i, postingsBenchSuffix))
 		ref, err := app.Append(0, l, int64(i+1), 0)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2666,6 +2666,11 @@ func BenchmarkQueryIterator(b *testing.B) {
 			overlapPercentages:          []int{0, 10, 30},
 		},
 	}
+	if testing.Short() {
+		cases[0].numBlocks = 2
+		cases[0].numSeries = 10
+		cases[0].numSamplesPerSeriesPerBlock = 100
+	}
 
 	for _, c := range cases {
 		for _, overlapPercentage := range c.overlapPercentages {
@@ -2728,6 +2733,11 @@ func BenchmarkQuerySeek(b *testing.B) {
 			numSamplesPerSeriesPerBlock: 2000,
 			overlapPercentages:          []int{0, 10, 30, 50},
 		},
+	}
+	if testing.Short() {
+		cases[0].numBlocks = 2
+		cases[0].numSeries = 10
+		cases[0].numSamplesPerSeriesPerBlock = 100
 	}
 
 	for _, c := range cases {
@@ -3421,20 +3431,18 @@ func BenchmarkQueries(b *testing.B) {
 		typ     string
 		querier storage.Querier
 	}
-	var queryTypes []qt // We use a slice instead of map to keep the order of test cases consistent.
-	defer func() {
-		for _, q := range queryTypes {
-			// Can't run a check for error here as some of these will fail as
-			// queryTypes is using the same slice for the different block queriers
-			// and would have been closed in the previous iteration.
-			q.querier.Close()
-		}
-	}()
 
+	sampleCounts := []int64{1000, 10000, 100000}
+	if testing.Short() {
+		sampleCounts = sampleCounts[:1]
+	}
 	for title, selectors := range cases {
 		for _, nSeries := range []int{10} {
-			for _, nSamples := range []int64{1000, 10000, 100000} {
+			for _, nSamples := range sampleCounts {
 				dir := b.TempDir()
+				var queryTypes []qt // We use a slice instead of map to keep the order of test cases consistent.
+				var blocks []*Block
+				var heads []*Head
 
 				series := genSeries(nSeries, 5, 1, nSamples)
 
@@ -3466,6 +3474,7 @@ func BenchmarkQueries(b *testing.B) {
 				for x := 0; x <= 10; x++ {
 					block, err := OpenBlock(nil, createBlock(b, dir, series), nil, nil)
 					require.NoError(b, err)
+					blocks = append(blocks, block)
 					q, err := NewBlockQuerier(block, 1, nSamples)
 					require.NoError(b, err)
 					qs = append(qs, q)
@@ -3477,6 +3486,7 @@ func BenchmarkQueries(b *testing.B) {
 
 				chunkDir := b.TempDir()
 				head := createHead(b, nil, series, chunkDir)
+				heads = append(heads, head)
 				qHead, err := NewBlockQuerier(NewRangeHead(head, 1, nSamples), 1, nSamples)
 				require.NoError(b, err)
 				queryTypes = append(queryTypes, qt{"_Head", qHead})
@@ -3486,6 +3496,7 @@ func BenchmarkQueries(b *testing.B) {
 					totalOOOSamples := oooPercentage * int(nSamples) / 100
 					oooSampleFrequency := int(nSamples) / totalOOOSamples
 					head := createHeadWithOOOSamples(b, nil, series, chunkDir, oooSampleFrequency)
+					heads = append(heads, head)
 
 					qHead, err := NewBlockQuerier(NewRangeHead(head, 1, nSamples), 1, nSamples)
 					require.NoError(b, err)
@@ -3504,7 +3515,15 @@ func BenchmarkQueries(b *testing.B) {
 						benchQuery(b, expExpansions, q.querier, selectors)
 					})
 				}
-				require.NoError(b, head.Close())
+				for _, q := range queryTypes {
+					_ = q.querier.Close()
+				}
+				for _, block := range blocks {
+					require.NoError(b, block.Close())
+				}
+				for _, head := range heads {
+					require.NoError(b, head.Close())
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Part of #14926.

This adds a serial `-short -benchtime=1x` CI smoke run for all Go benchmarks. Successful measurement lines are filtered while failure diagnostics and the pipeline status remain visible. Benchmarks with large fixed setup reduce only their setup size under `testing.Short()`; normal performance runs keep their existing workloads.

Running the broader smoke found and fixes benchmark decay in several areas:

- validate relabel configs before processing them;
- preserve the original series when generating multi-series out-of-order exemplar timestamps;
- keep `b.N` iteration control outside isolation benchmark worker goroutines;
- close scrape responses and idle HTTP connections;
- read the correct labeled append metrics;
- isolate and close query benchmark resources per case;
- validate WAL replay and clean up each replayed Head.

Tests:

- `go test -short -run '^$' -bench '^(BenchmarkOpenBlock|BenchmarkLabelValuesWithMatchers|BenchmarkHead_Truncate|BenchmarkHeadLabelValuesWithMatchers|BenchmarkCompaction|BenchmarkCompactionFromHead|BenchmarkCompactionFromOOOHead|BenchmarkCompactSelectedSeries|BenchmarkLoadWLs|BenchmarkLabelValues_SlowPath|BenchmarkQuerier|BenchmarkQuerierSelect|BenchmarkQuerierSelectWithOutOfOrder|BenchmarkQueryIterator|BenchmarkQuerySeek|BenchmarkQueries)$' -benchtime=1x -timeout=10m ./tsdb`
- `go test -short -run '^$' -bench '^BenchmarkMemPostings_Delete$' -benchtime=1x ./tsdb/index`
- `go test -short -run '^$' -bench '^BenchmarkTargetScraperGzip$' -benchtime=1x ./scrape`
- `go test ./scrape ./tsdb`
- `golangci-lint run --new-from-rev origin/main ./scrape ./tsdb ./tsdb/index` (v2.13.1)

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```