### PR TITLE
discovery/aws: reject non-positive request_concurrency

### DIFF
--- a/discovery/aws/aws_test.go
+++ b/discovery/aws/aws_test.go
@@ -543,6 +543,109 @@ func TestAWSSDConfigUnmarshalYAML_NoRegionResolution(t *testing.T) {
 	}
 }
 
+// TestRequestConcurrencyUnmarshalYAML checks that request_concurrency is
+// rejected unless it is positive. A zero value makes errgroup.SetLimit block
+// Go() forever on an unbuffered channel, which hangs the refresh regardless of
+// the context deadline, and a negative one silently means "no limit at all".
+func TestRequestConcurrencyUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	// Every AWS SD config that exposes request_concurrency, along with the
+	// default it falls back to when the field is omitted.
+	configs := []struct {
+		name               string
+		defaultConcurrency int
+		parse              func(string) (int, error)
+	}{
+		{
+			name:               "ecs_sd",
+			defaultConcurrency: DefaultECSSDConfig.RequestConcurrency,
+			parse: func(s string) (int, error) {
+				var cfg ECSSDConfig
+				err := yaml.Unmarshal([]byte(s), &cfg)
+				return cfg.RequestConcurrency, err
+			},
+		},
+		{
+			name:               "elasticache_sd",
+			defaultConcurrency: DefaultElasticacheSDConfig.RequestConcurrency,
+			parse: func(s string) (int, error) {
+				var cfg ElasticacheSDConfig
+				err := yaml.Unmarshal([]byte(s), &cfg)
+				return cfg.RequestConcurrency, err
+			},
+		},
+		{
+			name:               "msk_sd",
+			defaultConcurrency: DefaultMSKSDConfig.RequestConcurrency,
+			parse: func(s string) (int, error) {
+				var cfg MSKSDConfig
+				err := yaml.Unmarshal([]byte(s), &cfg)
+				return cfg.RequestConcurrency, err
+			},
+		},
+		{
+			name:               "rds_sd",
+			defaultConcurrency: DefaultRDSSDConfig.RequestConcurrency,
+			parse: func(s string) (int, error) {
+				var cfg RDSSDConfig
+				err := yaml.Unmarshal([]byte(s), &cfg)
+				return cfg.RequestConcurrency, err
+			},
+		},
+	}
+
+	cases := []struct {
+		name        string
+		yaml        string
+		expectedErr string
+		expected    int
+		wantDefault bool
+	}{
+		{
+			name:        "Zero",
+			yaml:        "request_concurrency: 0",
+			expectedErr: "request_concurrency must be positive, got 0",
+		},
+		{
+			name:        "Negative",
+			yaml:        "request_concurrency: -1",
+			expectedErr: "request_concurrency must be positive, got -1",
+		},
+		{
+			name:     "Positive",
+			yaml:     "request_concurrency: 5",
+			expected: 5,
+		},
+		{
+			name:        "Omitted",
+			yaml:        "",
+			wantDefault: true,
+		},
+	}
+
+	for _, cfg := range configs {
+		for _, tt := range cases {
+			t.Run(cfg.name+"/"+tt.name, func(t *testing.T) {
+				t.Parallel()
+				got, err := cfg.parse("region: us-west-2\n" + tt.yaml + "\n")
+
+				if tt.expectedErr != "" {
+					require.EqualError(t, err, cfg.name+": "+tt.expectedErr)
+					return
+				}
+
+				require.NoError(t, err)
+				expected := tt.expected
+				if tt.wantDefault {
+					expected = cfg.defaultConcurrency
+				}
+				require.Equal(t, expected, got)
+			})
+		}
+	}
+}
+
 func TestSDConfigSetDirectory(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -145,6 +145,10 @@ func (c *ECSSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
+	if c.RequestConcurrency <= 0 {
+		return fmt.Errorf("ecs_sd: request_concurrency must be positive, got %d", c.RequestConcurrency)
+	}
+
 	return c.HTTPClientConfig.Validate()
 }
 

--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -233,6 +233,10 @@ func (c *ElasticacheSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
+	if c.RequestConcurrency <= 0 {
+		return fmt.Errorf("elasticache_sd: request_concurrency must be positive, got %d", c.RequestConcurrency)
+	}
+
 	return c.HTTPClientConfig.Validate()
 }
 

--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -145,6 +145,10 @@ func (c *MSKSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
+	if c.RequestConcurrency <= 0 {
+		return fmt.Errorf("msk_sd: request_concurrency must be positive, got %d", c.RequestConcurrency)
+	}
+
 	return c.HTTPClientConfig.Validate()
 }
 

--- a/discovery/aws/rds.go
+++ b/discovery/aws/rds.go
@@ -266,6 +266,10 @@ func (c *RDSSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
+	if c.RequestConcurrency <= 0 {
+		return fmt.Errorf("rds_sd: request_concurrency must be positive, got %d", c.RequestConcurrency)
+	}
+
 	return c.HTTPClientConfig.Validate()
 }
 


### PR DESCRIPTION
`request_concurrency` is passed straight to `errgroup.SetLimit`. A value of `0`
allocates an unbuffered semaphore channel, so the very first `Go()` blocks on a
channel send that nothing can ever complete:

```go
// golang.org/x/sync/errgroup
func (g *Group) SetLimit(n int) {
    if n < 0 { g.sem = nil; return }
    g.sem = make(chan token, n)
}

func (g *Group) Go(f func() error) {
    if g.sem != nil { g.sem <- token{} }   // no select on ctx
    ...
}
```

The send does not select on the context, so the refresh outlives its deadline
and the discovery neither returns nor reports a failure. With
`request_concurrency: 0` in an `ecs_sd_configs` entry, `describeClusters` is
still blocked 3s after start against a 2s context deadline:

```
Goroutine 53 in state chan send:
  golang.org/x/sync/errgroup.(*Group).Go
  aws.(*ECSDiscovery).describeClusters  ecs.go:368
```

A negative value takes the other branch and removes the limit entirely, which
silently contradicts what the user asked for.

Neither case was rejected at parse time. This validates the field in the four
SD configs that expose it: `ecs`, `elasticache`, `msk` and `rds`.

Note that the field is only settable through the dedicated `ecs_sd_configs`,
`elasticache_sd_configs`, `msk_sd_configs` and `rds_sd_configs` sections. The
unified `aws_sd_config` has no `request_concurrency` field, so the value never
reaches `SetLimit` through that path.

```release-notes
[BUGFIX] AWS SD: Reject non-positive `request_concurrency` instead of hanging service discovery indefinitely.
```
