### PR TITLE
discovery/aws: guard against nil Placement and ImageId on EC2 instances

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -400,15 +400,19 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 							ec2LabelSeparator)
 				}
 
-				labels[ec2LabelAMI] = model.LabelValue(*inst.ImageId)
-				labels[ec2LabelAZ] = model.LabelValue(*inst.Placement.AvailabilityZone)
-				azID, ok := d.azToAZID[*inst.Placement.AvailabilityZone]
-				if !ok && d.azToAZID != nil {
-					d.logger.Debug(
-						"Availability zone ID not found",
-						"az", *inst.Placement.AvailabilityZone)
+				if inst.ImageId != nil {
+					labels[ec2LabelAMI] = model.LabelValue(*inst.ImageId)
 				}
-				labels[ec2LabelAZID] = model.LabelValue(azID)
+				if inst.Placement != nil && inst.Placement.AvailabilityZone != nil {
+					labels[ec2LabelAZ] = model.LabelValue(*inst.Placement.AvailabilityZone)
+					azID, ok := d.azToAZID[*inst.Placement.AvailabilityZone]
+					if !ok && d.azToAZID != nil {
+						d.logger.Debug(
+							"Availability zone ID not found",
+							"az", *inst.Placement.AvailabilityZone)
+					}
+					labels[ec2LabelAZID] = model.LabelValue(azID)
+				}
 				labels[ec2LabelInstanceState] = model.LabelValue(inst.State.Name)
 				labels[ec2LabelInstanceType] = model.LabelValue(inst.InstanceType)
 

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -111,6 +111,40 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 		expected []*targetgroup.Group
 	}{
 		{
+			name: "NilPlacementAndImageId",
+			ec2Data: &ec2DataStore{
+				region: "region-nilfields",
+				azToAZID: map[string]string{
+					"azname-a": "azid-1",
+				},
+				instances: []ec2Types.Instance{
+					{
+						InstanceId:       strptr("instance-id-nilfields"),
+						PrivateIpAddress: strptr("1.2.3.4"),
+						State:            &ec2Types.InstanceState{Name: "running"},
+						InstanceType:     "instance-type-nilfields",
+						// Placement and ImageId are nil
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "region-nilfields",
+					Targets: []model.LabelSet{
+						{
+							"__address__":               model.LabelValue("1.2.3.4:4242"),
+							"__meta_ec2_instance_id":    model.LabelValue("instance-id-nilfields"),
+							"__meta_ec2_instance_state": model.LabelValue("running"),
+							"__meta_ec2_instance_type":  model.LabelValue("instance-type-nilfields"),
+							"__meta_ec2_owner_id":       model.LabelValue(""),
+							"__meta_ec2_private_ip":     model.LabelValue("1.2.3.4"),
+							"__meta_ec2_region":         model.LabelValue("region-nilfields"),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "NoPrivateIpOrIpv6",
 			ec2Data: &ec2DataStore{
 				region: "region-noprivateip",


### PR DESCRIPTION
## Problem
When EC2 service discovery runs against AWS environments where `DescribeInstances` returns instances with a `nil` `Placement` or `nil` `ImageId` field, Prometheus encounters a runtime panic in `discovery/aws/ec2.go` due to unguarded dereferences (`*inst.Placement.AvailabilityZone` and `*inst.ImageId`). Since discovery runs without `recover()`, this causes an immediate process crash.

Fixes #19374

## Solution
- Guard dereference of `inst.ImageId` when assigning `ec2LabelAMI`.
- Guard dereferences of `inst.Placement` and `inst.Placement.AvailabilityZone` when setting `ec2LabelAZ` and resolving `azID`.
- Added unit test case `NilPlacementAndImageId` under `TestEC2DiscoveryRefresh` to prevent regression.

## Verification
- Unit test case `NilPlacementAndImageId` passes and asserts correct label generation without panic.
- Commits signed off with DCO.

Signed-off-by: K J sundeep kumar <sundeep8967@gmail.com>