### PR TITLE
scrape: reject zstd responses when the feature flag is off

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -406,3 +406,5 @@ instead.
 `--enable-feature=zstd-scrape`
 
 When enabled, Prometheus advertises support for Zstandard-compressed scrape responses in addition to gzip. The uncompressed response remains subject to the configured `body_size_limit`.
+
+When the flag is disabled, Prometheus does not advertise `zstd`. A target that answers with `Content-Encoding: zstd` regardless fails the scrape, because Prometheus cannot decode the body.

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -767,7 +767,10 @@ type targetScraper struct {
 	metrics *scrapeMetrics
 }
 
-var errBodySizeLimit = errors.New("body size limit exceeded")
+var (
+	errBodySizeLimit  = errors.New("body size limit exceeded")
+	errZstdNotEnabled = errors.New(`received a zstd-compressed response, but the "zstd-scrape" feature flag is not enabled`)
+)
 
 const zstdMaxWindowSize = 8 << 20
 
@@ -871,7 +874,9 @@ func (s *targetScraper) readResponse(_ context.Context, resp *http.Response, w i
 		reader = s.gzipr
 	case "zstd":
 		if !s.enableZstd {
-			break
+			// Nothing here can decode the body, and passing the raw frame on
+			// would hand a zstd stream to the metrics parser.
+			return "", errZstdNotEnabled
 		}
 		if s.Target == nil {
 			s.logger.Debug("Using zstd-compressed scrape response")

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -5399,6 +5399,58 @@ func TestTargetScraperZstdWindowLimit(t *testing.T) {
 	require.ErrorContains(t, err, "decompressed size exceeds configured limit")
 }
 
+func TestTargetScraperZstdFeatureFlag(t *testing.T) {
+	const responseBody = "metric_a 1\nmetric_b 2\n"
+
+	encoder, err := zstd.NewWriter(nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { encoder.Close() })
+	compressed := encoder.EncodeAll([]byte(responseBody), nil)
+
+	for _, tc := range []struct {
+		name       string
+		enableZstd bool
+		expectErr  string
+	}{
+		{
+			name:       "enabled decompresses the body",
+			enableZstd: true,
+		},
+		{
+			name:       "disabled rejects the response",
+			enableZstd: false,
+			expectErr:  "zstd-scrape",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Encoding": []string{"zstd"},
+				},
+				Body: io.NopCloser(bytes.NewReader(compressed)),
+			}
+			ts := &targetScraper{
+				bodySizeLimit: math.MaxInt64,
+				metrics:       newTestScrapeMetrics(t),
+				enableZstd:    tc.enableZstd,
+				logger:        promslog.NewNopLogger(),
+			}
+
+			var buf bytes.Buffer
+			_, err := ts.readResponse(context.Background(), resp, &buf)
+			if tc.expectErr != "" {
+				require.ErrorContains(t, err, tc.expectErr)
+				// The undecoded frame must not reach the parser.
+				require.Empty(t, buf.String())
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, responseBody, buf.String())
+		})
+	}
+}
+
 // testScraper implements the scraper interface and allows setting values
 // returned by its methods. It also allows setting a custom scrape function.
 type testScraper struct {


### PR DESCRIPTION
`readResponse` matches `Content-Encoding: zstd` and then uses `break` to skip decompression when the `zstd-scrape` feature flag is disabled. `break` only leaves the `switch`, so `reader` stays `resp.Body`, the raw zstd frame is copied into the scrape buffer and handed to the metrics parser.

Observed against a server that answers with `Content-Encoding: zstd` while the flag is off:

```
enableZstd=false  ct="text/plain"  err=<nil>  out="(\xb5/\xfd\x04\x00\xb1\x00\x00metric_a 1\nmetric_b 2\nߨ\xb62"
enableZstd=true   ct="text/plain"  err=<nil>  out="metric_a 1\nmetric_b 2\n"
```

The scrape then fails inside the parser with `expected a valid start token, got "("`, which points at the metrics text rather than at the encoding. Prometheus only advertises `zstd` when the flag is on, so this needs a target or proxy that compresses regardless of `Accept-Encoding`, which RFC 9110 §12.5.3 forbids but is not rare.

Return an explicit error instead. This mirrors how the unified OTLP handler rejects a `Content-Encoding` it cannot decode (`storage/remote/codec.go`), and how the OpenMetrics 2.0 content type is rejected when its feature flag is off (`model/textparse/interface.go`).

Out of scope: the `switch` still passes any other unknown `Content-Encoding` through undecoded. That predates zstd support, and rejecting it would break targets that send a bogus header with an uncompressed body, so it is left alone.

Introduced in [#19502](https://redirect.github.com/prometheus/prometheus/pull/19502).

```release-notes
NONE
```
