### PR TITLE
tsdb: retain mmap ownership through byte views

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -848,7 +848,10 @@ func checkErr(err error) int {
 }
 
 func backfillOpenMetrics(path, outputDir string, humanReadable, quiet bool, maxBlockDuration time.Duration, customLabels map[string]string) int {
-	var buf []byte
+	var (
+		buf       []byte
+		inputFile *fileutil.MmapFile
+	)
 	info, err := os.Stat(path)
 	if err != nil {
 		return checkErr(err)
@@ -860,18 +863,23 @@ func backfillOpenMetrics(path, outputDir string, humanReadable, quiet bool, maxB
 			return checkErr(err)
 		}
 	} else {
-		inputFile, err := fileutil.OpenMmapFile(path)
+		inputFile, err = fileutil.OpenMmapFile(path)
 		if err != nil {
 			return checkErr(err)
 		}
 		defer inputFile.Close()
-		buf = inputFile.Bytes()
 	}
 
 	if err := os.MkdirAll(outputDir, 0o777); err != nil {
 		return checkErr(fmt.Errorf("create output dir: %w", err))
 	}
 
+	if inputFile != nil {
+		view := inputFile.BytesView()
+		return checkErr(view.WithBytes(func(b []byte) error {
+			return backfill(5000, b, outputDir, humanReadable, quiet, maxBlockDuration, customLabels)
+		}))
+	}
 	return checkErr(backfill(5000, buf, outputDir, humanReadable, quiet, maxBlockDuration, customLabels))
 }
 

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -838,11 +839,96 @@ func TestStreamResponse(t *testing.T) {
 	require.Equal(t, expectData, writer.actual)
 }
 
+func TestStreamResponseWithMmapBackedChunk(t *testing.T) {
+	reader, series := newMmapBackedChunkSeries(t)
+	writer := mockWriter{beforeWrite: runtime.GC}
+	ss := &singleChunkSeriesSet{series: series}
+
+	warnings, err := StreamChunkedReadResponses(&writer, 0, ss, nil, 1<<20, &sync.Pool{})
+	require.NoError(t, err)
+	require.Nil(t, warnings)
+	require.Len(t, writer.actual, 1)
+	require.Len(t, writer.actual[0].Chunks, 1)
+	it := series.Iterator(nil)
+	require.True(t, it.Next())
+	require.Equal(t, it.At().Chunk.Bytes(), writer.actual[0].Chunks[0].Data)
+	runtime.KeepAlive(reader)
+}
+
+func BenchmarkStreamResponseWithMmapBackedChunk(b *testing.B) {
+	reader, series := newMmapBackedChunkSeries(b)
+	ss := &singleChunkSeriesSet{series: series}
+	pool := &sync.Pool{}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ss.done = false
+		if _, err := StreamChunkedReadResponses(io.Discard, 0, ss, nil, 1<<20, pool); err != nil {
+			b.Fatal(err)
+		}
+	}
+	runtime.KeepAlive(reader)
+}
+
+func newMmapBackedChunkSeries(tb testing.TB) (*chunks.Reader, storage.ChunkSeries) {
+	tb.Helper()
+	dir := tb.TempDir()
+	writer, err := chunks.NewWriter(dir)
+	require.NoError(tb, err)
+	chunk := chunkenc.NewXORChunk()
+	app, err := chunk.Appender()
+	require.NoError(tb, err)
+	for i := range 120 {
+		app.Append(0, int64(i), float64(i))
+	}
+	metas := []chunks.Meta{{MinTime: 0, MaxTime: 119, Chunk: chunk}}
+	require.NoError(tb, writer.WriteChunks(metas...))
+	require.NoError(tb, writer.Close())
+
+	reader, err := chunks.NewDirReader(dir, chunkenc.NewPool())
+	require.NoError(tb, err)
+	tb.Cleanup(func() { require.NoError(tb, reader.Close()) })
+	mappedChunk, iterable, err := reader.ChunkOrIterable(metas[0])
+	require.NoError(tb, err)
+	require.Nil(tb, iterable)
+	meta := chunks.Meta{MinTime: metas[0].MinTime, MaxTime: metas[0].MaxTime, Chunk: mappedChunk}
+	series := &storage.ChunkSeriesEntry{
+		Lset: labels.FromStrings(labels.MetricName, "mmap_metric"),
+		ChunkIteratorFn: func(chunks.Iterator) chunks.Iterator {
+			return storage.NewListChunkSeriesIterator(meta)
+		},
+	}
+	return reader, series
+}
+
+type singleChunkSeriesSet struct {
+	series storage.ChunkSeries
+	done   bool
+}
+
+func (s *singleChunkSeriesSet) Next() bool {
+	if s.done {
+		return false
+	}
+	s.done = true
+	return true
+}
+
+func (s *singleChunkSeriesSet) At() storage.ChunkSeries { return s.series }
+
+func (*singleChunkSeriesSet) Warnings() annotations.Annotations { return nil }
+
+func (*singleChunkSeriesSet) Err() error { return nil }
+
 type mockWriter struct {
-	actual []*prompb.ChunkedSeries
+	actual      []*prompb.ChunkedSeries
+	beforeWrite func()
 }
 
 func (m *mockWriter) Write(p []byte) (n int, err error) {
+	if m.beforeWrite != nil {
+		m.beforeWrite()
+	}
 	cr := &prompb.ChunkedReadResponse{}
 	if err := proto.Unmarshal(p, cr); err != nil {
 		return 0, fmt.Errorf("unmarshaling: %w", err)

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -57,11 +57,13 @@ type IndexWriter interface {
 	Close() error
 }
 
-// IndexReader provides reading access of serialized index data.
+// IndexReader provides reading access of serialized index data. Returned
+// strings and iterators may borrow index data. Keep the reader reachable and
+// open through their final use; defer Close or use runtime.KeepAlive as needed.
 type IndexReader interface {
 	// Symbols return an iterator over sorted string symbols that may occur in
-	// series' labels and indices. It is not safe to use the returned strings
-	// beyond the lifetime of the index reader.
+	// series' labels and indices. Keep the reader reachable and open through the
+	// final use of the returned strings.
 	Symbols() index.StringIter
 
 	// SortedLabelValues returns sorted possible label values.
@@ -77,6 +79,7 @@ type IndexReader interface {
 	Postings(ctx context.Context, name string, values ...string) (index.Postings, error)
 
 	// PostingsForLabelMatching returns a sorted iterator over postings having a label with the given name and a value for which match returns true.
+	// The value passed to match is borrowed and must not be retained.
 	// If no postings are found having at least one matching label, an empty iterator is returned.
 	PostingsForLabelMatching(ctx context.Context, name string, match func(value string) bool) index.Postings
 
@@ -122,7 +125,9 @@ type ChunkWriter interface {
 	Close() error
 }
 
-// ChunkReader provides reading access of serialized time series data.
+// ChunkReader provides reading access of serialized time series data. Returned
+// chunks and iterables may borrow chunk data. Keep the reader reachable and
+// open through their final use; defer Close or use runtime.KeepAlive as needed.
 type ChunkReader interface {
 	// ChunkOrIterable returns the series data for the given chunks.Meta.
 	// Either a single chunk will be returned, or an iterable.

--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 )
 
@@ -605,19 +606,21 @@ func (b realByteSlice) Range(start, end int) []byte {
 	return b[start:end]
 }
 
-// Reader implements a ChunkReader for a serialized byte stream
-// of series data.
+// Reader implements a ChunkReader for serialized series data. Returned chunks
+// may borrow segment data. Keep the Reader reachable and open through their
+// final use; defer Close or use runtime.KeepAlive as needed.
 type Reader struct {
 	// The underlying bytes holding the encoded series data.
 	// Each slice holds the data for a different segment.
-	bs   []ByteSlice
-	cs   []io.Closer // Closers for resources behind the byte slices.
-	size int64       // The total size of bytes in the reader.
-	pool chunkenc.Pool
+	bs    []ByteSlice
+	views []encoding.ByteView
+	cs    []io.Closer // Closers for resources behind the byte slices.
+	size  int64       // The total size of bytes in the reader.
+	pool  chunkenc.Pool
 }
 
-func newReader(bs []ByteSlice, cs []io.Closer, pool chunkenc.Pool) (*Reader, error) {
-	cr := Reader{pool: pool, bs: bs, cs: cs}
+func newReader(bs []ByteSlice, views []encoding.ByteView, cs []io.Closer, pool chunkenc.Pool) (*Reader, error) {
+	cr := Reader{pool: pool, bs: bs, views: views, cs: cs}
 	for i, b := range cr.bs {
 		if b.Len() < SegmentHeaderSize {
 			return nil, fmt.Errorf("invalid segment header in segment %d: %w", i, errInvalidSize)
@@ -648,8 +651,9 @@ func NewDirReader(dir string, pool chunkenc.Pool) (*Reader, error) {
 	}
 
 	var (
-		bs []ByteSlice
-		cs []io.Closer
+		bs    []ByteSlice
+		views []encoding.ByteView
+		cs    []io.Closer
 	)
 	for _, fn := range files {
 		f, err := fileutil.OpenMmapFile(fn)
@@ -660,10 +664,17 @@ func NewDirReader(dir string, pool chunkenc.Pool) (*Reader, error) {
 			)
 		}
 		cs = append(cs, f)
-		bs = append(bs, realByteSlice(f.Bytes()))
+		view := f.BytesView()
+		if err := view.WithBytes(func(b []byte) error {
+			bs = append(bs, realByteSlice(b))
+			return nil
+		}); err != nil {
+			return nil, errors.Join(err, closeAll(cs))
+		}
+		views = append(views, view)
 	}
 
-	reader, err := newReader(bs, cs, pool)
+	reader, err := newReader(bs, views, cs, pool)
 	if err != nil {
 		return nil, errors.Join(
 			err,
@@ -682,7 +693,8 @@ func (s *Reader) Size() int64 {
 	return s.size
 }
 
-// ChunkOrIterable returns a chunk from a given reference.
+// ChunkOrIterable returns a chunk from a given reference. The result may borrow
+// segment data; keep the Reader reachable and open through its final use.
 func (s *Reader) ChunkOrIterable(meta Meta) (chunkenc.Chunk, chunkenc.Iterable, error) {
 	sgmIndex, chkStart := BlockChunkRef(meta.Ref).Unpack()
 
@@ -691,6 +703,11 @@ func (s *Reader) ChunkOrIterable(meta Meta) (chunkenc.Chunk, chunkenc.Iterable, 
 	}
 
 	sgmBytes := s.bs[sgmIndex]
+	var view encoding.ByteView
+	if sgmIndex < len(s.views) {
+		view = s.views[sgmIndex]
+	}
+	defer view.KeepAlive()
 
 	if chkStart+MaxChunkLengthFieldSize > sgmBytes.Len() {
 		return nil, nil, fmt.Errorf("segment doesn't include enough bytes to read the chunk size data field - required:%v, available:%v", chkStart+MaxChunkLengthFieldSize, sgmBytes.Len())
@@ -717,9 +734,8 @@ func (s *Reader) ChunkOrIterable(meta Meta) (chunkenc.Chunk, chunkenc.Iterable, 
 		return nil, nil, err
 	}
 
-	chkData := sgmBytes.Range(chkDataStart, chkDataEnd)
 	chkEnc := sgmBytes.Range(chkEncStart, chkEncStart+ChunkEncodingSize)[0]
-	chk, err := s.pool.Get(chunkenc.Encoding(chkEnc), chkData)
+	chk, err := s.pool.Get(chunkenc.Encoding(chkEnc), sgmBytes.Range(chkDataStart, chkDataEnd))
 	return chk, nil, err
 }
 

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 )
 
@@ -235,6 +236,7 @@ type ChunkDiskMapper struct {
 // mmappedChunkFile provides mmap access to an entire head chunks file that holds many chunks.
 type mmappedChunkFile struct {
 	byteSlice ByteSlice
+	view      encoding.ByteView
 	maxt      int64 // Max timestamp among all of this file's chunks.
 }
 
@@ -335,7 +337,13 @@ func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
 			return fmt.Errorf("mmap files, file: %s: %w", fn, err)
 		}
 		cdm.closers[seq] = f
-		cdm.mmappedChunkFiles[seq] = &mmappedChunkFile{byteSlice: realByteSlice(f.Bytes())}
+		view := f.BytesView()
+		var bs realByteSlice
+		_ = view.WithBytes(func(b []byte) error {
+			bs = realByteSlice(b)
+			return nil
+		})
+		cdm.mmappedChunkFiles[seq] = &mmappedChunkFile{byteSlice: bs, view: view}
 		chkFileIndices = append(chkFileIndices, seq)
 	}
 
@@ -519,9 +527,10 @@ func (cdm *ChunkDiskMapper) writeChunk(seriesRef HeadSeriesRef, mint, maxt int64
 		}
 	}
 
-	// if len(chk.Bytes())+MaxHeadChunkMetaSize >= writeBufferSize, it means that chunk >= the buffer size;
+	chkLen := len(chk.Bytes())
+	// If chkLen+MaxHeadChunkMetaSize >= writeBufferSize, the chunk is at least as large as the buffer;
 	// so no need to flush here, as we have to flush at the end (to not keep partial chunks in buffer).
-	if len(chk.Bytes())+MaxHeadChunkMetaSize < cdm.writeBufferSize && cdm.chkWriter.Available() < MaxHeadChunkMetaSize+len(chk.Bytes()) {
+	if chkLen+MaxHeadChunkMetaSize < cdm.writeBufferSize && cdm.chkWriter.Available() < MaxHeadChunkMetaSize+chkLen {
 		if err := cdm.flushBuffer(); err != nil {
 			return err
 		}
@@ -542,7 +551,7 @@ func (cdm *ChunkDiskMapper) writeChunk(seriesRef HeadSeriesRef, mint, maxt int64
 	}
 	cdm.byteBuf[bytesWritten] = byte(enc)
 	bytesWritten += ChunkEncodingSize
-	n := binary.PutUvarint(cdm.byteBuf[bytesWritten:], uint64(len(chk.Bytes())))
+	n := binary.PutUvarint(cdm.byteBuf[bytesWritten:], uint64(chkLen))
 	bytesWritten += n
 
 	if err := cdm.writeAndAppendToCRC32(cdm.byteBuf[:bytesWritten]); err != nil {
@@ -561,7 +570,7 @@ func (cdm *ChunkDiskMapper) writeChunk(seriesRef HeadSeriesRef, mint, maxt int64
 
 	cdm.chunkBuffer.put(ref, chk)
 
-	if len(chk.Bytes())+MaxHeadChunkMetaSize >= cdm.writeBufferSize {
+	if chkLen+MaxHeadChunkMetaSize >= cdm.writeBufferSize {
 		// The chunk was bigger than the buffer itself.
 		// Flushing to not keep partial chunks in buffer.
 		if err := cdm.flushBuffer(); err != nil {
@@ -648,7 +657,13 @@ func (cdm *ChunkDiskMapper) cut() (seq, offset int, returnErr error) {
 	}
 
 	cdm.closers[cdm.curFileSequence] = mmapFile
-	cdm.mmappedChunkFiles[cdm.curFileSequence] = &mmappedChunkFile{byteSlice: realByteSlice(mmapFile.Bytes())}
+	view := mmapFile.BytesView()
+	var bs realByteSlice
+	_ = view.WithBytes(func(b []byte) error {
+		bs = realByteSlice(b)
+		return nil
+	})
+	cdm.mmappedChunkFiles[cdm.curFileSequence] = &mmappedChunkFile{byteSlice: bs, view: view}
 	cdm.readPathMtx.Unlock()
 
 	cdm.curFileMaxt = 0

--- a/tsdb/chunks/ownership_test.go
+++ b/tsdb/chunks/ownership_test.go
@@ -1,0 +1,86 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunks
+
+import (
+	"os"
+	"runtime"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/encoding"
+)
+
+func TestReaderRetainsSegmentOwner(t *testing.T) {
+	cleaned := exerciseOwnedReaderChunk(t)
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		return cleaned.Load()
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func exerciseOwnedReaderChunk(t *testing.T) *atomic.Bool {
+	t.Helper()
+	r, chunk, pool, segment, cleaned := ownedReaderChunk(t)
+	runtime.GC()
+	runtime.KeepAlive(r)
+	require.False(t, cleaned.Load())
+
+	chunkStart := uintptr(unsafe.Pointer(unsafe.SliceData(chunk.Bytes())))
+	segmentStart := uintptr(unsafe.Pointer(unsafe.SliceData(segment)))
+	require.GreaterOrEqual(t, chunkStart, segmentStart)
+	require.Less(t, chunkStart, segmentStart+uintptr(len(segment)))
+	require.Equal(t, chunkenc.ValFloat, chunk.Iterator(nil).Next())
+
+	require.NoError(t, pool.Put(chunk))
+	runtime.KeepAlive(r)
+	return cleaned
+}
+
+func ownedReaderChunk(t *testing.T) (*Reader, chunkenc.Chunk, chunkenc.Pool, []byte, *atomic.Bool) {
+	t.Helper()
+	dir := t.TempDir()
+	w, err := NewWriter(dir)
+	require.NoError(t, err)
+	c := chunkenc.NewXORChunk()
+	app, err := c.Appender()
+	require.NoError(t, err)
+	app.Append(0, 1000, 1)
+	require.NoError(t, w.WriteChunks(Meta{Chunk: c}))
+	require.NoError(t, w.Close())
+
+	files, err := sequenceFiles(dir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	b, err := os.ReadFile(files[0])
+	require.NoError(t, err)
+
+	owner := new([64]byte)
+	cleaned := &atomic.Bool{}
+	runtime.AddCleanup(owner, func(cleaned *atomic.Bool) {
+		cleaned.Store(true)
+	}, cleaned)
+	view := encoding.NewByteViewWithOwner(b, owner)
+	pool := chunkenc.NewPool()
+	r, err := newReader([]ByteSlice{realByteSlice(b)}, []encoding.ByteView{view}, nil, pool)
+	require.NoError(t, err)
+	chunk, _, err := r.ChunkOrIterable(Meta{Ref: ChunkRef(NewBlockChunkRef(0, SegmentHeaderSize))})
+	require.NoError(t, err)
+	return r, chunk, pool, b, cleaned
+}

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -14,15 +14,85 @@
 package encoding
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash"
 	"hash/crc32"
+	"io"
 	"math"
+	"runtime"
 
 	"github.com/dennwc/varint"
 )
+
+// ByteView is an owner-aware view over a byte slice.
+// A view and its derived views share the same owner.
+type ByteView struct {
+	b     []byte
+	owner any
+}
+
+// NewByteView returns a view over ordinary Go-managed memory.
+func NewByteView(b []byte) ByteView {
+	return ByteView{b: b}
+}
+
+// NewByteViewWithOwner returns a view that keeps owner alive while the bytes
+// are in use.
+func NewByteViewWithOwner(b []byte, owner any) ByteView {
+	return ByteView{b: b, owner: owner}
+}
+
+func (v ByteView) Len() int { return len(v.b) }
+
+func (v ByteView) At(i int) byte {
+	b := v.b[i]
+	v.KeepAlive()
+	return b
+}
+
+func (v ByteView) Slice(start, end int) ByteView {
+	return ByteView{b: v.b[start:end], owner: v.owner}
+}
+
+func (v ByteView) Copy() []byte {
+	b := append([]byte(nil), v.b...)
+	v.KeepAlive()
+	return b
+}
+
+func (v ByteView) String() string {
+	s := string(v.b)
+	v.KeepAlive()
+	return s
+}
+
+func (v ByteView) Equal(other ByteView) bool {
+	equal := bytes.Equal(v.b, other.b)
+	v.KeepAlive()
+	other.KeepAlive()
+	return equal
+}
+
+// WithBytes exposes the bytes for the duration of fn. Code that retains the
+// slice must also retain the view and call KeepAlive after its final use.
+func (v ByteView) WithBytes(fn func([]byte) error) error {
+	err := fn(v.b)
+	v.KeepAlive()
+	return err
+}
+
+func (v ByteView) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(v.b)
+	v.KeepAlive()
+	return int64(n), err
+}
+
+func (v ByteView) KeepAlive() {
+	runtime.KeepAlive(v.owner)
+}
 
 var (
 	ErrInvalidSize     = errors.New("invalid size")

--- a/tsdb/encoding/ownership_test.go
+++ b/tsdb/encoding/ownership_test.go
@@ -1,0 +1,77 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encoding
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestByteViewDerivedViewRetainsOwner(t *testing.T) {
+	cleaned := exerciseDerivedView(t)
+	requireOwnerCleaned(t, cleaned)
+}
+
+func exerciseDerivedView(t *testing.T) *atomic.Bool {
+	t.Helper()
+	owner := new([64]byte)
+	cleaned := addOwnerCleanup(owner)
+	view := NewByteViewWithOwner([]byte("mapped"), owner).Slice(1, 4)
+
+	runtime.GC()
+	runtime.KeepAlive(view)
+	require.False(t, cleaned.Load())
+	require.Equal(t, "app", view.String())
+	return cleaned
+}
+
+func TestByteViewWithBytesRetainsOwnerDuringCallback(t *testing.T) {
+	cleaned := exerciseWithBytes(t)
+	requireOwnerCleaned(t, cleaned)
+}
+
+func exerciseWithBytes(t *testing.T) *atomic.Bool {
+	t.Helper()
+	owner := new([64]byte)
+	cleaned := addOwnerCleanup(owner)
+	view := NewByteViewWithOwner([]byte("mapped"), owner)
+
+	require.NoError(t, view.WithBytes(func(b []byte) error {
+		runtime.GC()
+		require.False(t, cleaned.Load())
+		require.Equal(t, []byte("mapped"), b)
+		return nil
+	}))
+	return cleaned
+}
+
+func addOwnerCleanup(owner *[64]byte) *atomic.Bool {
+	cleaned := &atomic.Bool{}
+	runtime.AddCleanup(owner, func(cleaned *atomic.Bool) {
+		cleaned.Store(true)
+	}, cleaned)
+	return cleaned
+}
+
+func requireOwnerCleaned(t *testing.T, cleaned *atomic.Bool) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		return cleaned.Load()
+	}, 2*time.Second, 10*time.Millisecond)
+}

--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -14,6 +14,7 @@
 package fileutil
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -25,7 +26,7 @@ type mmapRef struct {
 
 func (m *mmapRef) close() error {
 	if m.b == nil {
-		return fmt.Errorf("mmap already closed")
+		return errors.New("mmap already closed")
 	}
 	err := munmap(m.b)
 	m.b = nil

--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -64,8 +64,7 @@ func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 		return nil, fmt.Errorf("mmap, size %d: %w", size, err)
 	}
 
-	mr := &mmapRef{b: b}
-	mmapFile := &MmapFile{f: f, m: mr}
+	mmapFile := &MmapFile{f: f, m: &mmapRef{b: b}}
 
 	runtime.AddCleanup(mmapFile, func(m *mmapRef) {
 		_ = m.close()

--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -16,11 +16,25 @@ package fileutil
 import (
 	"fmt"
 	"os"
+	"runtime"
 )
+
+type mmapRef struct {
+	b []byte
+}
+
+func (m *mmapRef) close() error {
+	if m.b == nil {
+		return fmt.Errorf("mmap already closed")
+	}
+	err := munmap(m.b)
+	m.b = nil
+	return err
+}
 
 type MmapFile struct {
 	f *os.File
-	b []byte
+	m *mmapRef
 }
 
 func OpenMmapFile(path string) (*MmapFile, error) {
@@ -50,11 +64,18 @@ func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 		return nil, fmt.Errorf("mmap, size %d: %w", size, err)
 	}
 
-	return &MmapFile{f: f, b: b}, nil
+	mr := &mmapRef{b: b}
+	mmapFile := &MmapFile{f: f, m: mr}
+
+	runtime.AddCleanup(mmapFile, func(m *mmapRef) {
+		_ = m.close()
+	}, mmapFile.m)
+
+	return mmapFile, nil
 }
 
 func (f *MmapFile) Close() error {
-	err0 := munmap(f.b)
+	err0 := f.m.close()
 	err1 := f.f.Close()
 
 	if err0 != nil {
@@ -68,5 +89,5 @@ func (f *MmapFile) File() *os.File {
 }
 
 func (f *MmapFile) Bytes() []byte {
-	return f.b
+	return f.m.b
 }

--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+
+	"github.com/prometheus/prometheus/tsdb/encoding"
 )
 
 type mmapRef struct {
@@ -25,17 +27,25 @@ type mmapRef struct {
 }
 
 func (m *mmapRef) close() error {
+	return m.closeWith(munmap)
+}
+
+func (m *mmapRef) closeWith(unmap func([]byte) error) error {
 	if m.b == nil {
 		return errors.New("mmap already closed")
 	}
-	err := munmap(m.b)
+	err := unmap(m.b)
+	if err != nil {
+		return err
+	}
 	m.b = nil
-	return err
+	return nil
 }
 
 type MmapFile struct {
-	f *os.File
-	m *mmapRef
+	f       *os.File
+	m       *mmapRef
+	cleanup runtime.Cleanup
 }
 
 func OpenMmapFile(path string) (*MmapFile, error) {
@@ -65,18 +75,23 @@ func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 		return nil, fmt.Errorf("mmap, size %d: %w", size, err)
 	}
 
-	mmapFile := &MmapFile{f: f, m: &mmapRef{b: b}}
-
-	runtime.AddCleanup(mmapFile, func(m *mmapRef) {
-		_ = m.close()
-	}, mmapFile.m)
+	m := &mmapRef{b: b}
+	mmapFile := &MmapFile{f: f, m: m}
+	mmapFile.cleanup = runtime.AddCleanup(m, func(b []byte) {
+		_ = munmap(b)
+	}, b)
 
 	return mmapFile, nil
 }
 
+// Close invalidates all views returned by Bytes and BytesView.
 func (f *MmapFile) Close() error {
 	err0 := f.m.close()
+	if err0 == nil {
+		f.cleanup.Stop()
+	}
 	err1 := f.f.Close()
+	runtime.KeepAlive(f.m)
 
 	if err0 != nil {
 		return err0
@@ -88,6 +103,16 @@ func (f *MmapFile) File() *os.File {
 	return f.f
 }
 
+// Bytes returns a borrowed view of the mapping. The caller must keep f
+// reachable until it finishes using the slice. The slice is invalid after Close.
 func (f *MmapFile) Bytes() []byte {
-	return f.m.b
+	b := f.m.b
+	runtime.KeepAlive(f)
+	return b
+}
+
+// BytesView returns a view that keeps the mapping reachable. It is invalid
+// after Close.
+func (f *MmapFile) BytesView() encoding.ByteView {
+	return encoding.NewByteViewWithOwner(f.m.b, f.m)
 }

--- a/tsdb/fileutil/mmap_test.go
+++ b/tsdb/fileutil/mmap_test.go
@@ -1,0 +1,148 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !js && !plan9
+
+package fileutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestOpenMmapFile(t *testing.T) {
+	dir := testutil.NewTemporaryDirectory("test_mmap", t)
+	defer dir.Close()
+
+	content := []byte("lorem impsum, this content is mmapped")
+
+	file := filepath.Join(dir.Path(), "mmap_target")
+	err := os.WriteFile(file, content, 0666)
+	require.NoError(t, err, "Failed to write test target file %q.", file)
+
+	mmap, err := OpenMmapFile(file)
+	require.NoError(t, err, "Failed to mmap target file %q.", file)
+
+	defer mmap.Close()
+	require.Equal(t, content, mmap.Bytes(), "Mmap does not match the data in the file")
+}
+
+func TestOpenMmapFileWithSize(t *testing.T) {
+	dir := testutil.NewTemporaryDirectory("test_mmap", t)
+	defer dir.Close()
+
+	content := []byte("lorem impsum, this content is mmapped")
+	sizes := []int{len(content), 12}
+
+	for idx, size := range sizes {
+		file := filepath.Join(dir.Path(), fmt.Sprintf("mmap_target_%d", idx))
+		err := os.WriteFile(file, content, 0666)
+		require.NoError(t, err, "Failed to write test target file %q.", file)
+
+		mmap, err := OpenMmapFileWithSize(file, size)
+		require.NoError(t, err, "Failed to mmap target file %q.", file)
+
+		defer mmap.Close()
+		require.Equal(t, content[:size], mmap.Bytes(), "Mmap does not match the data in the file")
+	}
+}
+
+func TestClose(t *testing.T) {
+	dir := testutil.NewTemporaryDirectory("test_mmap", t)
+	defer dir.Close()
+
+	content := []byte("lorem impsum, this content is mmapped")
+
+	file := filepath.Join(dir.Path(), "mmap_target")
+	err := os.WriteFile(file, content, 0666)
+	require.NoError(t, err, "Failed to write test target file %q.", file)
+
+	mmap, err := OpenMmapFile(file)
+	require.NoError(t, err, "Failed to mmap target file %q.", file)
+
+	err = mmap.Close()
+	require.NoError(t, err, "Failed to close mmap.")
+
+	err = mmap.Close()
+	require.Error(t, err, "Closing mmap multiple times should error.")
+}
+
+func TestGCCleanup(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("inspecting process memorymaps not implemented on this platform")
+	}
+
+	_, err := os.ReadFile("/proc/self/maps")
+	if err != nil {
+		t.Skip("procfs is not mounted, cannot validate mmappings")
+	}
+
+	dir := testutil.NewTemporaryDirectory("test_mmap", t)
+	defer dir.Close()
+
+	content := []byte("lorem impsum, this content is mmapped")
+
+	file := filepath.Join(dir.Path(), "mmap_leak_target")
+	err = os.WriteFile(file, content, 0666)
+	require.NoError(t, err, "Failed to write test target file %q.", file)
+
+	mmap, err := OpenMmapFile(file)
+	require.NoError(t, err, "Failed to mmap target file %q.", file)
+
+	// ensure we can find the file in /proc/self/maps
+	mmapped, err := isPathMmapped(file)
+	require.NoError(t, err, "Failed to determine if file is mapped %q.", file)
+	require.True(t, mmapped, "mmap memory map was unexpectedly missing")
+
+	// leak the mmap. Note the statement here keeps the object alive. After this
+	// the mmap is eligible for GC
+	_ = mmap
+
+	// run GC to run cleanup. This is undeterministic so let's run it a few times
+	for retry := 0; retry < 3; retry++ {
+		runtime.GC()
+		mmapped, err = isPathMmapped(file)
+		require.NoError(t, err, "Failed to determine if file is mapped %q.", file)
+
+		if !mmapped {
+			// GC cleaned the mmap
+			break
+		}
+
+		// GC didn't clean the handle, retry
+		time.Sleep(time.Second)
+	}
+
+	// ensure the mmap was cleaned up, and we cannot find the mapping in /proc/self/maps
+	mmapped, err = isPathMmapped(file)
+	require.False(t, mmapped, "mmap memory map was unexpectedly leaked")
+}
+
+// Determines if this process has the given file in a file-backed memory map
+func isPathMmapped(file string) (bool, error) {
+	maps, err := os.ReadFile("/proc/self/maps")
+	if err != nil {
+		return false, err
+	}
+	// don't bother parsing maps. The test file path is unique enough
+	return strings.Contains(string(maps), file), nil
+}

--- a/tsdb/fileutil/mmap_test.go
+++ b/tsdb/fileutil/mmap_test.go
@@ -36,7 +36,7 @@ func TestOpenMmapFile(t *testing.T) {
 	content := []byte("lorem impsum, this content is mmapped")
 
 	file := filepath.Join(dir.Path(), "mmap_target")
-	err := os.WriteFile(file, content, 0666)
+	err := os.WriteFile(file, content, 0o666)
 	require.NoError(t, err, "Failed to write test target file %q.", file)
 
 	mmap, err := OpenMmapFile(file)
@@ -55,7 +55,7 @@ func TestOpenMmapFileWithSize(t *testing.T) {
 
 	for idx, size := range sizes {
 		file := filepath.Join(dir.Path(), fmt.Sprintf("mmap_target_%d", idx))
-		err := os.WriteFile(file, content, 0666)
+		err := os.WriteFile(file, content, 0o666)
 		require.NoError(t, err, "Failed to write test target file %q.", file)
 
 		mmap, err := OpenMmapFileWithSize(file, size)
@@ -73,7 +73,7 @@ func TestClose(t *testing.T) {
 	content := []byte("lorem impsum, this content is mmapped")
 
 	file := filepath.Join(dir.Path(), "mmap_target")
-	err := os.WriteFile(file, content, 0666)
+	err := os.WriteFile(file, content, 0o666)
 	require.NoError(t, err, "Failed to write test target file %q.", file)
 
 	mmap, err := OpenMmapFile(file)
@@ -102,7 +102,7 @@ func TestGCCleanup(t *testing.T) {
 	content := []byte("lorem impsum, this content is mmapped")
 
 	file := filepath.Join(dir.Path(), "mmap_leak_target")
-	err = os.WriteFile(file, content, 0666)
+	err = os.WriteFile(file, content, 0o666)
 	require.NoError(t, err, "Failed to write test target file %q.", file)
 
 	mmap, err := OpenMmapFile(file)
@@ -118,7 +118,7 @@ func TestGCCleanup(t *testing.T) {
 	_ = mmap
 
 	// run GC to run cleanup. This is undeterministic so let's run it a few times
-	for retry := 0; retry < 3; retry++ {
+	for range 3 {
 		runtime.GC()
 		mmapped, err = isPathMmapped(file)
 		require.NoError(t, err, "Failed to determine if file is mapped %q.", file)
@@ -133,11 +133,10 @@ func TestGCCleanup(t *testing.T) {
 	}
 
 	// ensure the mmap was cleaned up, and we cannot find the mapping in /proc/self/maps
-	mmapped, err = isPathMmapped(file)
 	require.False(t, mmapped, "mmap memory map was unexpectedly leaked")
 }
 
-// Determines if this process has the given file in a file-backed memory map
+// Determines if this process has the given file in a file-backed memory map.
 func isPathMmapped(file string) (bool, error) {
 	maps, err := os.ReadFile("/proc/self/maps")
 	if err != nil {

--- a/tsdb/fileutil/mmap_test.go
+++ b/tsdb/fileutil/mmap_test.go
@@ -16,6 +16,7 @@
 package fileutil
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -86,6 +88,65 @@ func TestClose(t *testing.T) {
 	require.Error(t, err, "Closing mmap multiple times should error.")
 }
 
+func TestMmapRefCloseRetriesAfterFailure(t *testing.T) {
+	wantErr := errors.New("unmap failed")
+	m := &mmapRef{b: []byte("mapped")}
+	calls := 0
+
+	err := m.closeWith(func([]byte) error {
+		calls++
+		return wantErr
+	})
+	require.ErrorIs(t, err, wantErr)
+	require.NotNil(t, m.b)
+
+	err = m.closeWith(func([]byte) error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	require.Nil(t, m.b)
+	require.Equal(t, 2, calls)
+}
+
+func TestMmapViewRetainsMapping(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("inspecting process memory maps is only implemented on Linux")
+	}
+	if _, err := os.ReadFile("/proc/self/maps"); err != nil {
+		t.Skip("procfs is not mounted")
+	}
+
+	dir := testutil.NewTemporaryDirectory("test_mmap_view", t)
+	defer dir.Close()
+	path := filepath.Join(dir.Path(), "mmap_view_target")
+	content := []byte("the view owns this mapping")
+	require.NoError(t, os.WriteFile(path, content, 0o666))
+
+	assertMmapViewRetainsMapping(t, path, content)
+	requireEventuallyUnmapped(t, path)
+}
+
+func assertMmapViewRetainsMapping(t *testing.T, path string, content []byte) {
+	t.Helper()
+	view := openMmapView(t, path)
+	for range 3 {
+		runtime.GC()
+	}
+	mapped, err := isPathMmapped(path)
+	require.NoError(t, err)
+	require.True(t, mapped)
+	require.Equal(t, content, view.Copy())
+	runtime.KeepAlive(view)
+}
+
+func openMmapView(t *testing.T, path string) encoding.ByteView {
+	t.Helper()
+	f, err := OpenMmapFile(path)
+	require.NoError(t, err)
+	return f.BytesView()
+}
+
 func TestGCCleanup(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("inspecting process memorymaps not implemented on this platform")
@@ -105,35 +166,36 @@ func TestGCCleanup(t *testing.T) {
 	err = os.WriteFile(file, content, 0o666)
 	require.NoError(t, err, "Failed to write test target file %q.", file)
 
-	mmap, err := OpenMmapFile(file)
-	require.NoError(t, err, "Failed to mmap target file %q.", file)
+	openAndVerifyMmap(t, file)
+	requireEventuallyUnmapped(t, file)
+}
 
-	// ensure we can find the file in /proc/self/maps
-	mmapped, err := isPathMmapped(file)
-	require.NoError(t, err, "Failed to determine if file is mapped %q.", file)
-	require.True(t, mmapped, "mmap memory map was unexpectedly missing")
+func openAndVerifyMmap(t *testing.T, path string) {
+	t.Helper()
+	mmapFile, err := OpenMmapFile(path)
+	require.NoError(t, err, "Failed to mmap target file %q.", path)
 
-	// leak the mmap. Note the statement here keeps the object alive. After this
-	// the mmap is eligible for GC
-	_ = mmap
+	mapped, err := isPathMmapped(path)
+	require.NoError(t, err, "Failed to determine if file is mapped %q.", path)
+	require.True(t, mapped, "mmap memory map was unexpectedly missing")
+	runtime.KeepAlive(mmapFile)
+}
 
-	// run GC to run cleanup. This is undeterministic so let's run it a few times
-	for range 3 {
+func requireEventuallyUnmapped(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
 		runtime.GC()
-		mmapped, err = isPathMmapped(file)
-		require.NoError(t, err, "Failed to determine if file is mapped %q.", file)
-
-		if !mmapped {
-			// GC cleaned the mmap
-			break
+		mapped, err := isPathMmapped(path)
+		require.NoError(t, err, "Failed to determine if file is mapped %q.", path)
+		if !mapped {
+			return
 		}
-
-		// GC didn't clean the handle, retry
-		time.Sleep(time.Second)
+		if time.Now().After(deadline) {
+			require.FailNow(t, "mmap memory map was unexpectedly leaked", "path: %q", path)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-
-	// ensure the mmap was cleaned up, and we cannot find the mapping in /proc/self/maps
-	require.False(t, mmapped, "mmap memory map was unexpectedly leaked")
 }
 
 // Determines if this process has the given file in a file-backed memory map.

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -947,9 +947,13 @@ type StringIter interface {
 	Err() error
 }
 
+// Reader reads an index. Returned strings and iterators may borrow index data.
+// Keep the Reader reachable and open through their final use; defer Close or
+// use runtime.KeepAlive as needed.
 type Reader struct {
-	b   ByteSlice
-	toc *TOC
+	b    ByteSlice
+	view encoding.ByteView
+	toc  *TOC
 
 	// Close that releases the underlying resources of the byte slice.
 	c io.Closer
@@ -1007,7 +1011,13 @@ func NewFileReader(path string, decoder PostingsDecoder) (*Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	r, err := newReader(realByteSlice(f.Bytes()), f, decoder)
+	view := f.BytesView()
+	var mapped realByteSlice
+	_ = view.WithBytes(func(b []byte) error {
+		mapped = realByteSlice(b)
+		return nil
+	})
+	r, err := newReaderWithView(mapped, view, f, decoder)
 	if err != nil {
 		return nil, errors.Join(
 			err,
@@ -1019,8 +1029,14 @@ func NewFileReader(path string, decoder PostingsDecoder) (*Reader, error) {
 }
 
 func newReader(b ByteSlice, c io.Closer, postingsDecoder PostingsDecoder) (*Reader, error) {
+	return newReaderWithView(b, encoding.ByteView{}, c, postingsDecoder)
+}
+
+func newReaderWithView(b ByteSlice, view encoding.ByteView, c io.Closer, postingsDecoder PostingsDecoder) (*Reader, error) {
+	defer view.KeepAlive()
 	r := &Reader{
 		b:        b,
+		view:     view,
 		c:        c,
 		postings: map[string][]postingOffset{},
 		st:       labels.NewSymbolTable(),
@@ -1135,6 +1151,7 @@ type Range struct {
 // PostingsRanges returns a new map of byte range in the underlying index file
 // for all postings lists.
 func (r *Reader) PostingsRanges() (map[labels.Label]Range, error) {
+	defer r.view.KeepAlive()
 	m := map[labels.Label]Range{}
 	if err := ReadPostingsOffsetTable(r.b, r.toc.PostingsTable, func(name, value []byte, off uint64, _ int) error {
 		d := encoding.NewDecbufAt(r.b, int(off), castagnoliTable)
@@ -1333,12 +1350,17 @@ func (r *Reader) lookupSymbol(_ context.Context, o uint32) (string, error) {
 	if s, ok := r.nameSymbols[o]; ok {
 		return s, nil
 	}
-	return r.symbols.Lookup(o)
+	s, err := r.symbols.Lookup(o)
+	r.view.KeepAlive()
+	return s, err
 }
 
 // Symbols returns an iterator over the symbols that exist within the index.
+// Keep the Reader reachable and open through the final use of returned strings.
 func (r *Reader) Symbols() StringIter {
-	return r.symbols.Iter()
+	it := r.symbols.Iter()
+	r.view.KeepAlive()
+	return it
 }
 
 // SymbolTableSize returns the symbol table size in bytes.
@@ -1347,8 +1369,7 @@ func (r *Reader) SymbolTableSize() uint64 {
 }
 
 // SortedLabelValues returns value tuples that exist for the given label name.
-// It is not safe to use the return value beyond the lifetime of the byte slice
-// passed into the Reader.
+// Keep the Reader reachable and open through the final use of returned values.
 func (r *Reader) SortedLabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
 	values, err := r.LabelValues(ctx, name, hints, matchers...)
 	if err == nil && r.version == FormatV1 {
@@ -1358,8 +1379,7 @@ func (r *Reader) SortedLabelValues(ctx context.Context, name string, hints *stor
 }
 
 // LabelValues returns value tuples that exist for the given label name.
-// It is not safe to use the return value beyond the lifetime of the byte slice
-// passed into the Reader.
+// Keep the Reader reachable and open through the final use of returned values.
 // TODO(replay): Support filtering by matchers.
 func (r *Reader) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) > 0 {
@@ -1407,6 +1427,7 @@ func (r *Reader) LabelValues(ctx context.Context, name string, hints *storage.La
 // LabelNamesFor returns all the label names for the series referred to by IDs.
 // The names returned are sorted.
 func (r *Reader) LabelNamesFor(ctx context.Context, postings Postings) ([]string, error) {
+	defer r.view.KeepAlive()
 	// Gather offsetsMap the name offsetsMap in the symbol table first
 	offsetsMap := make(map[uint32]struct{})
 	i := 0
@@ -1459,6 +1480,7 @@ func (r *Reader) LabelNamesFor(ctx context.Context, postings Postings) ([]string
 
 // Series reads the series with the given ID and writes its labels and chunks into builder and chks.
 func (r *Reader) Series(id storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
+	defer r.view.KeepAlive()
 	offset := id
 	// In version 2 series IDs are no longer exact references but series are 16-byte padded
 	// and the ID is the multiple of 16 of the actual position.
@@ -1481,6 +1503,7 @@ func (r *Reader) Series(id storage.SeriesRef, builder *labels.ScratchBuilder, ch
 // traversePostingOffsets traverses r's posting offsets table, starting at off, and calls cb with every label value and postings offset.
 // If cb returns false (or an error), the traversing is interrupted.
 func (r *Reader) traversePostingOffsets(ctx context.Context, off int, cb func(string, uint64) (bool, error)) error {
+	defer r.view.KeepAlive()
 	// Don't Crc32 the entire postings offset table, this is very slow
 	// so hope any issues were caught at startup.
 	d := encoding.NewDecbufAt(r.b, int(r.toc.PostingsTable), nil)
@@ -1517,6 +1540,7 @@ func (r *Reader) traversePostingOffsets(ctx context.Context, off int, cb func(st
 }
 
 func (r *Reader) Postings(ctx context.Context, name string, values ...string) (Postings, error) {
+	defer r.view.KeepAlive()
 	if r.version == FormatV1 {
 		e, ok := r.postingsV1[name]
 		if !ok {
@@ -1598,6 +1622,8 @@ func (r *Reader) Postings(ctx context.Context, name string, values ...string) (P
 	return Merge(ctx, res...), nil
 }
 
+// PostingsForLabelMatching returns postings for matching label values. Values
+// passed to match are borrowed and must not be retained.
 func (r *Reader) PostingsForLabelMatching(ctx context.Context, name string, match func(string) bool) Postings {
 	return r.postingsForLabelMatching(ctx, name, match)
 }
@@ -1608,6 +1634,7 @@ func (r *Reader) PostingsForAllLabelValues(ctx context.Context, name string) Pos
 
 // postingsForLabelMatching implements PostingsForLabelMatching if match is non-nil, and PostingsForAllLabelValues otherwise.
 func (r *Reader) postingsForLabelMatching(ctx context.Context, name string, match func(string) bool) Postings {
+	defer r.view.KeepAlive()
 	if r.version == FormatV1 {
 		return r.postingsForLabelMatchingV1(ctx, name, match)
 	}

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -18,14 +18,18 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"go.uber.org/goleak"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -237,6 +241,65 @@ func TestIndexRW_Postings(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestReaderRetainsIndexOwner(t *testing.T) {
+	ctx := context.Background()
+	_, fn, _ := createFileReader(ctx, t, indexWriterSeriesSlice{
+		&indexWriterSeries{labels: labels.FromStrings("a", "1", "b", "2")},
+	})
+
+	cleaned := exerciseOwnedIndexReader(t, fn)
+	requireIndexOwnerCleaned(t, cleaned)
+}
+
+func exerciseOwnedIndexReader(t *testing.T, fn string) *atomic.Bool {
+	t.Helper()
+	r, cleaned := newOwnedIndexReader(t, fn)
+	postings, err := r.Postings(context.Background(), "a", "1")
+	require.NoError(t, err)
+	symbols := r.Symbols()
+	values, err := r.LabelValues(context.Background(), "b", nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"2"}, values)
+
+	var matched string
+	_ = r.PostingsForLabelMatching(context.Background(), "b", func(v string) bool {
+		matched = v
+		return false
+	})
+	require.Equal(t, "2", matched)
+
+	runtime.GC()
+	runtime.KeepAlive(r)
+	require.False(t, cleaned.Load())
+	require.True(t, postings.Next())
+	require.True(t, symbols.Next())
+	runtime.KeepAlive(r)
+	return cleaned
+}
+
+func newOwnedIndexReader(t *testing.T, fn string) (*Reader, *atomic.Bool) {
+	t.Helper()
+	b, err := os.ReadFile(fn)
+	require.NoError(t, err)
+	owner := new([64]byte)
+	cleaned := &atomic.Bool{}
+	runtime.AddCleanup(owner, func(cleaned *atomic.Bool) {
+		cleaned.Store(true)
+	}, cleaned)
+	view := encoding.NewByteViewWithOwner(b, owner)
+	r, err := newReaderWithView(realByteSlice(b), view, io.NopCloser(nil), DecodePostingsRaw)
+	require.NoError(t, err)
+	return r, cleaned
+}
+
+func requireIndexOwnerCleaned(t *testing.T, cleaned *atomic.Bool) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		return cleaned.Load()
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestPostingsMany(t *testing.T) {
@@ -524,6 +587,31 @@ func BenchmarkReader_ShardedPostings(b *testing.B) {
 		require.NoError(b, err)
 
 		ir.ShardedPostings(allPostings, uint64(n%numShards), numShards)
+	}
+}
+
+func BenchmarkReader_PostingsForLabelMatching(b *testing.B) {
+	ctx := context.Background()
+	for _, numValues := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("values=%d", numValues), func(b *testing.B) {
+			input := make(indexWriterSeriesSlice, 0, numValues)
+			for i := range numValues {
+				input = append(input, &indexWriterSeries{
+					labels: labels.FromStrings("label", fmt.Sprintf("%08d", i)),
+				})
+			}
+			ir, _, _ := createFileReader(ctx, b, input)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				p := ir.PostingsForLabelMatching(ctx, "label", func(string) bool { return false })
+				if err := p.Err(); err != nil {
+					b.Fatal(err)
+				}
+			}
+			runtime.KeepAlive(ir)
+		})
 	}
 }
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Related to #17311, originally authored by @gunjambi. This draft carries its five commits with their original authorship and extends the combined work for safe borrowed-data lifetimes; it does not change the status of the original PR.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] TSDB: Release mmap-backed file references during garbage collection when readers are not explicitly closed, preventing system file-table leaks
```

## Summary

This PR adds automatic cleanup for leaked mmap files while preserving the lifetime of mmap-backed data used by Prometheus readers.

- Coordinate automatic cleanup with explicit `Close`.
- Keep mmap ownership reachable through owner-aware byte views held by index and chunk readers.
- Preserve the existing borrowed reader-lifetime contract without per-chunk or per-string copies.
- Keep `MmapFile.Bytes` source-compatible and provide `BytesView` for owner-aware access.
- Cover cleanup, derived views, index/chunk ownership, and remote-read streaming.