### PR TITLE
fix(promql): handle round() with to_nearest 0 or negative

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1163,6 +1163,12 @@ func funcRound(vectorVals []Vector, _ Matrix, args parser.Expressions, enh *Eval
 	if len(args) >= 2 {
 		toNearest = vectorVals[1][0].F
 	}
+	if toNearest == 0 {
+		return vectorVals[0], nil
+	}
+	if toNearest < 0 {
+		toNearest = -toNearest
+	}
 	// Invert as it seems to cause fewer floating point accuracy issues.
 	toNearestInverse := 1.0 / toNearest
 	return simpleFloatFunc(vectorVals, enh, func(f float64) float64 {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

No issue is linked. Related discussion: #19198.

`round()` returns NaN when `to_nearest` is 0, because `1.0 / toNearest` in `promql/functions.go:1167` is Inf. For a negative `to_nearest` the inverse is negative, so `Floor` operates on the wrong sign and the result rounds the wrong way.

This change returns the input vector unchanged when `toNearest == 0`, and negates a negative `toNearest` before inverting. Six lines in one file.

Checks:

- `round(2.7, 0)` was NaN, now 2.7. `round(1.5, -1)` was 1, now 2, matching the positive case.
- promql tests pass before (7.27s, bug present) and after (7.43s), no regressions.
- gofmt clean.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] promql: Fix round() to return input unchanged for to_nearest 0 and to handle negative to_nearest correctly.
```
