### PR TITLE
prompb: fix write v2 comments about exemplars without samples

### DIFF
--- a/prompb/io/prometheus/write/v2/types.pb.go
+++ b/prompb/io/prometheus/write/v2/types.pb.go
@@ -106,7 +106,7 @@ func (Histogram_ResetHint) EnumDescriptor() ([]byte, []int) {
 // The canonical Content-Type request header value for this message is
 // "application/x-protobuf;proto=io.prometheus.write.v2.Request"
 //
-// Version: v2.0-rc.4
+// Version: v2.0-rc.5
 //
 // NOTE: gogoproto options might change in future for this file, they
 // are not part of the spec proto (they only modify the generated Go code, not
@@ -185,14 +185,15 @@ type TimeSeries struct {
 	// Requests with the same labels e.g. for different exemplars, metadata
 	// or start timestamp.
 	LabelsRefs []uint32 `protobuf:"varint,1,rep,packed,name=labels_refs,json=labelsRefs,proto3" json:"labels_refs,omitempty"`
-	// Timeseries messages can either specify samples or (native) histogram samples
-	// (histogram field), but not both. For a typical sender (real-time metric
-	// streaming), in healthy cases, there will be only one sample or histogram.
+	// TimeSeries messages must specify at least one float sample, native histogram sample
+	// or exemplar. Samples and histograms must not be specified at the same time.
+	// Exemplars may be specified without samples or histograms. For a typical sender
+	// (real-time metric streaming), in healthy cases, there will be only one sample or histogram.
 	//
 	// Samples and histograms are sorted by timestamp (older first).
 	Samples    []Sample    `protobuf:"bytes,2,rep,name=samples,proto3" json:"samples"`
 	Histograms []Histogram `protobuf:"bytes,3,rep,name=histograms,proto3" json:"histograms"`
-	// exemplars represents an optional set of exemplars attached to this series' samples.
+	// exemplars represents an optional set of exemplars for this series.
 	Exemplars []Exemplar `protobuf:"bytes,4,rep,name=exemplars,proto3" json:"exemplars"`
 	// metadata represents the metadata associated with the given series' samples.
 	Metadata             Metadata `protobuf:"bytes,5,opt,name=metadata,proto3" json:"metadata"`
@@ -269,7 +270,7 @@ func (m *TimeSeries) GetMetadata() Metadata {
 	return Metadata{}
 }
 
-// Exemplar is an additional information attached to some series' samples.
+// Exemplar contains additional information associated with a series.
 // It is typically used to attach an example trace or request ID associated with
 // the metric changes.
 type Exemplar struct {

--- a/prompb/io/prometheus/write/v2/types.proto
+++ b/prompb/io/prometheus/write/v2/types.proto
@@ -28,7 +28,7 @@ import "gogoproto/gogo.proto";
 // The canonical Content-Type request header value for this message is
 // "application/x-protobuf;proto=io.prometheus.write.v2.Request"
 //
-// Version: v2.0-rc.4
+// Version: v2.0-rc.5
 //
 // NOTE: gogoproto options might change in future for this file, they
 // are not part of the spec proto (they only modify the generated Go code, not
@@ -65,15 +65,16 @@ message TimeSeries {
   // or start timestamp.
   repeated uint32 labels_refs = 1;
 
-  // Timeseries messages can either specify samples or (native) histogram samples
-  // (histogram field), but not both. For a typical sender (real-time metric
-  // streaming), in healthy cases, there will be only one sample or histogram.
+  // TimeSeries messages must specify at least one float sample, native histogram sample
+  // or exemplar. Samples and histograms must not be specified at the same time.
+  // Exemplars may be specified without samples or histograms. For a typical sender
+  // (real-time metric streaming), in healthy cases, there will be only one sample or histogram.
   //
   // Samples and histograms are sorted by timestamp (older first).
   repeated Sample samples = 2 [(gogoproto.nullable) = false];
   repeated Histogram histograms = 3 [(gogoproto.nullable) = false];
 
-  // exemplars represents an optional set of exemplars attached to this series' samples.
+  // exemplars represents an optional set of exemplars for this series.
   repeated Exemplar exemplars = 4 [(gogoproto.nullable) = false];
 
   // metadata represents the metadata associated with the given series' samples.
@@ -84,7 +85,7 @@ message TimeSeries {
   reserved 6;
 }
 
-// Exemplar is an additional information attached to some series' samples.
+// Exemplar contains additional information associated with a series.
 // It is typically used to attach an example trace or request ID associated with
 // the metric changes.
 message Exemplar {


### PR DESCRIPTION
The comments on `io.prometheus.write.v2.TimeSeries` say that a message specifies samples or histograms, and that its exemplars belong to the series' samples. The sender in this repository does not do that.

`populateV2TimeSeries` builds one output `TimeSeries` per queue item, and each item carries one kind of data. For a `tExemplar` item it clears `Samples`, clears `Histograms` when native histograms are on, fills in the series metadata, and then appends the exemplar:

```go
pendingData[nPending].Samples = pendingData[nPending].Samples[:0]
switch {
...
case d.metadata != nil:
	pendingData[nPending].Metadata.Type = writev2.FromMetadataType(d.metadata.Type)
	...
}
...
if sendNativeHistograms {
	pendingData[nPending].Histograms = pendingData[nPending].Histograms[:0]
}
...
case tExemplar:
	pendingData[nPending].Exemplars = append(pendingData[nPending].Exemplars, writev2.Exemplar{...})
```

So an exemplar leaves the sender in a `TimeSeries` that has labels, metadata and one exemplar, with no sample and no histogram. #17857 goes through the history of that in detail.

Three comments change to describe what the code does:

* the payload rule names samples, histograms and exemplars, and says exemplars may travel without the other two.
* `exemplars` belongs to the series rather than to the series' samples.
* the `Exemplar` message says the same.

No field, option or wire format changes.

The specification side is prometheus/docs#3085, which stops requiring a sample or a histogram in every `TimeSeries`. @krajorama asked there whether the copy of this file inside the specification document would follow the real one, so the two are changed together.

### On the generated file

`types.pb.go` carries the same three comments. Running `scripts/genproto.sh` here also rewrote the embedded file descriptors in four files, including ones whose `.proto` I never touched, so that part is a toolchain difference on my machine rather than a result of this change.

To be sure which was which, I generated once with the change and once without. The two outputs differ only in the three comment blocks and the descriptor bytes are identical between them, so the descriptor does not encode comments. This commit carries only the three comment lines, and a regeneration in CI should land on the same bytes.

### Note on #18014

That one has been open since February taking the opposite route, dropping exemplars that arrive without a matching sample. @AftAb-25 wrote it against the specification as it read at the time. bwplotka's 26 August comment on #17857 says the plan now is to allow the current shape and adjust the specification instead, so the ground it was written on has moved.

### Version

The source comment moves to `v2.0-rc.5` here, matching the document bump in prometheus/docs#3080.

#### Which issue(s) does the PR fix:

Part of #17857.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```



