### PR TITLE
logging: move Kube deprecation warning logger to cmd/prometheus

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -921,7 +921,7 @@ func main() {
 	klog.SetOutputBySeverity("INFO", klogv1Writer{})
 	// Avoid duplicate API deprecation warnings (e.g., "v1 Endpoints is deprecated in v1.33+...")
 	// that can pollute the logs.
-	rest.SetDefaultWarningHandlerWithContext(logging.NewDedupDeprecationWarningLogger())
+	rest.SetDefaultWarningHandlerWithContext(newDedupDeprecationWarningLogger())
 
 	modeAppName := "Prometheus Server"
 	mode := "server"

--- a/cmd/prometheus/warnings.go
+++ b/cmd/prometheus/warnings.go
@@ -1,0 +1,63 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"sync"
+
+	"github.com/grafana/regexp"
+	"k8s.io/client-go/rest"
+)
+
+// deprecationRegex matches the format of Kubernetes API deprecation warnings:
+// See https://github.com/kubernetes/kubernetes/blob/da663405beb487d66c27a0220ea4073305ae9077/staging/src/k8s.io/apiserver/pkg/endpoints/deprecation/deprecation.go#L117.
+var deprecationRegex = regexp.MustCompile(`\S+ \S+ is deprecated in v\d+\.\d+\+`)
+
+// Even though deprecation warnings should be bounded in number, this safeguard should help prevent leaks.
+const maxDeprecationWarnings = 32
+
+// dedupDeprecationWarningLogger deduplicates Kube API deprecation warnings by message before logging them.
+// Inspired by https://github.com/kubernetes/kubernetes/blob/3edae6c1c49958fd10a708d9cc8c4c9e7f5fb6e8/staging/src/k8s.io/client-go/rest/warnings.go#L113
+type dedupDeprecationWarningLogger struct {
+	logger rest.WarningHandlerWithContext
+	lock   sync.Mutex
+	logged map[string]struct{}
+}
+
+func newDedupDeprecationWarningLogger() *dedupDeprecationWarningLogger {
+	return &dedupDeprecationWarningLogger{
+		logger: rest.WarningLogger{},
+		logged: make(map[string]struct{}),
+	}
+}
+
+func (w *dedupDeprecationWarningLogger) HandleWarningHeaderWithContext(ctx context.Context, code int, agent, message string) {
+	if code != 299 || message == "" {
+		return
+	}
+
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	if _, seen := w.logged[message]; seen {
+		return
+	}
+
+	if deprecationRegex.MatchString(message) && len(w.logged) < maxDeprecationWarnings {
+		w.logged[message] = struct{}{}
+	}
+
+	w.logger.HandleWarningHeaderWithContext(ctx, code, agent, message)
+}

--- a/cmd/prometheus/warnings_test.go
+++ b/cmd/prometheus/warnings_test.go
@@ -1,0 +1,52 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeWarningLogger struct {
+	logs []string
+}
+
+func (fl *fakeWarningLogger) HandleWarningHeaderWithContext(_ context.Context, _ int, _, message string) {
+	fl.logs = append(fl.logs, message)
+}
+
+func TestDedupeDeprecationWarningLogger(t *testing.T) {
+	wl := dedupDeprecationWarningLogger{
+		logger: &fakeWarningLogger{},
+		logged: make(map[string]struct{}),
+	}
+
+	deprecationMessage := "v1 Endpoints is deprecated in v1.33+; use [discovery.k8s.io/v1](http://discovery.k8s.io/v1) EndpointSlice"
+	for range 10 {
+		wl.HandleWarningHeaderWithContext(context.Background(), 299, "", deprecationMessage)
+	}
+	require.Len(t, wl.logger.(*fakeWarningLogger).logs, 1)
+	require.Len(t, wl.logged, 1)
+	require.Equal(t, wl.logger.(*fakeWarningLogger).logs[0], deprecationMessage)
+
+	for i := range 10 {
+		wl.HandleWarningHeaderWithContext(context.Background(), 299, "", fmt.Sprintf("some other warning %d", i+1))
+	}
+	require.Len(t, wl.logger.(*fakeWarningLogger).logs, 11)
+	require.Len(t, wl.logged, 1)
+	require.Equal(t, "some other warning 10", wl.logger.(*fakeWarningLogger).logs[10])
+}

--- a/util/logging/dedupe.go
+++ b/util/logging/dedupe.go
@@ -18,9 +18,6 @@ import (
 	"log/slog"
 	"sync"
 	"time"
-
-	"github.com/grafana/regexp"
-	"k8s.io/client-go/rest"
 )
 
 const (
@@ -136,45 +133,4 @@ func (d *Deduper) run() {
 			return
 		}
 	}
-}
-
-// deprecationRegex matches the format of Kubernetes API deprecation warnings:
-// See https://github.com/kubernetes/kubernetes/blob/da663405beb487d66c27a0220ea4073305ae9077/staging/src/k8s.io/apiserver/pkg/endpoints/deprecation/deprecation.go#L117.
-var deprecationRegex = regexp.MustCompile(`\S+ \S+ is deprecated in v\d+\.\d+\+`)
-
-// Even though deprecation warnings should be bounded in number, this safeguard should help prevent leaks.
-const maxDeprecationWarnings = 32
-
-// DedupDeprecationWarningLogger deduplicates Kube API deprecation warnings by message before logging them.
-// Inspired by https://github.com/kubernetes/kubernetes/blob/3edae6c1c49958fd10a708d9cc8c4c9e7f5fb6e8/staging/src/k8s.io/client-go/rest/warnings.go#L113
-type DedupDeprecationWarningLogger struct {
-	logger rest.WarningHandlerWithContext
-	lock   sync.Mutex
-	logged map[string]struct{}
-}
-
-func NewDedupDeprecationWarningLogger() *DedupDeprecationWarningLogger {
-	return &DedupDeprecationWarningLogger{
-		logger: rest.WarningLogger{},
-		logged: make(map[string]struct{}),
-	}
-}
-
-func (w *DedupDeprecationWarningLogger) HandleWarningHeaderWithContext(ctx context.Context, code int, agent, message string) {
-	if code != 299 || message == "" {
-		return
-	}
-
-	w.lock.Lock()
-	defer w.lock.Unlock()
-
-	if _, seen := w.logged[message]; seen {
-		return
-	}
-
-	if deprecationRegex.MatchString(message) && len(w.logged) < maxDeprecationWarnings {
-		w.logged[message] = struct{}{}
-	}
-
-	w.logger.HandleWarningHeaderWithContext(ctx, code, agent, message)
 }

--- a/util/logging/dedupe_test.go
+++ b/util/logging/dedupe_test.go
@@ -15,8 +15,6 @@ package logging
 
 import (
 	"bytes"
-	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -81,34 +79,4 @@ func TestDedupeConcurrent(t *testing.T) {
 	}
 
 	require.NotPanics(t, func() { concurrentWriteFunc() })
-}
-
-type fakeWarningLogger struct {
-	logs []string
-}
-
-func (fl *fakeWarningLogger) HandleWarningHeaderWithContext(_ context.Context, _ int, _, message string) {
-	fl.logs = append(fl.logs, message)
-}
-
-func TestDedupeDeprecationWarningLogger(t *testing.T) {
-	wl := DedupDeprecationWarningLogger{
-		logger: &fakeWarningLogger{},
-		logged: make(map[string]struct{}),
-	}
-
-	deprecationMessage := "v1 Endpoints is deprecated in v1.33+; use [discovery.k8s.io/v1](http://discovery.k8s.io/v1) EndpointSlice"
-	for range 10 {
-		wl.HandleWarningHeaderWithContext(context.Background(), 299, "", deprecationMessage)
-	}
-	require.Len(t, wl.logger.(*fakeWarningLogger).logs, 1)
-	require.Len(t, wl.logged, 1)
-	require.Equal(t, wl.logger.(*fakeWarningLogger).logs[0], deprecationMessage)
-
-	for i := range 10 {
-		wl.HandleWarningHeaderWithContext(context.Background(), 299, "", fmt.Sprintf("some other warning %d", i+1))
-	}
-	require.Len(t, wl.logger.(*fakeWarningLogger).logs, 11)
-	require.Len(t, wl.logged, 1)
-	require.Equal(t, "some other warning 10", wl.logger.(*fakeWarningLogger).logs[10])
 }


### PR DESCRIPTION
## What

`util/logging` imports `k8s.io/client-go/rest` for one Kubernetes-specific
helper, `DedupDeprecationWarningLogger`. This moves it to `cmd/prometheus`,
next to its only caller. No behaviour change.

## Why it's a problem

`util/logging` is imported by `promql`, `scrape` and `storage/remote`. All three
need only the Kubernetes-free parts (`JSONFileLogger`, `Deduper`) — but they
link client-go anyway, so every downstream project embedding them pulls in
**79 Kubernetes packages it can never reach**.

The linker keeps them. Measured on a service that embeds `promql` and imports no
Kubernetes code of its own: 2 837 `k8s.io` symbols in the binary and 53 `init`
functions running at every process start — DNS-1123 validation regexes, CBOR
serializer modes, apimachinery scheme registration. Removing the import drops it
from 124 to 107 modules, 822 to 726 packages, 51.3 to 47.7 MB, and also clears
`x/oauth2`, `x/term`, `x/time`, `fxamacker/cbor`, `sigs.k8s.io/*` and
`kube-openapi` from the SBOM.

## Where it came from

Two changes that were harmless on their own:

1. `promql/engine.go:132` imports `util/logging` for a single compile-time
   assertion, `var _ QueryLogger = (*logging.JSONFileLogger)(nil)` — the only
   non-test reference to `logging.` in the package. `scrape/scrape.go:77` does
   the same for `FailureLogger`.
2. #17829 added `DedupDeprecationWarningLogger` to `util/logging/dedupe.go`,
   beside the existing `Deduper`, bringing in `rest.WarningHandlerWithContext`
   and `rest.WarningLogger{}`.

Introduced in v3.11.0, still on `main`.

## The fix

`NewDedupDeprecationWarningLogger` has exactly one caller,
`cmd/prometheus/main.go:924`. Move the type, its regex, its constant and its
test there, unexported. `cmd/prometheus` already imports `client-go/rest` and
`klog`, so nothing new is pulled in.

`go list -deps | grep -c k8s.io`:

| Package | Before | After |
|---|---|---|
| `util/logging` | 79 | **0** |
| `promql` | 79 | **0** |
| `scrape` | 79 | 14 |
| `storage/remote` | 79 | 14 |

The remaining 14 arrive via `config` → `discovery`, which genuinely includes
Kubernetes SD — a real dependency, out of scope here.

`go build ./...`, `go vet` and `go test ./util/logging/... ./promql/...
./cmd/prometheus/...` pass.

## Notes

`DedupDeprecationWarningLogger` becomes unexported. It is an internal `util/`
package, added in v3.11.0, with no caller outside `cmd/prometheus`. If you'd
rather keep it exported, a `util/logging/k8s` subpackage is equivalent for the
dependency graph — happy to switch.

@machine424 @bboreham — you both have the context from #17829, so tagging you
here. Feedback welcome, in particular on whether to keep the type exported.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[CHANGE] logging: Move `DedupDeprecationWarningLogger` to `cmd/prometheus` and unexport it, so `promql`, `scrape` and `storage/remote` no longer pull in `k8s.io/client-go` (library use only). #19556
```
