### PR TITLE
scrape: test JSON log target formatting

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -8070,6 +8071,39 @@ func BenchmarkScrapePoolRestartLoops(b *testing.B) {
 	for b.Loop() {
 		sp.restartLoops(true)
 	}
+}
+
+func TestNewScrapeLoopJSONLoggerTarget(t *testing.T) {
+	const (
+		targetAddress = "test.invalid:80"
+		wantTarget    = "http://test.invalid:80/metrics"
+	)
+
+	var output bytes.Buffer
+	format := promslog.NewFormat()
+	require.NoError(t, format.Set("json"))
+
+	sp := newTestScrapePool(t, nil, false, nil)
+	sp.logger = promslog.New(&promslog.Config{
+		Format: format,
+		Writer: &output,
+	})
+	target := newTestTarget(targetAddress, 0, labels.EmptyLabels())
+
+	sl := newScrapeLoop(scrapeLoopOptions{
+		target: target,
+		cache:  newScrapeCache(sp.metrics),
+		sp:     sp,
+	})
+	t.Cleanup(sl.cancel)
+
+	sl.l.Warn("test message")
+
+	var entry struct {
+		Target string `json:"target"`
+	}
+	require.NoError(t, json.Unmarshal(output.Bytes(), &entry))
+	require.Equal(t, wantTarget, entry.Target)
 }
 
 // TestNewScrapeLoopHonorLabelsWiring verifies that newScrapeLoop correctly wires


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
Adds regression coverage for the JSON log `target` field fixed in #19472.
The test verifies that the scrape target is logged as a URL string instead of an empty JSON object.


#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Follow-up to #19472

#### Validation

Ran the targeted regression test and the full `scrape` package test against both the pre-fix and fixed implementations.

Before the fix:

```go
l: opts.sp.logger.With("target", opts.target),
```

The regression test failed as expected:

```console
$ go test -count=1 ./scrape -run '^TestNewScrapeLoopJSONLoggerTarget$'
--- FAIL: TestNewScrapeLoopJSONLoggerTarget (0.00s)
    Error: json: cannot unmarshal object into Go struct field .target of type string
FAIL
FAIL    github.com/prometheus/prometheus/scrape    1.052s
FAIL

$ go test -count=1 ./scrape
--- FAIL: TestNewScrapeLoopJSONLoggerTarget (0.00s)
    Error: json: cannot unmarshal object into Go struct field .target of type string
FAIL
FAIL    github.com/prometheus/prometheus/scrape    30.662s
FAIL
```

After the fix:

```go
l: opts.sp.logger.With("target", opts.target.String()),
```

Both tests passed:

```console
$ go test -count=1 ./scrape -run '^TestNewScrapeLoopJSONLoggerTarget$'
ok      github.com/prometheus/prometheus/scrape    1.007s

$ go test -count=1 ./scrape
ok      github.com/prometheus/prometheus/scrape    30.169s
```

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
