### PR TITLE
tsdb: cache all symbols for lookup

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1153,12 +1153,12 @@ func (r *Reader) PostingsRanges() (map[labels.Label]Range, error) {
 }
 
 type Symbols struct {
-	bs      ByteSlice
-	version int
-	off     int
-
-	offsets []int
-	seen    int
+	bs          ByteSlice         // Index data.
+	lookupCache map[uint32]string // V1 offset / V2+ ID -> symbol string value.
+	offsets     []int             // Byte offsets for every symbolFactor symbol.
+	seen        int               // Count of symbols read from the table.
+	version     int               // Index format version.
+	off         int               // Start of the symbol table.
 }
 
 const symbolFactor = 32
@@ -1177,11 +1177,17 @@ func NewSymbols(bs ByteSlice, version, off int) (*Symbols, error) {
 		basePos = off + 4
 	)
 	s.offsets = make([]int, 0, 1+cnt/symbolFactor)
+	s.lookupCache = make(map[uint32]string, cnt)
 	for d.Err() == nil && s.seen < cnt {
+		offset := basePos + origLen - d.Len()
 		if s.seen%symbolFactor == 0 {
-			s.offsets = append(s.offsets, basePos+origLen-d.Len())
+			s.offsets = append(s.offsets, offset)
 		}
-		d.UvarintBytes() // The symbol.
+		cacheKey := uint32(s.seen)
+		if version == FormatV1 {
+			cacheKey = uint32(offset)
+		}
+		s.lookupCache[cacheKey] = d.UvarintStr()
 		s.seen++
 	}
 	if d.Err() != nil {
@@ -1191,25 +1197,9 @@ func NewSymbols(bs ByteSlice, version, off int) (*Symbols, error) {
 }
 
 func (s Symbols) Lookup(o uint32) (string, error) {
-	d := encoding.Decbuf{
-		B: s.bs.Range(0, s.bs.Len()),
-	}
-
-	if s.version == FormatV1 {
-		d.Skip(int(o))
-	} else {
-		if int(o) >= s.seen {
-			return "", fmt.Errorf("unknown symbol offset %d", o)
-		}
-		d.Skip(s.offsets[int(o/symbolFactor)])
-		// Walk until we find the one we want.
-		for i := o - (o / symbolFactor * symbolFactor); i > 0; i-- {
-			d.UvarintBytes()
-		}
-	}
-	sym := d.UvarintStr()
-	if d.Err() != nil {
-		return "", d.Err()
+	sym, ok := s.lookupCache[o]
+	if !ok {
+		return "", fmt.Errorf("unknown symbol offset %d", o)
 	}
 	return sym, nil
 }

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -502,6 +502,22 @@ func TestSymbols(t *testing.T) {
 		i++
 	}
 	require.NoError(t, iter.Err())
+
+	// Cached symbols do not change with the source buffer.
+	v1Symbols, err := NewSymbols(realByteSlice(buf.Get()), FormatV1, symbolsStart)
+	require.NoError(t, err)
+	symbolOffset := symbolsStart + 8 + 99*2
+	sym, err := v1Symbols.Lookup(uint32(symbolOffset))
+	require.NoError(t, err)
+	require.Equal(t, "c", sym)
+
+	buf.Get()[symbolOffset+1] = 'x'
+	sym, err = s.Lookup(99)
+	require.NoError(t, err)
+	require.Equal(t, "c", sym)
+	sym, err = v1Symbols.Lookup(uint32(symbolOffset))
+	require.NoError(t, err)
+	require.Equal(t, "c", sym)
 }
 
 func BenchmarkReader_ShardedPostings(b *testing.B) {


### PR DESCRIPTION
Serve Lookup calls from the cache to avoid repeated decoding and allocations.

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: 13th Gen Intel(R) Core(TM) i7-13800H
                                       │ before.txt  │              after.txt              │
                                       │   sec/op    │   sec/op     vs base                │
QuerierSelect/Block/1of1000000-4         239.5m ± 0%   209.8m ± 1%  -12.42% (p=0.000 n=10)
QuerierSelect/Block/10of1000000-4        239.5m ± 0%   213.4m ± 2%  -10.90% (p=0.000 n=10)
QuerierSelect/Block/100of1000000-4       239.6m ± 0%   207.8m ± 1%  -13.24% (p=0.000 n=10)
QuerierSelect/Block/1000of1000000-4      239.5m ± 0%   210.4m ± 1%  -12.18% (p=0.000 n=10)
QuerierSelect/Block/10000of1000000-4     240.4m ± 0%   210.5m ± 1%  -12.42% (p=0.000 n=10)
QuerierSelect/Block/100000of1000000-4    248.3m ± 0%   221.7m ± 1%  -10.73% (p=0.000 n=10)
QuerierSelect/Block/1000000of1000000-4   322.1m ± 7%   271.8m ± 1%  -15.61% (p=0.000 n=10)
geomean                                  251.3m        219.9m       -12.51%

                                       │    before.txt    │               after.txt               │
                                       │       B/op       │     B/op      vs base                 │
QuerierSelect/Block/1of1000000-4          51200632.0 ± 0%     632.0 ± 1%  -100.00% (p=0.000 n=10)
QuerierSelect/Block/10of1000000-4        50001.602Ki ± 0%   1.602Ki ± 0%  -100.00% (p=0.000 n=10)
QuerierSelect/Block/100of1000000-4        50011.45Ki ± 0%   11.45Ki ± 0%   -99.98% (p=0.000 n=10)
QuerierSelect/Block/1000of1000000-4        50109.9Ki ± 0%   109.9Ki ± 0%   -99.78% (p=0.000 n=10)
QuerierSelect/Block/10000of1000000-4        49.897Mi ± 0%   1.069Mi ± 0%   -97.86% (p=0.000 n=10)
QuerierSelect/Block/100000of1000000-4        59.51Mi ± 0%   10.68Mi ± 0%   -82.05% (p=0.000 n=10)
QuerierSelect/Block/1000000of1000000-4       155.6Mi ± 0%   106.8Mi ± 0%   -31.37% (p=0.000 n=10)
geomean                                      59.48Mi        149.0Ki        -99.76%

                                       │   before.txt    │              after.txt               │
                                       │    allocs/op    │  allocs/op   vs base                 │
QuerierSelect/Block/1of1000000-4         2000011.00 ± 0%    11.00 ± 0%  -100.00% (p=0.000 n=10)
QuerierSelect/Block/10of1000000-4        2000029.00 ± 0%    29.00 ± 0%  -100.00% (p=0.000 n=10)
QuerierSelect/Block/100of1000000-4        2000209.0 ± 0%    209.0 ± 0%   -99.99% (p=0.000 n=10)
QuerierSelect/Block/1000of1000000-4       2002.009k ± 0%   2.009k ± 0%   -99.90% (p=0.000 n=10)
QuerierSelect/Block/10000of1000000-4       2020.01k ± 0%   20.01k ± 0%   -99.01% (p=0.000 n=10)
QuerierSelect/Block/100000of1000000-4       2200.0k ± 0%   200.0k ± 0%   -90.91% (p=0.000 n=10)
QuerierSelect/Block/1000000of1000000-4       4.000M ± 0%   2.000M ± 0%   -50.00% (p=0.000 n=10)
geomean                                      2.242M        2.709k        -99.88%
```

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[PERF] tsdb: cache all symbols for lookup
```
