### PR TITLE
rules: migrate rule evaluation to AppenderV2

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1041,7 +1041,7 @@ func main() {
 
 		ruleManager = rules.NewManager(&rules.ManagerOptions{
 			NameValidationScheme:   cfgFile.GlobalConfig.MetricNameValidationScheme,
-			Appendable:             fanoutStorage,
+			AppendableV2:           fanoutStorage,
 			Queryable:              localStorage,
 			QueryFunc:              rules.EngineQueryFunc(queryEngine, fanoutStorage),
 			NotifyFunc:             rules.SendAlerts(notifierManager, cfg.web.ExternalURL.String()),

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -250,12 +250,12 @@ func (tg *testGroup) test(testname string, evalInterval time.Duration, groupOrde
 
 	// Load the rule files.
 	opts := &rules.ManagerOptions{
-		QueryFunc:  rules.EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
-		Appendable: suite.Storage(),
-		Context:    context.Background(),
-		NotifyFunc: func(context.Context, string, ...*rules.Alert) {},
-		Logger:     promslog.NewNopLogger(),
-		Parser:     tg.parser,
+		QueryFunc:    rules.EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
+		AppendableV2: suite.Storage(),
+		Context:      context.Background(),
+		NotifyFunc:   func(context.Context, string, ...*rules.Alert) {},
+		Logger:       promslog.NewNopLogger(),
+		Parser:       tg.parser,
 	}
 	m := rules.NewManager(opts)
 	groupsMap, ers := m.LoadGroups(time.Duration(tg.Interval), tg.ExternalLabels, tg.ExternalURL, nil, ignoreUnknownFields, ruleFiles...)

--- a/rules/group.go
+++ b/rules/group.go
@@ -73,7 +73,7 @@ type Group struct {
 	// defaults to DefaultEvalIterationFunc.
 	evalIterationFunc GroupEvalIterationFunc
 
-	appOpts *storage.AppendOptions
+	appOpts storage.AOptions
 }
 
 // GroupEvalIterationFunc is used to implement and extend rule group
@@ -143,7 +143,7 @@ func NewGroup(o GroupOptions) *Group {
 		logger:               opts.Logger.With("file", o.File, "group", o.Name),
 		metrics:              metrics,
 		evalIterationFunc:    evalIterationFunc,
-		appOpts:              &storage.AppendOptions{DiscardOutOfOrder: true},
+		appOpts:              storage.AOptions{RejectOutOfOrder: true},
 	}
 }
 
@@ -567,7 +567,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 		// be the majority of trace duration. Trace it using dedicated span
 		// so it's clear from the trace where did all the duration go.
 		_, appenderSp := otel.Tracer("").Start(ctx, "newAppender")
-		app := g.opts.Appendable.Appender(ctx)
+		app := g.opts.AppendableV2.AppenderV2(ctx)
 		appenderSp.End()
 		seriesReturned := make(map[string]labels.Labels, len(g.seriesInPreviousEval[i]))
 		defer func() {
@@ -597,10 +597,9 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 
 		for _, s := range vector {
 			if s.H != nil {
-				_, err = app.AppendHistogram(0, s.Metric, s.T, nil, s.H)
+				_, err = app.Append(0, s.Metric, 0, s.T, 0, nil, s.H, g.appOpts)
 			} else {
-				app.SetOptions(g.appOpts)
-				_, err = app.Append(0, s.Metric, s.T, s.F)
+				_, err = app.Append(0, s.Metric, 0, s.T, s.F, nil, nil, g.appOpts)
 			}
 
 			if err != nil {
@@ -642,7 +641,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 		for metric, lset := range g.seriesInPreviousEval[i] {
 			if _, ok := seriesReturned[metric]; !ok {
 				// Series no longer exposed, mark it stale.
-				_, err = app.Append(0, lset, timestamp.FromTime(ts.Add(-ruleQueryOffset)), math.Float64frombits(value.StaleNaN))
+				_, err = app.Append(0, lset, 0, timestamp.FromTime(ts.Add(-ruleQueryOffset)), math.Float64frombits(value.StaleNaN), nil, nil, g.appOpts)
 				unwrappedErr := errors.Unwrap(err)
 				if unwrappedErr == nil {
 					unwrappedErr = err
@@ -728,12 +727,11 @@ func (g *Group) cleanupStaleSeries(ctx context.Context, ts time.Time) {
 	if len(g.staleSeries) == 0 {
 		return
 	}
-	app := g.opts.Appendable.Appender(ctx)
-	app.SetOptions(g.appOpts)
+	app := g.opts.AppendableV2.AppenderV2(ctx)
 	queryOffset := g.QueryOffset()
 	for _, s := range g.staleSeries {
 		// Rule that produced series no longer configured, mark it stale.
-		_, err := app.Append(0, s, timestamp.FromTime(ts.Add(-queryOffset)), math.Float64frombits(value.StaleNaN))
+		_, err := app.Append(0, s, 0, timestamp.FromTime(ts.Add(-queryOffset)), math.Float64frombits(value.StaleNaN), nil, nil, g.appOpts)
 		unwrappedErr := errors.Unwrap(err)
 		if unwrappedErr == nil {
 			unwrappedErr = err

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -140,7 +140,7 @@ type ManagerOptions struct {
 	QueryFunc                 QueryFunc
 	NotifyFunc                NotifyFunc
 	Context                   context.Context
-	Appendable                storage.Appendable
+	AppendableV2              storage.AppendableV2
 	Queryable                 storage.Queryable
 	Logger                    *slog.Logger
 	Registerer                prometheus.Registerer

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -374,7 +374,7 @@ func TestForStateRestore(t *testing.T) {
 			ng := testEngine(t)
 			opts := &ManagerOptions{
 				QueryFunc:       EngineQueryFunc(ng, storage),
-				Appendable:      storage,
+				AppendableV2:    storage,
 				Queryable:       storage,
 				Context:         context.Background(),
 				Logger:          promslog.NewNopLogger(),
@@ -546,11 +546,11 @@ func TestStaleness(t *testing.T) {
 		}
 		engine := promqltest.NewTestEngineWithOpts(t, engineOpts)
 		opts := &ManagerOptions{
-			QueryFunc:  EngineQueryFunc(engine, st),
-			Appendable: st,
-			Queryable:  st,
-			Context:    context.Background(),
-			Logger:     promslog.NewNopLogger(),
+			QueryFunc:    EngineQueryFunc(engine, st),
+			AppendableV2: st,
+			Queryable:    st,
+			Context:      context.Background(),
+			Logger:       promslog.NewNopLogger(),
 		}
 
 		expr, err := testParser.ParseExpr("a + 1")
@@ -738,7 +738,7 @@ func TestDeletedRuleMarkedStale(t *testing.T) {
 		rules:                []Rule{},
 		seriesInPreviousEval: []map[string]labels.Labels{},
 		opts: &ManagerOptions{
-			Appendable:                st,
+			AppendableV2:              st,
 			RuleConcurrencyController: sequentialRuleEvalController{},
 		},
 		metrics: NewGroupMetrics(nil),
@@ -780,11 +780,11 @@ func TestUpdate(t *testing.T) {
 	}
 	engine := promqltest.NewTestEngineWithOpts(t, opts)
 	ruleManager := NewManager(&ManagerOptions{
-		Appendable: st,
-		Queryable:  st,
-		QueryFunc:  EngineQueryFunc(engine, st),
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
+		AppendableV2: st,
+		Queryable:    st,
+		QueryFunc:    EngineQueryFunc(engine, st),
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
 	})
 	ruleManager.start()
 	defer ruleManager.Stop()
@@ -922,13 +922,13 @@ func TestNotify(t *testing.T) {
 		lastNotified = alerts
 	}
 	opts := &ManagerOptions{
-		QueryFunc:   EngineQueryFunc(engine, storage),
-		Appendable:  storage,
-		Queryable:   storage,
-		Context:     context.Background(),
-		Logger:      promslog.NewNopLogger(),
-		NotifyFunc:  notifyFunc,
-		ResendDelay: 2 * time.Second,
+		QueryFunc:    EngineQueryFunc(engine, storage),
+		AppendableV2: storage,
+		Queryable:    storage,
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
+		NotifyFunc:   notifyFunc,
+		ResendDelay:  2 * time.Second,
 	}
 
 	expr, err := testParser.ParseExpr("a > 1")
@@ -994,12 +994,12 @@ func TestMetricsUpdate(t *testing.T) {
 	}
 	engine := promqltest.NewTestEngineWithOpts(t, opts)
 	ruleManager := NewManager(&ManagerOptions{
-		Appendable: storage,
-		Queryable:  storage,
-		QueryFunc:  EngineQueryFunc(engine, storage),
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
-		Registerer: registry,
+		AppendableV2: storage,
+		Queryable:    storage,
+		QueryFunc:    EngineQueryFunc(engine, storage),
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
+		Registerer:   registry,
 	})
 	ruleManager.start()
 	defer ruleManager.Stop()
@@ -1066,11 +1066,11 @@ func TestGroupStalenessOnRemoval(t *testing.T) {
 	}
 	engine := promqltest.NewTestEngineWithOpts(t, opts)
 	ruleManager := NewManager(&ManagerOptions{
-		Appendable: storage,
-		Queryable:  storage,
-		QueryFunc:  EngineQueryFunc(engine, storage),
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
+		AppendableV2: storage,
+		Queryable:    storage,
+		QueryFunc:    EngineQueryFunc(engine, storage),
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
 	})
 	var stopped bool
 	ruleManager.start()
@@ -1144,11 +1144,11 @@ func TestMetricsStalenessOnManagerShutdown(t *testing.T) {
 	}
 	engine := promqltest.NewTestEngineWithOpts(t, opts)
 	ruleManager := NewManager(&ManagerOptions{
-		Appendable: storage,
-		Queryable:  storage,
-		QueryFunc:  EngineQueryFunc(engine, storage),
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
+		AppendableV2: storage,
+		Queryable:    storage,
+		QueryFunc:    EngineQueryFunc(engine, storage),
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
 	})
 	var stopped bool
 	ruleManager.start()
@@ -1214,11 +1214,11 @@ func TestRuleMovedBetweenGroups(t *testing.T) {
 	}
 	engine := promql.NewEngine(opts)
 	ruleManager := NewManager(&ManagerOptions{
-		Appendable: storage,
-		Queryable:  storage,
-		QueryFunc:  EngineQueryFunc(engine, storage),
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
+		AppendableV2: storage,
+		Queryable:    storage,
+		QueryFunc:    EngineQueryFunc(engine, storage),
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
 	})
 	var stopped bool
 	ruleManager.start()
@@ -1296,11 +1296,11 @@ func TestRuleHealthUpdates(t *testing.T) {
 	}
 	engine := promqltest.NewTestEngineWithOpts(t, engineOpts)
 	opts := &ManagerOptions{
-		QueryFunc:  EngineQueryFunc(engine, st),
-		Appendable: st,
-		Queryable:  st,
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
+		QueryFunc:    EngineQueryFunc(engine, st),
+		AppendableV2: st,
+		Queryable:    st,
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
 	}
 
 	expr, err := testParser.ParseExpr("a + 1")
@@ -1395,7 +1395,7 @@ func TestRuleGroupEvalIterationFunc(t *testing.T) {
 	testFunc := func(tst testInput) {
 		opts := &ManagerOptions{
 			QueryFunc:       EngineQueryFunc(ng, storage),
-			Appendable:      storage,
+			AppendableV2:    storage,
 			Queryable:       storage,
 			Context:         context.Background(),
 			Logger:          promslog.NewNopLogger(),
@@ -1477,11 +1477,11 @@ func TestNativeHistogramsInRecordingRules(t *testing.T) {
 
 	ng := testEngine(t)
 	opts := &ManagerOptions{
-		QueryFunc:  EngineQueryFunc(ng, storage),
-		Appendable: storage,
-		Queryable:  storage,
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
+		QueryFunc:    EngineQueryFunc(ng, storage),
+		AppendableV2: storage,
+		Queryable:    storage,
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
 	}
 
 	expr, err := testParser.ParseExpr("sum(histogram_metric)")
@@ -1543,10 +1543,10 @@ func TestManager_LoadGroups_ShouldCheckWhetherEachRuleHasDependentsAndDependenci
 	storage := teststorage.New(t)
 
 	ruleManager := NewManager(&ManagerOptions{
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
-		Appendable: storage,
-		QueryFunc:  func(context.Context, string, time.Time) (promql.Vector, error) { return nil, nil },
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
+		AppendableV2: storage,
+		QueryFunc:    func(context.Context, string, time.Time) (promql.Vector, error) { return nil, nil },
 	})
 
 	t.Run("load a mix of dependent and independent rules", func(t *testing.T) {
@@ -1972,11 +1972,11 @@ func TestDependencyMapUpdatesOnGroupUpdate(t *testing.T) {
 
 	files := []string{"fixtures/rules.yaml"}
 	ruleManager := NewManager(&ManagerOptions{
-		Appendable: storage,
-		Queryable:  storage,
-		QueryFunc:  EngineQueryFunc(engine, storage),
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
+		AppendableV2: storage,
+		Queryable:    storage,
+		QueryFunc:    EngineQueryFunc(engine, storage),
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
 	})
 
 	ruleManager.start()
@@ -2369,7 +2369,7 @@ func TestNewRuleGroupRestoration(t *testing.T) {
 
 	option := optsFactory(store, &maxInflight, &inflightQueries, maxConcurrency)
 	option.Queryable = store
-	option.Appendable = store
+	option.AppendableV2 = store
 	option.NotifyFunc = func(context.Context, string, ...*Alert) {}
 
 	var evalCount atomic.Int32
@@ -2433,7 +2433,7 @@ func TestNewRuleGroupRestorationWithRestoreNewGroupOption(t *testing.T) {
 
 	option := optsFactory(store, &maxInflight, &inflightQueries, maxConcurrency)
 	option.Queryable = store
-	option.Appendable = store
+	option.AppendableV2 = store
 	option.RestoreNewRuleGroups = true
 	option.NotifyFunc = func(context.Context, string, ...*Alert) {}
 
@@ -2574,7 +2574,7 @@ func optsFactory(storage storage.Storage, maxInflight, inflightQueries *atomic.I
 		Logger:                 promslog.NewNopLogger(),
 		ConcurrentEvalsEnabled: concurrent,
 		MaxConcurrentEvals:     maxConcurrent,
-		Appendable:             storage,
+		AppendableV2:           storage,
 		QueryFunc: func(_ context.Context, _ string, ts time.Time) (promql.Vector, error) {
 			inflightMu.Lock()
 
@@ -2750,10 +2750,10 @@ func TestRuleDependencyController_AnalyseRules(t *testing.T) {
 			storage := teststorage.New(t)
 
 			ruleManager := NewManager(&ManagerOptions{
-				Context:    context.Background(),
-				Logger:     promslog.NewNopLogger(),
-				Appendable: storage,
-				QueryFunc:  func(context.Context, string, time.Time) (promql.Vector, error) { return nil, nil },
+				Context:      context.Background(),
+				Logger:       promslog.NewNopLogger(),
+				AppendableV2: storage,
+				QueryFunc:    func(context.Context, string, time.Time) (promql.Vector, error) { return nil, nil },
 			})
 
 			groups, errs := ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, false, tc.ruleFile)
@@ -2778,10 +2778,10 @@ func BenchmarkRuleDependencyController_AnalyseRules(b *testing.B) {
 	storage := teststorage.New(b)
 
 	ruleManager := NewManager(&ManagerOptions{
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
-		Appendable: storage,
-		QueryFunc:  func(context.Context, string, time.Time) (promql.Vector, error) { return nil, nil },
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
+		AppendableV2: storage,
+		QueryFunc:    func(context.Context, string, time.Time) (promql.Vector, error) { return nil, nil },
 	})
 
 	groups, errs := ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, false, "fixtures/rules_multiple.yaml")

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -356,11 +356,11 @@ func (m *rulesRetrieverMock) CreateRuleGroups() {
 	}
 	engine := promqltest.NewTestEngineWithOpts(m.testing, engineOpts)
 	opts := &rules.ManagerOptions{
-		QueryFunc:  rules.EngineQueryFunc(engine, s),
-		Appendable: s,
-		Context:    context.Background(),
-		Logger:     promslog.NewNopLogger(),
-		NotifyFunc: func(context.Context, string, ...*rules.Alert) {},
+		QueryFunc:    rules.EngineQueryFunc(engine, s),
+		AppendableV2: s,
+		Context:      context.Background(),
+		Logger:       promslog.NewNopLogger(),
+		NotifyFunc:   func(context.Context, string, ...*rules.Alert) {},
 	}
 
 	var r []rules.Rule


### PR DESCRIPTION
Part of #17632. **Stacked on top of #19455** (mandatory, batched `AppendExemplars`) — base branch is `krajo/appenderv2-mandatory-exemplars`.

TL;DR: trivial switch of rule evaluations to AppenderV2, due to having no metadata or exemplars or indeed start timestamps.

## What

Rule evaluation (`rules/group.go`) and stale-series cleanup are ported from V1 `storage.Appender` to `storage.AppenderV2`:

- `ManagerOptions.Appendable storage.Appendable` becomes `AppendableV2 storage.AppendableV2`.
- Both `g.opts.Appendable.Appender(ctx)` call sites (`Eval`, `cleanupStaleSeries`) become `g.opts.AppendableV2.AppenderV2(ctx)`.
- The `AppendHistogram` / `Append` / `SetOptions` trio collapses into the unified `Append(ref, ls, st, t, v, h, fh, opts)` call. `AppenderV2` has no `SetOptions` — options are passed per call — so `g.appOpts` changes from `*storage.AppendOptions{DiscardOutOfOrder: true}` to `storage.AOptions{RejectOutOfOrder: true}` and is passed directly on every `Append` call (sample results, histogram results, and stale markers) instead of being set once on the appender.

### Incidental behaviour fix

In the old code, `SetOptions` was only called immediately before the plain-float `Append` branch, never before `AppendHistogram`. Since `SetOptions` mutates shared appender state, a histogram result only got `DiscardOutOfOrder` if a float result happened to be processed first in the same evaluation; a rule group returning only histograms got none. Passing `g.appOpts` explicitly on every `Append` call (float, histogram, and stale marker alike) makes this consistent regardless of sample type or order.

## Wiring

- `cmd/prometheus/main.go`: `Appendable: fanoutStorage` → `AppendableV2: fanoutStorage` (already implements it).
- `cmd/promtool/unittest.go`: `Appendable: suite.Storage()` → `AppendableV2: suite.Storage()` (already implements it via `promqltest`).

## Tests

`rules/manager_test.go` and `web/api/v1/api_test.go` just rename the field — no mock changes needed, since `teststorage.TestStorage` and `promqltest.LoadedStorage` already implement `AppenderV2` by embedding `*tsdb.DB`.

```release-notes
NONE
```