### PR TITLE
tsdb: recover from checkpoint corruption without truncating valid WAL

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1215,6 +1215,15 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 				return nil, fmt.Errorf("repair corrupted WBL: %w", err)
 			}
 			db.logger.Info("Successfully repaired WBL")
+		} else if e, ok := errors.AsType[*errLoadCheckpoint](initErr); ok {
+			db.logger.Warn("Encountered checkpoint read error, deleting corrupted checkpoint and recovering remaining WAL", "err", initErr)
+			if err := os.RemoveAll(e.checkpointDir); err != nil {
+				return nil, fmt.Errorf("remove corrupted checkpoint: %w", err)
+			}
+			if err := db.head.Init(minValidTime); err != nil {
+				return nil, fmt.Errorf("replaying WAL after corrupted checkpoint removal: %w", err)
+			}
+			db.logger.Info("Successfully recovered from corrupted checkpoint")
 		} else {
 			db.logger.Warn("Encountered WAL read error, attempting repair", "err", initErr)
 			if err := wal.Repair(initErr); err != nil {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -341,6 +341,74 @@ func TestNoPanicAfterWALCorruption(t *testing.T) {
 	}
 }
 
+// TestCheckpointCorruptionRecovery ensures that corruption in a checkpoint directory
+// does not mistakenly truncate or corrupt the main WAL, and that remaining WAL samples
+// can still be replayed.
+// https://github.com/prometheus/prometheus/issues/7530
+func TestCheckpointCorruptionRecovery(t *testing.T) {
+	db := newTestDB(t, withOpts(&Options{WALSegmentSize: 32 * 1024}))
+
+	ctx := context.Background()
+	var maxt int64
+
+	// 1. Append samples and trigger a checkpoint.
+	for range 100 {
+		app := db.Appender(ctx)
+		_, err := app.Append(0, labels.FromStrings("foo", "bar"), maxt, 0)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		maxt++
+	}
+
+	// Create checkpoint.
+	_, err := wlog.Checkpoint(promslog.NewNopLogger(), db.Head().wal, 0, 1, func(chunks.HeadSeriesRef) bool {
+		return true
+	}, 0, false)
+	require.NoError(t, err)
+
+	// 2. Append samples that go into WAL segments after the checkpoint.
+	for range 50 {
+		app := db.Appender(ctx)
+		_, err := app.Append(0, labels.FromStrings("foo", "bar"), maxt, float64(maxt))
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		maxt++
+	}
+
+	require.NoError(t, db.Close())
+
+	// 3. Corrupt the checkpoint segment file.
+	checkpointDir, _, err := wlog.LastCheckpoint(path.Join(db.Dir(), "wal"))
+	require.NoError(t, err)
+	checkpointFiles, err := os.ReadDir(checkpointDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, checkpointFiles)
+
+	f, err := os.OpenFile(path.Join(checkpointDir, checkpointFiles[0].Name()), os.O_RDWR, 0o666)
+	require.NoError(t, err)
+	// Write corrupted byte at the beginning of the checkpoint segment.
+	_, err = f.WriteAt([]byte{99}, 0)
+	require.NoError(t, err)
+	f.Close()
+
+	// 4. Open DB again and verify recovery.
+	{
+		reopenedDB := newTestDB(t, withDir(db.Dir()))
+		require.Equal(t, 1.0, prom_testutil.ToFloat64(reopenedDB.head.metrics.walCorruptionsTotal), "WAL corruption count mismatch")
+
+		// Check that the corrupted checkpoint directory has been removed.
+		_, _, err = wlog.LastCheckpoint(path.Join(db.Dir(), "wal"))
+		require.ErrorIs(t, err, record.ErrNotFound)
+
+		// Verify that the WAL segments were preserved and replayed.
+		querier, err := reopenedDB.Querier(0, maxt)
+		require.NoError(t, err)
+		seriesSet := query(t, querier, labels.MustNewMatcher(labels.MatchEqual, "", ""))
+		require.NotEmpty(t, seriesSet[`{foo="bar"}`])
+		require.NoError(t, reopenedDB.Close())
+	}
+}
+
 func TestDataNotAvailableAfterRollback(t *testing.T) {
 	db := newTestDB(t)
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -895,10 +895,8 @@ func (h *Head) Init(minValidTime int64) error {
 			}
 		}()
 
-		// A corrupted checkpoint is a hard error for now and requires user
-		// intervention. There's likely little data that can be recovered anyway.
 		if err := h.loadWAL(wlog.NewReader(sr), syms, multiRef, mmappedChunks, oooMmappedChunks); err != nil {
-			return fmt.Errorf("backfill checkpoint: %w", err)
+			return &errLoadCheckpoint{checkpointDir: dir, err: err}
 		}
 		h.updateWALReplayStatusRead(startFrom)
 		startFrom++

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1147,6 +1147,23 @@ func (e errLoadWbl) Unwrap() error {
 	return e.err
 }
 
+type errLoadCheckpoint struct {
+	checkpointDir string
+	err           error
+}
+
+func (e errLoadCheckpoint) Error() string {
+	return fmt.Sprintf("backfill checkpoint: %s", e.err.Error())
+}
+
+func (e errLoadCheckpoint) Cause() error {
+	return e.err
+}
+
+func (e errLoadCheckpoint) Unwrap() error {
+	return e.err
+}
+
 type wblSubsetProcessor struct {
 	input            chan wblSubsetProcessorInputItem
 	output           chan []record.RefSample


### PR DESCRIPTION
## Problem

When replaying a corrupted checkpoint during `tsdb.Open`, `head.Init` previously returned a generic error wrapping `wlog.CorruptionErr`. The caller in `tsdb.Open` caught this error and invoked `wal.Repair` against the main WAL directory. Because the checkpoint segment index (e.g. `0`) did not correspond to segment indices in the main WAL directory, `wal.Repair` mistakenly truncated or wiped all segments in the healthy main WAL, resulting in complete data loss for all post-checkpoint samples.

## Solution

1. Introduced `errLoadCheckpoint` in `tsdb/head_wal.go` to explicitly distinguish checkpoint replay errors from WAL replay errors.
2. In `tsdb/head.go`, wrapped checkpoint loading errors in `&errLoadCheckpoint{checkpointDir: dir, err: err}`.
3. In `tsdb/db.go`, on encountering an `errLoadCheckpoint`, `tsdb.Open` safely removes the corrupted checkpoint directory and re-runs `head.Init` to replay the remaining un-corrupted WAL segments from `minValidTime`, preserving all post-checkpoint data.
4. Added `TestCheckpointCorruptionRecovery` in `tsdb/db_test.go` to verify corrupted checkpoint cleanup and successful replay of subsequent WAL records.

#### Which issue(s) does the PR fix:
Fixes #7530

#### Release notes for end users (**ALL** commits must be considered).
```release-notes
[BUGFIX] TSDB: Recover from corrupted checkpoints without truncating valid WAL segments.
```