### PR TITLE
semconv: proof of concept for contract testing internal metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -274,3 +274,5 @@ exclude (
 )
 
 replace cloud.google.com/go => cloud.google.com/go v0.123.0
+
+replace github.com/prometheus/client_golang => /Users/ntakashi/Workspace/github.com/nicolastakashi/prometheus/client_golang

--- a/notifier/semconv_contract_test.go
+++ b/notifier/semconv_contract_test.go
@@ -1,0 +1,44 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notifier
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/semconv"
+)
+
+// TestRegistryContract asserts that the metrics this package declares match the
+// semantic convention registry. It inspects the descriptors rather than the
+// gathered metrics, so metrics that have not produced a sample are covered too.
+func TestRegistryContract(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	newAlertMetrics(reg, func() float64 { return 0 })
+
+	declared := make(map[string]prometheus.DescInfo)
+	for _, desc := range reg.DescribeAll() {
+		info := desc.Info()
+		declared[info.FQName] = info
+	}
+
+	registry, err := semconv.LoadFile("../semconv/registry.yaml")
+	require.NoError(t, err)
+
+	if diff := registry.Diff(declared); diff != "" {
+		require.Fail(t, "registry and code disagree (-registry +code):\n"+diff)
+	}
+}

--- a/semconv/README.md
+++ b/semconv/README.md
@@ -1,0 +1,96 @@
+# Semantic convention registry
+
+`registry.yaml` declares every metric the Prometheus binary exposes. It follows
+the [OpenTelemetry semantic convention][semconv] schema, so the common fields
+(`id`, `brief`, `metric_name`, `instrument`, `unit`, `stability`) mean what that
+specification says they mean. Everything else here is Prometheus specific.
+
+[semconv]: https://opentelemetry.io/docs/specs/semconv/
+
+A metric with a label and a histogram configuration looks like this:
+
+```yaml
+groups:
+  - id: attr.alertmanager
+    type: attribute_group
+    brief: Attributes for alertmanager metrics.
+    attributes:
+      - id: alertmanager
+        type: string
+        stability: development
+        brief: The alertmanager instance URL.
+        examples:
+          - "http://alertmanager:9093/api/v2/alerts"
+
+  - id: metric.prometheus_notifications_latency_histogram_seconds
+    type: metric
+    stability: development
+    brief: Latency histogram for sending alert notifications.
+    metric_name: prometheus_notifications_latency_histogram_seconds
+    instrument: histogram
+    unit: s
+    attributes:
+      - ref: alertmanager
+    annotations:
+      prometheus:
+        histogram_type: mixed_histogram
+        buckets: [0.01, 0.1, 1, 10]
+        bucket_factor: 1.1
+        max_bucket_number: 100
+        min_reset_duration: "1h"
+```
+
+## Attributes are labels
+
+An OpenTelemetry attribute is a Prometheus label. A label is defined once in an
+`attribute_group`, with its type and an example value, and every metric that
+carries it refers to that definition with `ref`. One definition serves every
+metric that uses the label, and Weaver fails resolution on a `ref` that matches
+no definition.
+
+The registry does not record whether a label is variable or fixed at
+construction time. Both are declared the same way, and the code decides. A
+metric that lists no attributes has no labels.
+
+## Histograms and summaries
+
+OpenTelemetry has one histogram instrument. Prometheus has four shapes, so
+`annotations.prometheus.histogram_type` is required on every metric declared
+with `instrument: histogram`, and it selects which bucket fields apply.
+
+| `histogram_type`    | Prometheus type              | Bucket fields                                                |
+| ------------------- | ---------------------------- | ------------------------------------------------------------ |
+| `classic_histogram` | Fixed buckets                | `buckets` or `exponential_buckets`                             |
+| `native_histogram`  | Exponential buckets          | `bucket_factor`, `max_bucket_number`, `min_reset_duration`     |
+| `mixed_histogram`   | Both at once                 | all of the above                                               |
+| `summary`           | Summary, not a histogram     | `objectives`, mapping quantile to allowed error                |
+
+Semantic conventions have no summary instrument, so a Prometheus summary is
+declared as a histogram carrying
+`histogram_type: summary`. Anything that reads `instrument` to decide a metric's
+type has to check this annotation first, or it will report a summary as a
+histogram.
+
+`exponential_buckets` takes `start`, `factor`, and `count` rather than a list of
+boundaries.
+
+## Callback metrics
+
+Some metrics compute their value when scraped rather than being set by the
+program. `prometheus.GaugeFunc` is the common case. A generated constructor has
+nothing to do for these, so the registry marks them `only_opts` and generation
+emits only an `Opts()` accessor carrying the schema-owned name, help, and unit.
+The closure stays in hand-written code.
+
+```yaml
+annotations:
+  prometheus:
+    only_opts: true # Implemented as GaugeFunc.
+```
+
+## Stability
+
+`stability` records where a metric sits in its lifecycle so that a change to it
+shows up in review. What `stable` obligates Prometheus to, and how long a
+deprecation runs, are policy questions this registry does not settle. Metrics carry `development` until that policy
+exists.

--- a/semconv/registry.go
+++ b/semconv/registry.go
@@ -1,0 +1,216 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package semconv reads the semantic convention registry that declares the
+// metrics the Prometheus binary exposes.
+package semconv
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// Registry is a resolved semantic convention registry. References and
+// inheritance are expected to be expanded already.
+type Registry struct {
+	Groups []Group `yaml:"groups"`
+}
+
+// Group types used in the registry.
+const (
+	// TypeMetric declares one metric.
+	TypeMetric = "metric"
+	// TypeAttributeGroup declares attributes that metric groups reference.
+	TypeAttributeGroup = "attribute_group"
+)
+
+// Group declares either one metric or a set of reusable attributes, depending
+// on its Type.
+type Group struct {
+	ID          string      `yaml:"id"`
+	Type        string      `yaml:"type"`
+	Stability   string      `yaml:"stability"`
+	Brief       string      `yaml:"brief"`
+	MetricName  string      `yaml:"metric_name"`
+	Instrument  string      `yaml:"instrument"`
+	Unit        string      `yaml:"unit"`
+	Attributes  []Attribute `yaml:"attributes"`
+	Annotations Annotations `yaml:"annotations"`
+}
+
+// Attribute is either the definition of a label, inside an attribute_group, or
+// a reference to one, inside a metric group.
+type Attribute struct {
+	// ID names the label. It is set on definitions.
+	ID string `yaml:"id"`
+	// Ref points at the ID of a definition. It is set on references.
+	Ref string `yaml:"ref"`
+	// Type is the value type of the label, e.g. string.
+	Type string `yaml:"type"`
+	// Stability is the lifecycle stage of the label.
+	Stability string `yaml:"stability"`
+	// Brief describes the label.
+	Brief string `yaml:"brief"`
+	// Examples are sample values of the label.
+	Examples []string `yaml:"examples"`
+}
+
+// Name returns the label name, whether the Attribute is a definition or a
+// reference.
+func (a Attribute) Name() string {
+	if a.Ref != "" {
+		return a.Ref
+	}
+
+	return a.ID
+}
+
+// Annotations carries details that semantic conventions cannot express.
+type Annotations struct {
+	Prometheus PrometheusAnnotations `yaml:"prometheus"`
+}
+
+// PrometheusAnnotations carries the Prometheus specific details of a metric.
+type PrometheusAnnotations struct {
+	// HistogramType is one of classic_histogram, native_histogram,
+	// mixed_histogram or summary.
+	HistogramType string `yaml:"histogram_type"`
+	// OnlyOpts marks a metric that is implemented as a callback, so only its
+	// Opts are generated rather than a full constructor.
+	OnlyOpts bool `yaml:"only_opts"`
+}
+
+// Load parses a registry from s. It rejects input that does not declare any
+// metric, so that pointing a caller at the wrong file fails loudly instead of
+// yielding an empty registry that compares equal to nothing.
+func Load(s []byte) (*Registry, error) {
+	r := &Registry{}
+	if err := yaml.Unmarshal(s, r); err != nil {
+		return nil, err
+	}
+	metrics := 0
+	for i, g := range r.Groups {
+		if g.Type != TypeMetric {
+			continue
+		}
+		if g.MetricName == "" {
+			return nil, fmt.Errorf("group %d (%q) declares no metric_name", i, g.ID)
+		}
+		metrics++
+	}
+	if metrics == 0 {
+		return nil, errors.New("registry declares no metric groups")
+	}
+
+	return r, nil
+}
+
+// LoadFile parses a registry from the given file.
+func LoadFile(filename string) (*Registry, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := Load(content)
+	if err != nil {
+		return nil, fmt.Errorf("parsing registry %s: %w", filename, err)
+	}
+
+	return r, nil
+}
+
+// DescInfos returns the metrics the registry declares, keyed by metric name and
+// shaped the way prometheus.Desc reports them, so the two can be compared.
+func (r *Registry) DescInfos() map[string]prometheus.DescInfo {
+	infos := make(map[string]prometheus.DescInfo, len(r.Groups))
+	for _, g := range r.Groups {
+		if g.Type != TypeMetric {
+			continue
+		}
+		infos[g.MetricName] = g.DescInfo()
+	}
+
+	return infos
+}
+
+// DescInfo returns the group shaped the way prometheus.Desc reports it.
+func (g Group) DescInfo() prometheus.DescInfo {
+	var labels []string
+	for _, a := range g.Attributes {
+		labels = append(labels, a.Name())
+	}
+
+	return prometheus.DescInfo{
+		FQName:         g.MetricName,
+		Help:           g.Brief,
+		Unit:           g.Unit,
+		Type:           g.metricType(),
+		VariableLabels: labels,
+	}
+}
+
+// metricType maps the declared instrument to the type client_golang reports.
+// Semantic conventions have no summary instrument, so a summary is declared as
+// a histogram carrying annotations.prometheus.histogram_type: summary. An
+// instrument that is missing or unrecognised maps to UNTYPED rather than to the
+// zero value of dto.MetricType, which is COUNTER.
+func (g Group) metricType() dto.MetricType {
+	if g.Annotations.Prometheus.HistogramType == "summary" {
+		return dto.MetricType_SUMMARY
+	}
+
+	t, ok := dto.MetricType_value[strings.ToUpper(g.Instrument)]
+	if !ok {
+		return dto.MetricType_UNTYPED
+	}
+
+	return dto.MetricType(t)
+}
+
+// sortLabels ignores label order, which is decided by the metric constructor
+// rather than by the registry.
+var sortLabels = cmpopts.SortSlices(func(a, b string) bool { return a < b })
+
+// Diff reports how the declared metrics differ from the registry, in the format
+// of cmp.Diff with the registry as the expected side. It returns an empty
+// string when they agree. Only metrics that differ are reported, so the result
+// stays readable for a registry covering the whole binary.
+func (r *Registry) Diff(declared map[string]prometheus.DescInfo) string {
+	want, got := map[string]prometheus.DescInfo{}, map[string]prometheus.DescInfo{}
+	for name, w := range r.DescInfos() {
+		d, ok := declared[name]
+		if ok && cmp.Equal(w, d, sortLabels) {
+			continue
+		}
+		want[name] = w
+		if ok {
+			got[name] = d
+		}
+	}
+	for name, d := range declared {
+		if _, ok := r.DescInfos()[name]; !ok {
+			got[name] = d
+		}
+	}
+
+	return cmp.Diff(want, got, sortLabels)
+}

--- a/semconv/registry.yaml
+++ b/semconv/registry.yaml
@@ -1,0 +1,111 @@
+# Semantic convention registry for the metrics the Prometheus binary exposes.
+#
+# This file is the source of truth for these metrics. See README.md for the
+# meaning of the Prometheus specific fields.
+#
+# Pilot scope: the notifier package only.
+
+groups:
+  - id: attr.alertmanager
+    type: attribute_group
+    brief: Attributes for alertmanager metrics.
+    attributes:
+      - id: alertmanager
+        type: string
+        stability: development
+        brief: The alertmanager instance URL.
+        examples:
+          - "http://alertmanager:9093/api/v2/alerts"
+
+  - id: metric.prometheus_notifications_alertmanagers_discovered
+    type: metric
+    stability: development
+    brief: The number of alertmanagers discovered and active.
+    metric_name: prometheus_notifications_alertmanagers_discovered
+    instrument: gauge
+    unit: ""
+    annotations:
+      prometheus:
+        only_opts: true # Implemented as GaugeFunc.
+
+  - id: metric.prometheus_notifications_queue_capacity
+    type: metric
+    stability: development
+    brief: The capacity of the alert notifications queue.
+    metric_name: prometheus_notifications_queue_capacity
+    instrument: gauge
+    unit: ""
+
+  - id: metric.prometheus_notifications_queue_length
+    type: metric
+    stability: development
+    brief: The number of alert notifications in the queue.
+    metric_name: prometheus_notifications_queue_length
+    instrument: gauge
+    unit: ""
+    attributes:
+      - ref: alertmanager
+
+  - id: metric.prometheus_notifications_dropped_total
+    type: metric
+    stability: development
+    brief: Total number of alerts dropped due to errors when sending to Alertmanager.
+    metric_name: prometheus_notifications_dropped_total
+    instrument: counter
+    unit: ""
+    attributes:
+      - ref: alertmanager
+
+  - id: metric.prometheus_notifications_errors_total
+    type: metric
+    stability: development
+    brief: Total number of sent alerts affected by errors.
+    metric_name: prometheus_notifications_errors_total
+    instrument: counter
+    unit: ""
+    attributes:
+      - ref: alertmanager
+
+  - id: metric.prometheus_notifications_sent_total
+    type: metric
+    stability: development
+    brief: Total number of alerts sent.
+    metric_name: prometheus_notifications_sent_total
+    instrument: counter
+    unit: ""
+    attributes:
+      - ref: alertmanager
+
+  - id: metric.prometheus_notifications_latency_seconds
+    type: metric
+    stability: development
+    brief: Latency quantiles for sending alert notifications.
+    metric_name: prometheus_notifications_latency_seconds
+    instrument: histogram
+    unit: ""
+    attributes:
+      - ref: alertmanager
+    annotations:
+      prometheus:
+        histogram_type: summary
+        objectives:
+          0.5: 0.05
+          0.9: 0.01
+          0.99: 0.001
+
+  - id: metric.prometheus_notifications_latency_histogram_seconds
+    type: metric
+    stability: development
+    brief: Latency histogram for sending alert notifications.
+    metric_name: prometheus_notifications_latency_histogram_seconds
+    instrument: histogram
+    unit: ""
+    attributes:
+      - ref: alertmanager
+    annotations:
+      prometheus:
+        histogram_type: mixed_histogram
+        buckets: [0.01, 0.1, 1, 10]
+        bucket_factor: 1.1
+        max_bucket_number: 100
+        min_reset_duration: "1h"

--- a/semconv/registry_test.go
+++ b/semconv/registry_test.go
@@ -1,0 +1,223 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestGroupDescInfo(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		group Group
+		want  prometheus.DescInfo
+	}{
+		{
+			name: "counter with attributes",
+			group: Group{
+				MetricName: "prometheus_notifications_sent_total",
+				Brief:      "Total number of alerts sent.",
+				Instrument: "counter",
+				Unit:       "s",
+				Attributes: []Attribute{{Ref: "alertmanager"}},
+			},
+			want: prometheus.DescInfo{
+				FQName:         "prometheus_notifications_sent_total",
+				Help:           "Total number of alerts sent.",
+				Unit:           "s",
+				Type:           dto.MetricType_COUNTER,
+				VariableLabels: []string{"alertmanager"},
+			},
+		},
+		{
+			name: "summary is declared as a histogram",
+			group: Group{
+				MetricName: "prometheus_notifications_latency_seconds",
+				Instrument: "histogram",
+				Annotations: Annotations{
+					Prometheus: PrometheusAnnotations{HistogramType: "summary"},
+				},
+			},
+			want: prometheus.DescInfo{
+				FQName: "prometheus_notifications_latency_seconds",
+				Type:   dto.MetricType_SUMMARY,
+			},
+		},
+		{
+			name: "attribute definitions are named by id, references by ref",
+			group: Group{
+				MetricName: "defined",
+				Instrument: "gauge",
+				Attributes: []Attribute{{ID: "shard"}, {Ref: "alertmanager"}},
+			},
+			want: prometheus.DescInfo{
+				FQName:         "defined",
+				Type:           dto.MetricType_GAUGE,
+				VariableLabels: []string{"shard", "alertmanager"},
+			},
+		},
+		{
+			// The zero value of dto.MetricType is COUNTER, so a missing
+			// instrument must not fall through to it.
+			name:  "missing instrument is untyped",
+			group: Group{MetricName: "no_instrument"},
+			want:  prometheus.DescInfo{FQName: "no_instrument", Type: dto.MetricType_UNTYPED},
+		},
+		{
+			name:  "unrecognised instrument is untyped",
+			group: Group{MetricName: "bogus", Instrument: "not_a_thing"},
+			want:  prometheus.DescInfo{FQName: "bogus", Type: dto.MetricType_UNTYPED},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.RequireEqual(t, tc.want, tc.group.DescInfo())
+		})
+	}
+}
+
+func TestLoad(t *testing.T) {
+	r, err := Load([]byte(`
+groups:
+  - id: metric.some_total
+    type: metric
+    stability: development
+    brief: A metric.
+    metric_name: some_total
+    instrument: counter
+    unit: "{thing}"
+    attributes:
+      - ref: label
+    annotations:
+      prometheus:
+        only_opts: true
+`))
+	require.NoError(t, err)
+	require.Len(t, r.Groups, 1)
+
+	g := r.Groups[0]
+	require.Equal(t, "metric.some_total", g.ID)
+	require.Equal(t, "development", g.Stability)
+	require.True(t, g.Annotations.Prometheus.OnlyOpts)
+
+	testutil.RequireEqual(t, map[string]prometheus.DescInfo{
+		"some_total": {
+			FQName:         "some_total",
+			Help:           "A metric.",
+			Unit:           "{thing}",
+			Type:           dto.MetricType_COUNTER,
+			VariableLabels: []string{"label"},
+		},
+	}, r.DescInfos())
+}
+
+func TestLoadRejectsInputWithoutMetrics(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{name: "empty", input: ""},
+		{name: "unrelated yaml", input: "hello: world\n"},
+		{
+			name:  "only attribute groups, no metrics",
+			input: "groups:\n  - id: attr.only\n    type: attribute_group\n",
+		},
+		{
+			name:  "otel telemetry schema, not a registry",
+			input: "file_format: 1.1.0\nversions:\n  1.0.0: {}\n",
+		},
+		{
+			name:  "metric group without a metric name",
+			input: "groups:\n  - id: metric.nameless\n    type: metric\n    brief: No name.\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load([]byte(tc.input))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestLoadFileNotFound(t *testing.T) {
+	_, err := LoadFile("testdata/does-not-exist.yaml")
+	require.Error(t, err)
+}
+
+func TestRegistryDiff(t *testing.T) {
+	r := &Registry{Groups: []Group{
+		{Type: TypeMetric, MetricName: "kept_total", Brief: "Kept.", Instrument: "counter"},
+		{Type: TypeMetric, MetricName: "changed_total", Brief: "Changed.", Instrument: "counter"},
+	}}
+	unchanged := prometheus.DescInfo{
+		FQName: "kept_total", Help: "Kept.", Type: dto.MetricType_COUNTER,
+	}
+
+	t.Run("no difference", func(t *testing.T) {
+		require.Empty(t, r.Diff(map[string]prometheus.DescInfo{
+			"kept_total": unchanged,
+			"changed_total": {
+				FQName: "changed_total", Help: "Changed.", Type: dto.MetricType_COUNTER,
+			},
+		}))
+	})
+
+	t.Run("reports only what differs", func(t *testing.T) {
+		diff := r.Diff(map[string]prometheus.DescInfo{
+			"kept_total": unchanged,
+			"changed_total": {
+				FQName: "changed_total", Help: "Changed.", Type: dto.MetricType_GAUGE,
+			},
+		})
+		require.Contains(t, diff, "changed_total")
+		require.Contains(t, diff, "GAUGE")
+		require.NotContains(t, diff, "kept_total")
+	})
+
+	t.Run("metric missing from the code", func(t *testing.T) {
+		diff := r.Diff(map[string]prometheus.DescInfo{"kept_total": unchanged})
+		require.Contains(t, diff, "changed_total")
+		require.NotContains(t, diff, "kept_total")
+	})
+
+	t.Run("metric absent from the registry", func(t *testing.T) {
+		declared := map[string]prometheus.DescInfo{
+			"kept_total":    unchanged,
+			"changed_total": {FQName: "changed_total", Help: "Changed.", Type: dto.MetricType_COUNTER},
+			"undeclared_total": {
+				FQName: "undeclared_total", Type: dto.MetricType_COUNTER,
+			},
+		}
+		diff := r.Diff(declared)
+		require.Contains(t, diff, "undeclared_total")
+		require.NotContains(t, diff, "kept_total")
+	})
+
+	t.Run("label order does not matter", func(t *testing.T) {
+		withLabels := &Registry{Groups: []Group{{
+			Type: TypeMetric, MetricName: "labelled", Instrument: "gauge",
+			Attributes: []Attribute{{Ref: "b"}, {Ref: "a"}},
+		}}}
+		require.Empty(t, withLabels.Diff(map[string]prometheus.DescInfo{
+			"labelled": {
+				FQName: "labelled", Type: dto.MetricType_GAUGE,
+				VariableLabels: []string{"a", "b"},
+			},
+		}))
+	})
+}


### PR DESCRIPTION
> **Do not merge.** This is a proof of concept for the contract testing part of [PROM-86](https://github.com/prometheus/proposals/pull/86), opened for discussion. `go.mod` carries a `replace` pointing at prometheus/client_golang#2094, so CI will not build until that lands.

## What

A registry declares the metrics a package exposes. A test checks that the code declares exactly that.

- `semconv/registry.yaml` declares the eight `notifier` metrics.
- `semconv/` reads a resolved registry and converts it into the shape `client_golang` reports.
- `notifier/semconv_contract_test.go` compares the two. 44 lines.
- `semconv/README.md` documents the Prometheus specific fields: `histogram_type`, `only_opts`, the bucket fields, and how attributes map to labels.

## What it catches

I introduced each of these deliberately. The test failed every time.

| Change | Caught |
| --- | --- |
| metric renamed in code | yes |
| metric renamed in registry | yes |
| label added | yes |
| label removed | yes |
| label renamed | yes |
| counter changed to gauge | yes |
| help string changed | yes |
| unit mismatch | yes |

I made the type change on `prometheus_notifications_dropped_total`, one of the six metrics that never emits, so no scrape-based check could have caught it. A gauge becoming a counter is the change raised in prometheus/client_golang#2004, from FluentBit v4 to v5.