### PR TITLE
storage: re-enable TestFanoutErrors chunk querier subtest

### DIFF
--- a/storage/fanout_test.go
+++ b/storage/fanout_test.go
@@ -288,7 +288,6 @@ func TestFanoutErrors(t *testing.T) {
 			}
 		})
 		t.Run("chunks", func(t *testing.T) {
-			t.Skip("enable once TestStorage and TSDB implements ChunkQuerier")
 			querier, err := fanoutStorage.ChunkQuerier(0, 8000)
 			require.NoError(t, err)
 			defer querier.Close()


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None.

The `chunks` subtest of `TestFanoutErrors` (`storage/fanout_test.go`) has
been skipped since 2020 with the note:

> enable once TestStorage and TSDB implements ChunkQuerier

Both the `teststorage` helper (backed by TSDB) and the error test doubles
in this file (`errStorage.ChunkQuerier` / `errChunkQuerier.Select`) now
implement `ChunkQuerier`, so the precondition in the skip note is satisfied.
Removing the skip makes the subtest exercise the fanout `ChunkQuerier`
error and warning propagation, mirroring the already-active `samples`
subtest.

Verification:
- `go test ./storage/ -run TestFanoutErrors -v`: the two `chunks` subtests
  now run and PASS (previously SKIP).
- Confirmed the reactivated subtest actually asserts: temporarily returning
  a different error from `errChunkQuerier.Select` makes the `chunks`
  subtests FAIL, so they are not vacuous.
- `go test ./storage/` passes for the whole package.

Change is a single-line deletion of the `t.Skip(...)` call.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```

