### PR TITLE
fix(PromQL): never skip buckets for histogram_stddev/histogram_stdvar

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -4751,7 +4751,7 @@ func detectHistogramStatsDecoding(expr parser.Expr) {
 					// further up (the latter wouldn't make sense,
 					// but no harm in detecting it).
 					n.SkipHistogramBuckets = true
-				case "histogram_quantile", "histogram_quantiles", "histogram_fraction":
+				case "histogram_quantile", "histogram_quantiles", "histogram_fraction", "histogram_stddev", "histogram_stdvar":
 					// If we ever see a function that needs the
 					// whole histogram, we will not skip the
 					// buckets.


### PR DESCRIPTION
PromQL engine skips histogram buckets for performance reasons in cases when they have no impact on query result. The logic controlling this feature disables bucket skipping for `histogram_quantile`, `histogram_quantiles` and `histogram_fraction` functions, but does not do that for `histogram_stddev` and `histogram_stdvar` functions (which operate on histogram buckets).

Note that currently it is not possible to write a meaningful query as a regression test for this (`histogram_count(histogram_stddev(foo))` does not really make sense), but this will hopefully change soon as I am planning to add more functions to the whitelist of `detectHistogramStatsDecoding`.

#### Release notes for end users (**ALL** commits must be considered).
```release-notes
[BUGFIX] Never skip histogram buckets for histogram_stddev and histogram_stdvar functions.
```
