### PR TITLE
mixin: add native histogram variants to remote write latency panel

### DIFF
--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -786,6 +786,24 @@ local row = panel.row;
           + prometheus.withFormat('time_series')
           + prometheus.withIntervalFactor(2)
           + prometheus.withLegendFormat('{{%(clusterLabel)s}}:{{instance}} {{remote_name}}:{{url}} p99' % $._config),
+          prometheus.new(
+            '$datasource',
+            |||
+              histogram_quantile(0.95, sum by (%(clusterLabel)s, instance, remote_name, url) (rate(prometheus_remote_storage_sent_batch_duration_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}[5m])))
+            ||| % $._config
+          )
+          + prometheus.withFormat('time_series')
+          + prometheus.withIntervalFactor(2)
+          + prometheus.withLegendFormat('{{%(clusterLabel)s}}:{{instance}} {{remote_name}}:{{url}} p95' % $._config),
+          prometheus.new(
+            '$datasource',
+            |||
+              histogram_quantile(0.99, sum by (%(clusterLabel)s, instance, remote_name, url) (rate(prometheus_remote_storage_sent_batch_duration_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}[5m])))
+            ||| % $._config
+          )
+          + prometheus.withFormat('time_series')
+          + prometheus.withIntervalFactor(2)
+          + prometheus.withLegendFormat('{{%(clusterLabel)s}}:{{instance}} {{remote_name}}:{{url}} p99' % $._config),
         ]);
 
       dashboard.new('%(prefix)sRemote Write' % $._config.grafanaPrometheus)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Fixes #19520

#### What does this PR do:

Follow-up to #19500. The `Send Batch Duration (p95 / p99)` panel in the
`prometheus-remote-write` dashboard queries
`prometheus_remote_storage_sent_batch_duration_seconds_bucket`, which
returns no series when the metric is scraped as a native histogram
(e.g. via NHCB), since there is no `_bucket` suffix in that case.

This adds the native histogram variants of the same p95/p99 queries as
two additional panel targets — metric name without the `_bucket` suffix
and no `le` label in the aggregation — as suggested in the issue. The
classic and native variants are mutually exclusive in practice, so the
panel works either way the histogram is scraped without duplicate
series.

#### Verification:

- `jsonnetfmt` check on the modified file (no formatting changes needed)
- `jb install` + `jsonnet -J vendor -m dashboards_out dashboards.jsonnet`
  renders successfully and the remote-write dashboard contains all four
  targets
