### PR TITLE
perf: save some struct alignment space

### DIFF
--- a/model/histogram/histogram.go
+++ b/model/histogram/histogram.go
@@ -534,7 +534,6 @@ type cumulativeBucketIterator struct {
 	posBucketsIdx int    // Index in h.PositiveBuckets.
 	idxInSpan     uint32 // Index in the current span. 0 <= idxInSpan < span.Length.
 
-	initialized         bool
 	currIdx             int32   // The actual bucket index after decoding from spans.
 	currUpper           float64 // The upper boundary of the current bucket.
 	currCount           int64   // Current non-cumulative count for the current bucket. Does not apply for empty bucket.
@@ -545,6 +544,8 @@ type cumulativeBucketIterator struct {
 	// When we hit the end of a span, we use this to iterate
 	// through the empty buckets.
 	emptyBucketCount int32
+
+	initialized bool
 }
 
 func (c *cumulativeBucketIterator) Next() bool {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -910,28 +910,28 @@ type scrapeLoop struct {
 	appendableV2 storage.AppendableV2
 	buffers      *pool.Pool
 
-	synthesizeST bool
-	offsetSeed   uint64
-	symbolTable  *labels.SymbolTable
-	metrics      *scrapeMetrics
+	offsetSeed  uint64
+	symbolTable *labels.SymbolTable
+	metrics     *scrapeMetrics
 
 	// Options from config.ScrapeConfig.
 	sampleLimit                   int
 	bucketLimit                   int
-	maxSchema                     int32
 	labelLimits                   *labelLimits
+	fallbackScrapeProtocol        string
+	mrc                           []*relabel.Config
+	validationScheme              model.ValidationScheme
+	maxSchema                     int32
 	honorLabels                   bool
 	honorTimestamps               bool
 	trackTimestampsStaleness      bool
 	enableNativeHistogramScraping bool
 	alwaysScrapeClassicHist       bool
 	convertClassicHistToNHCB      bool
-	fallbackScrapeProtocol        string
 	enableCompression             bool
-	mrc                           []*relabel.Config
-	validationScheme              model.ValidationScheme
 
 	// Options from scrape.Options.
+	synthesizeST            bool
 	enableSTZeroIngestion   bool
 	parseST                 bool // Used by AppenderV2 only.
 	enableTypeAndUnitLabels bool

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -240,11 +240,11 @@ type xorIterator struct {
 	numTotal uint16
 	numRead  uint16
 
-	t   int64
-	val float64
-
 	leading  uint8
 	trailing uint8
+
+	t   int64
+	val float64
 
 	tDelta uint64
 	err    error

--- a/tsdb/chunks/chunk_write_queue.go
+++ b/tsdb/chunks/chunk_write_queue.go
@@ -36,12 +36,12 @@ const (
 )
 
 type chunkWriteJob struct {
-	cutFile   bool
 	seriesRef HeadSeriesRef
 	mint      int64
 	maxt      int64
 	chk       chunkenc.Chunk
 	ref       ChunkDiskMapperRef
+	cutFile   bool
 	isOOO     bool
 	callback  func(error)
 }


### PR DESCRIPTION
Similar to #14484 and #16826 but I only did a few that seemed most impactful.

```
scrapeLoop               goes from 400(416) to 376(384)
xorIterator              goes from 104(112) to  96
cumulativeBucketIterator goes from  72(80)  to  64
chunkWriteJob            goes from  72(80)  to  64
```

Size in brackets is the size a heap allocation gets rounded up to (the "class" in Go runtime).

I used the tool `github.com/dkorunic/betteralign/cmd/betteralign`.

I did not bother with any "pointer bytes" reductions since I understand the Go "green tea" garbage collector now scans everything.

```release-notes
NONE
```
