### PR TITLE
build: align Renovate with pnpm release-age policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,14 @@
   "prHourlyLimit": 5,
   "packageRules": [
     {
+      "description": "Wait for npm releases to satisfy pnpm's cooldown",
+      "matchDatasources": [
+        "npm"
+      ],
+      "minimumReleaseAge": "1 day",
+      "internalChecksFilter": "strict"
+    },
+    {
       "description": "Don't update replace directives",
       "matchPackageNames": [
         "github.com/fsnotify/fsnotify"


### PR DESCRIPTION
## Summary

Configure Renovate to wait one day before raising npm dependency updates. This matches pnpm 11's default cooldown and keeps pnpm itself as the lockfile enforcement layer.

This prevents grouped dependency PRs from being refreshed with direct npm versions that CI will immediately reject, as happened in #19488.

This is intentionally narrower than #19238: it does not change pnpm policy or regenerate lockfiles.

```release-notes
NONE
```
