### PR TITLE
promparse: add missing EOF check

### DIFF
--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -138,6 +138,10 @@ func (l *promlexer) next() byte {
 	// they are allowed, consume them here immediately.
 	for l.b[l.i] == 0 && (l.state == sLValue || l.state == sMeta2 || l.state == sComment) {
 		l.i++
+		if l.i >= len(l.b) {
+			l.err = io.EOF
+			return byte(tEOF)
+		}
 	}
 	return l.b[l.i]
 }


### PR DESCRIPTION
OM parser checks if we're at the end of the input, but promparse doesn't. Add missing check so we never try to go past EOF.

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/textparse
cpu: 13th Gen Intel(R) Core(TM) i7-13800H
                                                  │  before.txt  │              after.txt               │
                                                  │    sec/op    │    sec/op     vs base                │
ParsePromText/parser=promtext-4                     1.124m ±  9%   1.098m ±  6%        ~ (p=0.393 n=10)
ParsePromText/parser=omtext-4                       67.14m ±  0%   67.03m ±  0%        ~ (p=0.353 n=10)
ParsePromText/parser=expfmt-promtext-4              4.760m ± 12%   5.291m ±  8%  +11.17% (p=0.005 n=10)
ParsePromText_NoMeta/parser=promtext-4              941.4µ ±  3%   890.6µ ± 11%        ~ (p=0.105 n=10)
ParsePromText_NoMeta/parser=expfmt-promtext-4       3.358m ± 14%   3.461m ± 12%        ~ (p=0.739 n=10)
ParseOMText-4                                       46.68µ ±  5%   45.28µ ±  3%        ~ (p=0.190 n=10)
ParsePromProto-4                                    38.48µ ± 19%   43.09µ ± 12%        ~ (p=0.165 n=10)
ParseOpenMetricsNHCB/parser=omtext-4                256.1µ ±  1%   255.3µ ±  1%        ~ (p=0.315 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-4      43.79µ ±  9%   45.65µ ±  7%        ~ (p=0.481 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-4   67.46µ ±  5%   67.91µ ±  3%        ~ (p=0.353 n=10)
geomean                                             523.4µ         533.1µ         +1.85%

                                                  │  before.txt   │               after.txt               │
                                                  │      B/s      │      B/s       vs base                │
ParsePromText/parser=promtext-4                     161.4Mi ±  8%   165.2Mi ±  6%        ~ (p=0.393 n=10)
ParsePromText/parser=omtext-4                       2.699Mi ±  0%   2.708Mi ±  1%        ~ (p=0.256 n=10)
ParsePromText/parser=expfmt-promtext-4              38.11Mi ± 11%   34.28Mi ±  7%  -10.04% (p=0.005 n=10)
ParsePromText_NoMeta/parser=promtext-4              150.1Mi ±  3%   158.6Mi ± 10%        ~ (p=0.105 n=10)
ParsePromText_NoMeta/parser=expfmt-promtext-4       42.07Mi ± 13%   40.83Mi ± 13%        ~ (p=0.739 n=10)
ParseOMText-4                                       91.48Mi ±  5%   94.29Mi ±  3%        ~ (p=0.184 n=10)
ParsePromProto-4                                    96.04Mi ± 16%   85.80Mi ± 14%        ~ (p=0.165 n=10)
ParseOpenMetricsNHCB/parser=omtext-4                15.61Mi ±  1%   15.65Mi ±  1%        ~ (p=0.305 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-4      91.28Mi ±  8%   87.56Mi ±  8%        ~ (p=0.481 n=10)
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-4   59.25Mi ±  5%   58.86Mi ±  3%        ~ (p=0.325 n=10)
geomean                                             48.87Mi         47.99Mi         -1.80%

                                                  │  before.txt  │               after.txt               │
                                                  │     B/op     │     B/op      vs base                 │
ParsePromText/parser=promtext-4                     310.8Ki ± 0%   310.8Ki ± 0%       ~ (p=0.109 n=10)
ParsePromText/parser=omtext-4                       580.0Ki ± 0%   580.0Ki ± 0%       ~ (p=0.381 n=10)
ParsePromText/parser=expfmt-promtext-4              2.342Mi ± 0%   2.342Mi ± 0%       ~ (p=0.324 n=10)
ParsePromText_NoMeta/parser=promtext-4              303.8Ki ± 0%   303.8Ki ± 0%       ~ (p=1.000 n=10) ¹
ParsePromText_NoMeta/parser=expfmt-promtext-4       1.705Mi ± 0%   1.705Mi ± 0%       ~ (p=0.180 n=10)
ParseOMText-4                                       10.88Ki ± 0%   10.88Ki ± 0%       ~ (p=1.000 n=10) ¹
ParsePromProto-4                                    19.63Ki ± 0%   19.63Ki ± 0%       ~ (p=1.000 n=10) ¹
ParseOpenMetricsNHCB/parser=omtext-4                22.40Ki ± 0%   22.40Ki ± 0%       ~ (p=1.000 n=10) ¹
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-4      13.99Ki ± 0%   13.99Ki ± 0%       ~ (p=1.000 n=10) ¹
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-4   14.89Ki ± 0%   14.89Ki ± 0%       ~ (p=0.474 n=10)
geomean                                             108.6Ki        108.6Ki       -0.00%
¹ all samples are equal

                                                  │ before.txt  │              after.txt               │
                                                  │  allocs/op  │  allocs/op   vs base                 │
ParsePromText/parser=promtext-4                     4.655k ± 0%   4.655k ± 0%       ~ (p=1.000 n=10) ¹
ParsePromText/parser=omtext-4                       10.82k ± 0%   10.82k ± 0%       ~ (p=1.000 n=10)
ParsePromText/parser=expfmt-promtext-4              54.83k ± 0%   54.83k ± 0%       ~ (p=1.000 n=10) ¹
ParsePromText_NoMeta/parser=promtext-4              3.722k ± 0%   3.722k ± 0%       ~ (p=1.000 n=10) ¹
ParsePromText_NoMeta/parser=expfmt-promtext-4       45.71k ± 0%   45.71k ± 0%       ~ (p=1.000 n=10) ¹
ParseOMText-4                                        231.0 ± 0%    231.0 ± 0%       ~ (p=1.000 n=10) ¹
ParsePromProto-4                                     383.0 ± 0%    383.0 ± 0%       ~ (p=1.000 n=10) ¹
ParseOpenMetricsNHCB/parser=omtext-4                 375.0 ± 0%    375.0 ± 0%       ~ (p=1.000 n=10) ¹
ParseOpenMetricsNHCB/parser=omtext_with_nhcb-4       163.0 ± 0%    163.0 ± 0%       ~ (p=1.000 n=10) ¹
ParseOpenMetricsNHCB/parser=omtext_with_nhcb_st-4    181.0 ± 0%    181.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                             1.846k        1.846k       +0.00%
¹ all samples are equal
```

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] promparse: add missing EOF check
```
