### PR TITLE
model/relabel: skip invalid labelmap targets

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -345,7 +345,9 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 		lb.Range(func(l labels.Label) {
 			if cfg.Regex.MatchString(l.Name) {
 				res := cfg.Regex.ReplaceAllString(l.Name, cfg.Replacement)
-				lb.Set(res, l.Value)
+				if cfg.NameValidationScheme.IsValidLabelName(res) {
+					lb.Set(res, l.Value)
+				}
 			}
 		})
 	case LabelDrop:

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -861,6 +861,21 @@ func TestRelabelValidate(t *testing.T) {
 	}
 }
 
+func TestRelabelLabelMapSkipsInvalidGeneratedLabelNames(t *testing.T) {
+	input := labels.FromStrings("_0foo", "bar")
+	cfg := &Config{
+		Regex:                MustNewRegexp("_(.*)"),
+		Replacement:          "$1",
+		Action:               LabelMap,
+		NameValidationScheme: model.LegacyValidation,
+	}
+	require.NoError(t, cfg.Validate(model.LegacyValidation))
+
+	lb := labels.NewBuilder(input)
+	require.True(t, ProcessBuilder(lb, cfg))
+	testutil.RequireEqual(t, input, lb.Labels())
+}
+
 func TestTargetLabelLegacyValidity(t *testing.T) {
 	for _, test := range []struct {
 		str   string


### PR DESCRIPTION
### Problem
`labelmap` relabel rules can expand a valid legacy replacement template into an invalid label name at runtime. For example, mapping `_0foo` with regex `_(.*)` and replacement `$1` produces `0foo`, even though legacy validation rejects label names that start with a digit. `replace` already skips invalid expanded target labels, but `labelmap` did not.

### Reproducer
```go
input := labels.FromStrings("_0foo", "bar")
cfg := &Config{Regex: MustNewRegexp("_(.*)"), Replacement: "$1", Action: LabelMap, NameValidationScheme: model.LegacyValidation}
// before: {"0foo"="bar", _0foo="bar"}
// after:  {_0foo="bar"}
```

### Fix
Validate each generated `labelmap` destination label name against the configured validation scheme before setting it. This keeps the existing behavior for valid generated names and matches the runtime validation already used by `replace`.

### Testing
Added `TestRelabelLabelMapSkipsInvalidGeneratedLabelNames`.

- `go test ./model/relabel -run TestRelabelLabelMapSkipsInvalidGeneratedLabelNames -count=1`
- `go test ./model/relabel -count=1`
- `go vet ./model/relabel`
- `go build ./...`