### PR TITLE
Consolidate start timestamp feature flags

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -294,12 +294,14 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 			case "st-storage":
 				c.scrape.ParseST = true
 				c.tsdb.EnableSTStorage = true
+				c.tsdb.FloatChunkEncoding = chunkenc.EncXOR2
+				c.tsdb.EnableHistogramSTEncoding = true
 				c.agent.EnableSTStorage = true
 
 				// Change relevant global variables. Hacky, but it's hard to pass a new option or default to unmarshallers. This is to widen the ST support surface.
 				config.DefaultConfig.GlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
 				config.DefaultGlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
-				logger.Info("Experimental start timestamp storage enabled. OpenMetrics 1.0 parsing will parse <metric>_created metrics as ST instead of normal sample. Changed default scrape_protocols to prefer PrometheusProto format.", "global.scrape_protocols", fmt.Sprintf("%v", config.DefaultGlobalConfig.ScrapeProtocols))
+				logger.Info("Experimental start timestamp storage enabled. XOR2 and ST-capable histogram chunk encodings enabled. OpenMetrics 1.0 parsing will parse <metric>_created metrics as ST instead of normal sample. Changed default scrape_protocols to prefer PrometheusProto format.", "global.scrape_protocols", fmt.Sprintf("%v", config.DefaultGlobalConfig.ScrapeProtocols))
 			case "use-start-timestamps":
 				c.useStartTimestamps = true
 				logger.Info("Experimental usage of start timestamps in PromQL engine is enabled.")

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -459,10 +459,10 @@ storage:
 			exitCode: 1,
 		},
 		{
-			name:     "st-storage without any float chunk encoding set",
+			name:     "st-storage implies ST-capable encodings",
 			config:   "",
 			features: "st-storage",
-			exitCode: 1,
+			exitCode: 0,
 		},
 		{
 			name: "xor without st-storage feature",

--- a/compliance/remote_write_sender_test.go
+++ b/compliance/remote_write_sender_test.go
@@ -86,9 +86,8 @@ func (p internalPrometheus) Run(ctx context.Context, opts sender.Options) error 
 		args = append(args, "--enable-feature=st-storage")
 		args = append(args, fmt.Sprintf("--storage.agent.path=%v", dir), "--agent")
 	} else {
-		// Server mode: st-storage requires XOR2 chunk encoding so that start
-		// timestamps can be stored in float chunks.
-		args = append(args, "--enable-feature=st-storage,xor2-encoding")
+		// Server mode: st-storage enables the ST-capable chunk encodings.
+		args = append(args, "--enable-feature=st-storage")
 		args = append(args, fmt.Sprintf("--storage.tsdb.path=%v", dir))
 	}
 	return sender.RunCommand(ctx, "../cmd/prometheus", nil, "go", args...)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -4166,8 +4166,8 @@ with this feature.
 # written, downgrading to a version without XOR2 support requires deleting the affected
 # blocks from disk manually, otherwise Prometheus returns an error on all queries.
 #
-# When absent, the encoding follows the deprecated --enable-feature=xor2-encoding
-# flag: 'xor2' if the flag is set, 'xor' otherwise.
+# When absent, the encoding is 'xor2' if --enable-feature=xor2-encoding or
+# --enable-feature=st-storage is set, and 'xor' otherwise.
 # Setting 'xor' is incompatible with --enable-feature=st-storage (XOR chunks do not store
 # start timestamps); Prometheus will refuse to start or reload in that case.
 # This field is runtime-reloadable.
@@ -4178,7 +4178,7 @@ with this feature.
 # (XOR chunks do not store start timestamps), so an in-progress chunk is cut
 # on the next append after the encoding changes.
 # For the equivalent ST-capable encoding for native histograms, see the experimental
-# histograms-st-encoding feature flag.
+# histograms-st-encoding feature flag. The st-storage feature enables that encoding too.
 [ chunk_encoding:
   [ floats: <string> ] ]
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -102,10 +102,8 @@ Besides enabling this feature in Prometheus, start timestamps need to be exposed
 
 > NOTE: This is an experimental feature with known limitations until fully implemented.
 > * It introduces new WAL record type (SamplesV2) that can only be replayed with Prometheus 3.11 or later versions.
-> * For persistent storage support (TSDB blocks), you need to manually opt-in for the XOR2 chunk format for floats ([`chunk_encoding.floats: xor2`](configuration/configuration.md#tsdb)) and the histogram ST chunk format for native histograms ([`histograms-st-encoding` flag](#histogram-st-chunk-encoding)).
->   The float chunk encoding must resolve to XOR2 when `st-storage` is active, because XOR chunks do not store start timestamps.
->   If the resolved encoding is XOR, Prometheus refuses to start and fails the configuration validation with an error rather than continuing to run.
->   Likewise, explicitly setting `chunk_encoding.floats: xor` in the config file while `st-storage` is active is rejected at config reload.
+> * For persistent storage support (TSDB blocks), this feature automatically enables the XOR2 chunk format for floats and the histogram ST chunk formats for native histograms. These are the same formats enabled independently through [`chunk_encoding.floats: xor2`](configuration/configuration.md#tsdb) and the [`histograms-st-encoding`](#histogram-st-chunk-encoding) flag.
+>   Explicitly setting `chunk_encoding.floats: xor` in the config file while `st-storage` is active is rejected at config reload because XOR chunks do not store start timestamps.
 >   These constraints might change later once we finish the experimentation phase.
 > * Other areas of ST support for native histograms and NHCBs are still in progress (see [#18315](https://github.com/prometheus/prometheus/issues/18315)).
 > * PromQL use of ST is out of scope of this feature.
@@ -294,6 +292,8 @@ For more details, see the [proposal](https://github.com/prometheus/proposals/pul
 
 > **Note:** This feature flag is deprecated. The XOR2 float chunk encoding is stable; select it with the `chunk_encoding.floats` field in the `storage.tsdb` section of the configuration file instead, documented in the [configuration documentation](configuration/configuration.md#tsdb). The flag only sets the default float chunk encoding to `xor2`, and will become a no-op in a future major version.
 
+The [`st-storage`](#start-timestamp-st-native-storage) feature also selects XOR2 as the default float chunk encoding because XOR chunks cannot store start timestamps.
+
 ## Histogram ST chunk encoding
 
 `--enable-feature=histograms-st-encoding`
@@ -304,6 +304,8 @@ For more details, see the [proposal](https://github.com/prometheus/proposals/pul
 > * This encoding is new, meaning downstream tools and LTS systems might not support it yet (e.g. Thanos sidecar uploaded blocks).
 
 This setting enables the new `histogramST` and `floathistogramST` chunk encodings for native histogram and float histogram samples. These encodings extend the corresponding histogram chunk formats with a Start Timestamp (ST) header and per-sample ST encoding, equivalent to what the [XOR2 encoding](configuration/configuration.md#tsdb) does for float chunks. The flag does not affect float chunks.
+
+The [`st-storage`](#start-timestamp-st-native-storage) feature automatically enables these histogram encodings. When enabled without `st-storage`, Prometheus uses the ST-capable histogram chunk encodings but does not store start timestamps from ingestion.
 
 ## Extended Range Selectors
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -270,8 +270,7 @@ type Options struct {
 	// resolve it into this one.
 	// Defaults to EncXOR. Set to EncXOR2 to encode new float chunks as XOR2.
 	// Always use DefaultOptions() rather than a bare Options literal; the zero value
-	// of this field is EncNone, not EncXOR. This field is independent of EnableSTStorage:
-	// st-storage does not automatically select EncXOR2.
+	// of this field is EncNone, not EncXOR.
 	FloatChunkEncoding chunkenc.Encoding
 
 	// FeatureRegistry is used to register TSDB features.


### PR DESCRIPTION
This PR updates the st-storage feature flag to also automatically set xor2-encoding and histograms-st-encoding flags. This is part of an attempt to consolidate the number of feature flags that need to be set in order to use the start timestamp feature. 

#### Which issue(s) does the PR fix:
Part of https://github.com/prometheus/prometheus/issues/17652. 

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[ENHANCEMENT] PromQL/TSDB: The `--enable-feature=st-storage` flag now automatically enables XOR2 float chunk encoding and ST-capable histogram chunk encoding, so you no longer need to pass `xor2-encoding` and `histograms-st-encoding` alongside it.
```

