### PR TITLE
ui: preserve series legend isolation across chart rebuilds

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/Graph.tsx
+++ b/web/ui/mantine-ui/src/pages/query/Graph.tsx
@@ -221,6 +221,7 @@ const Graph: FC<GraphProps> = ({
         />
         <UPlotChart
           data={dataAndRange.data.data.result}
+          expr={effectiveExpr}
           range={dataAndRange.range}
           width={width}
           showExemplars={showExemplars}

--- a/web/ui/mantine-ui/src/pages/query/UPlotChart.tsx
+++ b/web/ui/mantine-ui/src/pages/query/UPlotChart.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import { RangeSamples } from "../../api/responseTypes/query";
 import classes from "./Graph.module.css";
 import { GraphDisplayMode } from "../../state/queryPageSlice";
@@ -20,6 +20,7 @@ export interface UPlotChartRange {
 
 export interface UPlotChartProps {
   data: RangeSamples[];
+  expr: string;
   range: UPlotChartRange;
   width: number;
   showExemplars: boolean;
@@ -32,6 +33,7 @@ export interface UPlotChartProps {
 // uPlot format and sets up the uPlot options object depending on the UI settings.
 const UPlotChart: FC<UPlotChartProps> = ({
   data,
+  expr,
   range: { startTime, endTime, resolution },
   width,
   displayMode,
@@ -45,10 +47,22 @@ const UPlotChart: FC<UPlotChartProps> = ({
   const { useLocalTime } = useSettings();
   const theme = useComputedColorScheme();
 
+  // Per-series legend isolation state, keyed by series label so it survives
+  // even if series order shifts between requests. Cleared on expr changes
+  // below, kept across everything else (theme, resize, re-executing the same
+  // query, ...) since none of those should feel like a "new" chart.
+  const seriesVisibility = useRef<Map<string, boolean>>(new Map());
+  const prevExpr = useRef<string | null>(null);
+
   useEffect(() => {
     if (width === 0) {
       return;
     }
+
+    if (prevExpr.current !== expr) {
+      seriesVisibility.current.clear();
+    }
+    prevExpr.current = expr;
 
     const seriesData: uPlot.AlignedData = getUPlotData(
       data,
@@ -64,7 +78,8 @@ const UPlotChart: FC<UPlotChartProps> = ({
       useLocalTime,
       yAxisMin,
       theme === "light",
-      onSelectRange
+      onSelectRange,
+      seriesVisibility.current
     );
 
     if (displayMode === GraphDisplayMode.Stacked) {
@@ -77,6 +92,7 @@ const UPlotChart: FC<UPlotChartProps> = ({
   }, [
     width,
     data,
+    expr,
     displayMode,
     startTime,
     endTime,

--- a/web/ui/mantine-ui/src/pages/query/uPlotChartHelpers.test.ts
+++ b/web/ui/mantine-ui/src/pages/query/uPlotChartHelpers.test.ts
@@ -1,0 +1,51 @@
+import uPlot from "uplot";
+import { applySeriesVisibility } from "./uPlotChartHelpers";
+
+describe("applySeriesVisibility", () => {
+  const series = (label: string): uPlot.Series => ({ label, show: true });
+
+  const cases: {
+    name: string;
+    series: uPlot.Series[];
+    saved: Map<string, boolean>;
+    expectedShow: (boolean | undefined)[];
+  }[] = [
+    {
+      name: "leaves series untouched when nothing was saved for them",
+      series: [{}, series("up"), series("down")],
+      saved: new Map(),
+      expectedShow: [undefined, true, true],
+    },
+    {
+      name: "restores a hidden series from the saved map",
+      series: [{}, series("up"), series("down")],
+      saved: new Map([["down", false]]),
+      expectedShow: [undefined, true, false],
+    },
+    {
+      name: "ignores saved labels that no longer have a matching series",
+      series: [{}, series("up")],
+      saved: new Map([["down", false]]),
+      expectedShow: [undefined, true],
+    },
+    {
+      name: "skips the leading x-axis placeholder, which has no label",
+      series: [{}, series("up")],
+      saved: new Map([["up", false]]),
+      expectedShow: [undefined, false],
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      const result = applySeriesVisibility(c.series, c.saved);
+      expect(result.map((s) => s.show)).toEqual(c.expectedShow);
+    });
+  }
+
+  test("does not mutate the input series", () => {
+    const input = [series("up")];
+    applySeriesVisibility(input, new Map([["up", false]]));
+    expect(input[0].show).toBe(true);
+  });
+});

--- a/web/ui/mantine-ui/src/pages/query/uPlotChartHelpers.ts
+++ b/web/ui/mantine-ui/src/pages/query/uPlotChartHelpers.ts
@@ -307,6 +307,20 @@ const onlyDrawPointsForDisconnectedSamplesFilter = (
   return filtered.length ? filtered : null;
 };
 
+// uPlot only keeps legend show/hide state on the live chart instance, so it's
+// lost every time we swap in a new options object (theme, resize, a new
+// dataset, ...). This re-applies whatever was saved for a label, so callers
+// can carry it across rebuilds themselves.
+export const applySeriesVisibility = (
+  series: uPlot.Series[],
+  saved: Map<string, boolean>,
+): uPlot.Series[] =>
+  series.map((s) =>
+    typeof s.label === "string" && saved.has(s.label)
+      ? { ...s, show: saved.get(s.label) }
+      : s,
+  );
+
 export const getUPlotOptions = (
   data: AlignedData,
   width: number,
@@ -315,6 +329,7 @@ export const getUPlotOptions = (
   yAxisMin: number | null,
   light: boolean,
   onSelectRange: (_start: number, _end: number) => void,
+  seriesVisibility: Map<string, boolean>,
 ): uPlot.Options => ({
   width: width - 30,
   height: 550,
@@ -426,21 +441,24 @@ export const getUPlotOptions = (
       size: autoPadLeft,
     },
   ],
-  series: [
-    {},
-    ...result.map(
-      (r, idx): uPlot.Series => ({
-        points: {
-          filter: onlyDrawPointsForDisconnectedSamplesFilter,
-        },
-        label: formatSeries(r.metric),
-        width: 1.5,
-        // @ts-expect-error - uPlot doesn't have a field for labels, but we just attach some anyway.
-        labels: r.metric,
-        stroke: getSeriesColor(idx, light),
-      }),
-    ),
-  ],
+  series: applySeriesVisibility(
+    [
+      {},
+      ...result.map(
+        (r, idx): uPlot.Series => ({
+          points: {
+            filter: onlyDrawPointsForDisconnectedSamplesFilter,
+          },
+          label: formatSeries(r.metric),
+          width: 1.5,
+          // @ts-expect-error - uPlot doesn't have a field for labels, but we just attach some anyway.
+          labels: r.metric,
+          stroke: getSeriesColor(idx, light),
+        }),
+      ),
+    ],
+    seriesVisibility,
+  ),
   hooks: {
     setSelect: [
       (self: uPlot) => {
@@ -452,6 +470,20 @@ export const getUPlotOptions = (
         );
 
         onSelectRange(leftVal, rightVal);
+      },
+    ],
+    // Legend clicks call setSeries per affected series (once for a plain
+    // click's isolate, once for a ctrl/cmd click's toggle). Mirror whatever
+    // it lands on so a later rebuild can restore it.
+    setSeries: [
+      (u: uPlot, seriesIdx: number | null, opts: Series) => {
+        if (seriesIdx === null || opts.show === undefined) {
+          return;
+        }
+        const label = u.series[seriesIdx].label;
+        if (typeof label === "string") {
+          seriesVisibility.set(label, opts.show);
+        }
       },
     ],
   },

--- a/web/ui/mantine-ui/src/setupTests.ts
+++ b/web/ui/mantine-ui/src/setupTests.ts
@@ -1,5 +1,19 @@
 import "@testing-library/jest-dom";
 
+// uplot calls matchMedia on import; jsdom doesn't implement it
+if (typeof window.matchMedia !== "function") {
+  window.matchMedia = (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
 // Node.js v22+ pre-defines localStorage on globalThis as undefined (when
 // --localstorage-file is omitted), which prevents jsdom from installing its
 // Storage implementation. Provide an in-memory mock so module-level code that


### PR DESCRIPTION
Fixes #10970.

When you isolate a series in the graph legend (click, or ctrl/cmd-click to toggle), that selection gets dropped as soon as the chart rebuilds. Toggling local time is the reported case, but I found it also happens on theme switch, resize, and re-running the same query. The isolation state only lives on the uPlot instance, which gets thrown away and recreated whenever the options object changes, so every rebuild comes back with all series shown.

To fix it I keep a small map of per-series show-state, keyed by series label so it survives series reordering between requests, record legend clicks via uPlot's setSeries hook, and re-apply it when the options are rebuilt. I clear the map when the query expression changes, since a genuinely new query should start fresh, but keep it across theme, resize, local-time, and refreshes of the same query.

Per @juliusv's note on the issue, I kept this localized in the uPlot layer rather than lifting it into panel or URL state.

I also added a unit test for the visibility-merge helper.

```release-notes
[BUGFIX] UI: Preserve series isolation in the graph legend when the chart is rebuilt (e.g. toggling local time).
```
