### PR TITLE
test(remote storage): fix some issues in benchmarks

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -1854,8 +1854,8 @@ func BenchmarkBuildWriteRequest(b *testing.B) {
 				b.Fatal(err)
 			}
 			totalSize += len(req)
-			b.ReportMetric(float64(totalSize)/float64(b.N), "compressedSize/op")
 		}
+		b.ReportMetric(float64(totalSize)/float64(b.N), "compressedSize/op")
 	}
 
 	twoBatch := createDummyTimeSeries(2)
@@ -1902,8 +1902,8 @@ func BenchmarkBuildV2WriteRequest(b *testing.B) {
 				b.Fatal(err)
 			}
 			totalSize += len(req)
-			b.ReportMetric(float64(totalSize)/float64(b.N), "compressedSize/op")
 		}
+		b.ReportMetric(float64(totalSize)/float64(b.N), "compressedSize/op")
 	}
 
 	twoBatch := createDummyTimeSeries(2)

--- a/storage/remote/write_otlp_handler_test.go
+++ b/storage/remote/write_otlp_handler_test.go
@@ -603,6 +603,7 @@ func (discardAppender) Rollback() error {
 }
 
 func BenchmarkOTLP(b *testing.B) {
+	b.Skip("Not supported by teststorage Appender")
 	start := time.Date(2000, 1, 2, 3, 4, 5, 0, time.UTC)
 
 	type Type struct {


### PR DESCRIPTION
`b.N` is zero inside a loop governed by `b.Loop`, so we have to move that outside the loop.

And `BenchmarkOTLP` fails every time with an error like this:

```
teststorage.Appendable.AppenderV2() concurrent use is not supported; attempted opening new AppenderV2() without Commit/Rollback of the previous one. Extend the implementation if concurrent mock is needed
```

so I put a `Skip` in until someone more familiar can fix that up.

```release-notes
NONE
```
