### PR TITLE
Re-use a scratch buffer in matrixIterSlice

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1189,6 +1189,11 @@ type evaluator struct {
 	enableTypeAndUnitLabels  bool
 	useStartTimestamps       bool
 	querier                  storage.Querier
+
+	// hpointScratch stores *FloatHistogram pointers that matrixIterSlice
+	// removes from the histogram slice. It prevents a heap allocation
+	// on each step of a range query.
+	hpointScratch []*histogram.FloatHistogram
 }
 
 // errorf causes a panic with the input formatted into an error.
@@ -3004,13 +3009,27 @@ func (ev *evaluator) matrixIterSlice(
 		for drop = 0; histograms[drop].T <= mint; drop++ {
 		}
 		droppedSize := totalHPointSize(histograms[:drop])
-		// Rotate the buffer around the drop index so that points before mint can be
-		// reused to store new histograms.
-		tail := make([]HPoint, drop)
-		copy(tail, histograms[:drop])
+		// Save the *FloatHistogram pointers from the dropped elements.
+		// matrixIterSlice reuses these pointers for new histograms after
+		// the shift. This prevents a heap allocation of a temporary
+		// []HPoint slice on each step.
+		if cap(ev.hpointScratch) < drop {
+			ev.hpointScratch = make([]*histogram.FloatHistogram, drop)
+		} else {
+			ev.hpointScratch = ev.hpointScratch[:drop]
+		}
+		for i := 0; i < drop; i++ {
+			ev.hpointScratch[i] = histograms[i].H
+		}
 		copy(histograms, histograms[drop:])
-		copy(histograms[len(histograms)-drop:], tail)
-		histograms = histograms[:len(histograms)-drop]
+		// Put the saved pointers into the tail of the slice.
+		// AtFloatHistogram reuses these pointers for new histograms.
+		// Do this before the truncation so the indices stay valid.
+		n := len(histograms)
+		for i := 0; i < drop; i++ {
+			histograms[n-drop+i].H = ev.hpointScratch[i]
+		}
+		histograms = histograms[:n-drop]
 		ev.currentSamples -= droppedSize
 		// Only append points with timestamps after the last timestamp we have.
 		mintHistograms = histograms[len(histograms)-1].T


### PR DESCRIPTION
At the moment matrixIterSlice allocates a slice and then copies onto that slice:

```
tail := make([]HPoint, drop)
copy(tail, histograms[:drop])
copy(histograms, histograms[drop:])
```

This was added in 1f69dcfa6 to fix corruption when reusing float histograms. The problem is that the last copy shows up in my cpu profiles and contribute a lot to cpu usage. We can avoid allocation on every step and multiple copy() calls by using a scratch buffer bounded to the evaluator. And we only need to worry about *FloatHistogram on each histogram, rather then making a full copy of the entire []HPoint slice.

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
cpu: 13th Gen Intel(R) Core(TM) i7-13800H
                                                                            │ before.txt  │             after.txt              │
                                                                            │   sec/op    │   sec/op     vs base               │
NativeHistograms/sum-20                                                       600.3m ± 6%   563.3m ± 4%  -6.17% (p=0.007 n=10)
NativeHistograms/sum_rate_with_short_rate_interval-20                         765.8m ± 5%   760.0m ± 6%       ~ (p=0.190 n=10)
NativeHistograms/sum_rate_with_long_rate_interval-20                           1.102 ± 1%    1.102 ± 1%       ~ (p=0.684 n=10)
NativeHistograms/histogram_count_with_short_rate_interval-20                  523.4m ± 3%   522.8m ± 2%       ~ (p=0.971 n=10)
NativeHistograms/histogram_count_with_long_rate_interval-20                   806.1m ± 4%   802.2m ± 3%       ~ (p=0.796 n=10)
NativeHistograms/two-legged_histogram_count/sum_with_short_rate_interval-20    1.090 ± 3%    1.095 ± 3%       ~ (p=0.436 n=10)
NativeHistograms/two-legged_histogram_count/sum_with_long_rate_interval-20     1.633 ± 1%    1.633 ± 1%       ~ (p=0.739 n=10)
geomean                                                                       871.0m        862.0m       -1.03%

                                                                            │  before.txt   │              after.txt               │
                                                                            │     B/op      │     B/op       vs base               │
NativeHistograms/sum-20                                                       470.6Mi ±  0%   470.5Mi ±  0%       ~ (p=0.579 n=10)
NativeHistograms/sum_rate_with_short_rate_interval-20                         181.0Mi ±  0%   181.0Mi ±  0%       ~ (p=0.670 n=10)
NativeHistograms/sum_rate_with_long_rate_interval-20                          181.0Mi ±  0%   181.0Mi ±  0%  +0.00% (p=0.006 n=10)
NativeHistograms/histogram_count_with_short_rate_interval-20                  115.9Mi ±  0%   115.9Mi ±  0%       ~ (p=0.071 n=10)
NativeHistograms/histogram_count_with_long_rate_interval-20                   129.5Mi ± 10%   129.5Mi ± 10%       ~ (p=0.725 n=10)
NativeHistograms/two-legged_histogram_count/sum_with_short_rate_interval-20   259.0Mi ±  0%   259.0Mi ±  0%  +0.00% (p=0.024 n=10)
NativeHistograms/two-legged_histogram_count/sum_with_long_rate_interval-20    259.0Mi ±  0%   259.0Mi ±  0%       ~ (p=0.566 n=10)
geomean                                                                       205.6Mi         205.6Mi        -0.00%

                                                                            │ before.txt  │             after.txt              │
                                                                            │  allocs/op  │  allocs/op   vs base               │
NativeHistograms/sum-20                                                       7.975M ± 0%   7.975M ± 0%       ~ (p=0.516 n=10)
NativeHistograms/sum_rate_with_short_rate_interval-20                         3.683M ± 0%   3.683M ± 0%       ~ (p=0.277 n=10)
NativeHistograms/sum_rate_with_long_rate_interval-20                          3.684M ± 0%   3.684M ± 0%  +0.00% (p=0.006 n=10)
NativeHistograms/histogram_count_with_short_rate_interval-20                  819.7k ± 0%   819.7k ± 0%  +0.00% (p=0.020 n=10)
NativeHistograms/histogram_count_with_long_rate_interval-20                   853.4k ± 4%   853.4k ± 4%       ~ (p=0.424 n=10)
NativeHistograms/two-legged_histogram_count/sum_with_short_rate_interval-20   1.707M ± 0%   1.707M ± 0%  +0.00% (p=0.004 n=10)
NativeHistograms/two-legged_histogram_count/sum_with_long_rate_interval-20    1.707M ± 0%   1.707M ± 0%       ~ (p=0.399 n=10)
geomean                                                                       2.162M        2.162M       +0.00%
```

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes

```
