### PR TITLE
mixin: support native histograms in remote write latency panel

### DIFF
--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -786,6 +786,26 @@ local row = panel.row;
           + prometheus.withFormat('time_series')
           + prometheus.withIntervalFactor(2)
           + prometheus.withLegendFormat('{{%(clusterLabel)s}}:{{instance}} {{remote_name}}:{{url}} p99' % $._config),
+          // Native histograms, including NHCB, expose no _bucket series, so the queries above
+          // match nothing there. Exactly one pair returns data for a given scrape configuration.
+          prometheus.new(
+            '$datasource',
+            |||
+              histogram_quantile(0.95, sum by (%(clusterLabel)s, instance, remote_name, url) (rate(prometheus_remote_storage_sent_batch_duration_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}[5m])))
+            ||| % $._config
+          )
+          + prometheus.withFormat('time_series')
+          + prometheus.withIntervalFactor(2)
+          + prometheus.withLegendFormat('{{%(clusterLabel)s}}:{{instance}} {{remote_name}}:{{url}} p95 (native)' % $._config),
+          prometheus.new(
+            '$datasource',
+            |||
+              histogram_quantile(0.99, sum by (%(clusterLabel)s, instance, remote_name, url) (rate(prometheus_remote_storage_sent_batch_duration_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}[5m])))
+            ||| % $._config
+          )
+          + prometheus.withFormat('time_series')
+          + prometheus.withIntervalFactor(2)
+          + prometheus.withLegendFormat('{{%(clusterLabel)s}}:{{instance}} {{remote_name}}:{{url}} p99 (native)' % $._config),
         ]);
 
       dashboard.new('%(prefix)sRemote Write' % $._config.grafanaPrometheus)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Closes #19520. Follow-up to #19500.

#### Release notes 

```release-notes
[ENHANCEMENT] Mixin: Support native histograms in the remote-write send-batch latency panel.
```

### The problem

The Send Batch Duration (p95 / p99) panel queries the prometheus_remote_storage_sent_batch_duration_seconds_bucket and group that using le. But when the histogram is scraped as a native histogram the panel shows nothing because there is no _bucket series and no le label the buckets live inside the sample.

### The change

Adding two more targets querying the native representation is done.

histogram_quantile(0.95, sum by (<labels>) (rate(prometheus_remote_storage_sent_batch_duration_seconds{  }[5m])))
So there no _bucket suffix or le in the sum by.
The new targets are labelled as p95  and p99  other than reusing the existing labels because always_scrape_classic_histograms allows both representations to be present for the same metric and same legend labels would be a problem in that case.

### Testing

make -C documentation/prometheus-mixin passe matching the test_mixins CI job
The generated dashboards_out/prometheus-remote-write.json shows the panel with 4 targets and the expected expressions. Both new queries were checked with promtool promql format --experimental.

