### PR TITLE
promql: fix info() with mixed identifying-label presence

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -635,6 +635,11 @@ When only negated `__name__` matchers are provided (e.g.
 because negated matchers alone cannot positively identify which info
 metrics to consider.
 
+Identifying-label presence is evaluated per input series. Inputs containing
+only `job`, only `instance`, or both can therefore gain data labels from the
+corresponding info-series group; a missing identifying label is not treated as
+a wildcard.
+
 These limitations are partially defeating the purpose of the `info` function.
 At the current stage, this is an experiment to find out how useful the approach
 turns out to be in practice. A final version of the `info` function will indeed

--- a/promql/info.go
+++ b/promql/info.go
@@ -34,7 +34,7 @@ const targetInfo = "target_info"
 
 // identifyingLabels are the labels we consider as identifying for info metrics.
 // Currently hard coded, so we don't need knowledge of individual info metrics.
-var identifyingLabels = []string{"instance", "job"}
+var identifyingLabels = [...]string{"instance", "job"}
 
 // evalInfo implements the info PromQL function.
 func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (parser.Value, annotations.Annotations) {
@@ -245,27 +245,8 @@ func (ev *evaluator) fetchInfoSeries(ctx context.Context, mat Matrix, ignoreSeri
 		}
 	}
 
-	// A map of values for all identifying labels we are interested in.
-	idLblValues := map[string]map[string]struct{}{}
-	for _, s := range mat {
-		if _, exists := ignoreSeries[s.Metric.Hash()]; exists {
-			continue
-		}
-
-		// Register relevant values per identifying label for this series.
-		for _, l := range identifyingLabels {
-			val := s.Metric.Get(l)
-			if val == "" {
-				continue
-			}
-
-			if idLblValues[l] == nil {
-				idLblValues[l] = map[string]struct{}{}
-			}
-			idLblValues[l][val] = struct{}{}
-		}
-	}
-	if len(idLblValues) == 0 {
+	identifyingMatcherSets := infoIdentifyingMatcherSets(mat, ignoreSeries)
+	if len(identifyingMatcherSets) == 0 {
 		// Even when returning early, we need to remove __name__ from dataLabelMatchers
 		// since it's not a data label selector (it's used to select which info metrics
 		// to consider). Without this, combineWithInfoVector would incorrectly exclude
@@ -274,50 +255,135 @@ func (ev *evaluator) fetchInfoSeries(ctx context.Context, mat Matrix, ignoreSeri
 		return nil, nil, nil
 	}
 
-	// Generate regexps for every interesting value per identifying label.
-	var sb strings.Builder
-	idLblRegexps := make(map[string]string, len(idLblValues))
-	for name, vals := range idLblValues {
-		sb.Reset()
-		i := 0
-		for v := range vals {
-			if i > 0 {
-				sb.WriteRune('|')
-			}
-			sb.WriteString(regexp.QuoteMeta(v))
-			i++
-		}
-		idLblRegexps[name] = sb.String()
-	}
-
-	var infoLabelMatchers []*labels.Matcher
-	for name, re := range idLblRegexps {
-		infoLabelMatchers = append(infoLabelMatchers, labels.MustNewMatcher(labels.MatchRegexp, name, re))
-	}
 	var nameMatchers []*labels.Matcher
+	var dataMatchers []*labels.Matcher
 	for _, ms := range dataLabelMatchers {
 		for _, m := range ms {
 			if m.Name == model.MetricNameLabel {
 				nameMatchers = append(nameMatchers, m)
 				continue
 			}
-			infoLabelMatchers = append(infoLabelMatchers, m)
+			dataMatchers = append(dataMatchers, m)
 		}
 	}
 	removeNameFromDataLabelMatchers()
-	infoLabelMatchers = append(infoLabelMatchers, effectiveInfoNameMatchers(nameMatchers)...)
+	effectiveNameMatchers := effectiveInfoNameMatchers(nameMatchers)
 
-	infoIt := ev.querier.Select(ctx, false, &selectHints, infoLabelMatchers...)
-	infoSeries, ws, err := expandSeriesSet(ctx, infoIt)
-	if err != nil {
-		return nil, ws, err
+	var infoSeries []storage.Series
+	var warnings annotations.Annotations
+	for _, identifyingMatchers := range identifyingMatcherSets {
+		matchers := make([]*labels.Matcher, 0, len(identifyingMatchers)+len(dataMatchers)+len(effectiveNameMatchers))
+		matchers = append(matchers, identifyingMatchers...)
+		matchers = append(matchers, dataMatchers...)
+		matchers = append(matchers, effectiveNameMatchers...)
+
+		infoIt := ev.querier.Select(ctx, false, &selectHints, matchers...)
+		series, ws, err := expandSeriesSet(ctx, infoIt)
+		warnings.Merge(ws)
+		if err != nil {
+			return nil, warnings, err
+		}
+		infoSeries = append(infoSeries, series...)
 	}
 
 	// Evaluate the info series at the @-pinned timestamp (when set) and shifted by the offset,
 	// so enrichment reflects the info series as of the time selected by the first argument's
 	// modifiers, consistently at every step, rather than the raw evaluation timestamp.
 	infoMat := ev.evalSeries(ctx, infoSeries, offset, true, atTimestamp)
-	return infoMat, ws, nil
+	return infoMat, warnings, nil
+}
+
+// infoIdentifyingMatcherSets returns one disjoint storage matcher set per
+// non-empty identifying-label presence pattern among non-ignored series in mat.
+// Present labels match observed values; absent labels match the empty string.
+func infoIdentifyingMatcherSets(mat Matrix, ignoreSeries map[uint64]struct{}) [][]*labels.Matcher {
+	const (
+		instanceLabelIndex = iota
+		jobLabelIndex
+	)
+	type identifyingLabelPresence uint64
+	const (
+		jobPresent identifyingLabelPresence = 1 << iota
+		instancePresent
+	)
+	presenceBits := [len(identifyingLabels)]identifyingLabelPresence{
+		instanceLabelIndex: instancePresent,
+		jobLabelIndex:      jobPresent,
+	}
+
+	type group [len(identifyingLabels)]map[string]struct{}
+	groups := map[identifyingLabelPresence]*group{}
+
+	for _, s := range mat {
+		if _, exists := ignoreSeries[s.Metric.Hash()]; exists {
+			continue
+		}
+
+		values := [len(identifyingLabels)]string{
+			instanceLabelIndex: s.Metric.Get(identifyingLabels[instanceLabelIndex]),
+			jobLabelIndex:      s.Metric.Get(identifyingLabels[jobLabelIndex]),
+		}
+		var presence identifyingLabelPresence
+		if values[instanceLabelIndex] != "" {
+			presence |= instancePresent
+		}
+		if values[jobLabelIndex] != "" {
+			presence |= jobPresent
+		}
+		if presence == 0 {
+			continue
+		}
+
+		g := groups[presence]
+		if g == nil {
+			g = &group{}
+			groups[presence] = g
+		}
+		for i, value := range values {
+			if value == "" {
+				continue
+			}
+			if g[i] == nil {
+				g[i] = map[string]struct{}{}
+			}
+			g[i][value] = struct{}{}
+		}
+	}
+
+	presences := make([]identifyingLabelPresence, 0, len(groups))
+	for presence := range groups {
+		presences = append(presences, presence)
+	}
+	slices.Sort(presences)
+
+	matcherSets := make([][]*labels.Matcher, 0, len(groups))
+	for _, presence := range presences {
+		g := groups[presence]
+		matchers := make([]*labels.Matcher, 0, len(identifyingLabels))
+		for i, name := range identifyingLabels {
+			if presence&presenceBits[i] == 0 {
+				matchers = append(matchers, labels.MustNewMatcher(labels.MatchEqual, name, ""))
+				continue
+			}
+
+			values := make([]string, 0, len(g[i]))
+			for value := range g[i] {
+				values = append(values, value)
+			}
+			slices.Sort(values)
+
+			var sb strings.Builder
+			for i, value := range values {
+				if i > 0 {
+					sb.WriteRune('|')
+				}
+				sb.WriteString(regexp.QuoteMeta(value))
+			}
+			matchers = append(matchers, labels.MustNewMatcher(labels.MatchRegexp, name, sb.String()))
+		}
+		matcherSets = append(matcherSets, matchers)
+	}
+	return matcherSets
 }
 
 // combineWithInfoSeries combines mat with select data labels from infoMat.
@@ -328,7 +394,7 @@ func (ev *evaluator) combineWithInfoSeries(ctx context.Context, mat, infoMat Mat
 		return func(lset labels.Labels) string {
 			lb.Reset()
 			lb.Add(model.MetricNameLabel, name)
-			lset.MatchLabels(true, identifyingLabels...).Range(func(l labels.Label) {
+			lset.MatchLabels(true, identifyingLabels[:]...).Range(func(l labels.Label) {
 				lb.Add(l.Name, l.Value)
 			})
 			lb.Sort()

--- a/promql/info_internal_test.go
+++ b/promql/info_internal_test.go
@@ -1,0 +1,64 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func BenchmarkInfoIdentifyingMatcherSets(b *testing.B) {
+	testCases := []struct {
+		name  string
+		size  int
+		mixed bool
+	}{
+		{name: "homogeneous/1", size: 1},
+		{name: "homogeneous/10000", size: 10_000},
+		{name: "mixed/3", size: 3, mixed: true},
+		{name: "mixed/9999", size: 9_999, mixed: true},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			mat := make(Matrix, tc.size)
+			for i := range mat {
+				series := strconv.Itoa(i)
+				if !tc.mixed {
+					mat[i].Metric = labels.FromStrings("instance", "a", "job", "api", "series", series)
+					continue
+				}
+
+				switch i % 3 {
+				case 0:
+					mat[i].Metric = labels.FromStrings("job", "api", "series", series)
+				case 1:
+					mat[i].Metric = labels.FromStrings("instance", "standalone", "series", series)
+				case 2:
+					mat[i].Metric = labels.FromStrings("instance", "b", "job", "worker", "series", series)
+				}
+			}
+
+			b.ReportAllocs()
+			var matcherSets [][]*labels.Matcher
+			for b.Loop() {
+				matcherSets = infoIdentifyingMatcherSets(mat, nil)
+			}
+			runtime.KeepAlive(matcherSets)
+		})
+	}
+}

--- a/promql/promqltest/testdata/info.test
+++ b/promql/promqltest/testdata/info.test
@@ -465,6 +465,28 @@ eval range from 0m to 2m step 1m info(metric, {__name__="custom_info"})
 
 clear
 
+# Mixed identifying-label presence patterns must not force every series to
+# carry both labels. Cross-pairs admitted by the grouped prefetch are removed
+# by the exact signature join.
+load 1m
+	metric{job="api"} 1 2 3
+	metric{instance="standalone"} 4 5 6
+	metric{job="api", instance="a"} 7 8 9
+	metric{job="worker", instance="b"} 10 11 12
+	target_info{job="api", job_data="job-only"} 1 1 1
+	target_info{instance="standalone", instance_data="instance-only"} 1 1 1
+	target_info{job="api", instance="a", pair_data="api-a"} 1 1 1
+	target_info{job="worker", instance="b", pair_data="worker-b"} 1 1 1
+	target_info{job="api", instance="b", cross_pair="ignored"} 1 1 1
+
+eval range from 0m to 2m step 1m info(metric)
+	metric{job="api", job_data="job-only"} 1 2 3
+	metric{instance="standalone", instance_data="instance-only"} 4 5 6
+	metric{job="api", instance="a", pair_data="api-a"} 7 8 9
+	metric{job="worker", instance="b", pair_data="worker-b"} 10 11 12
+
+clear
+
 # Conflicting labels across different info metrics should error.
 load 1m
 	metric{instance="a", job="1"} 1 2 3

--- a/web/ui/mantine-ui/src/promql/functionDocs.tsx
+++ b/web/ui/mantine-ui/src/promql/functionDocs.tsx
@@ -1876,6 +1876,12 @@ const funcDocs: Record<string, React.ReactNode> = {
       </p>
 
       <p>
+        Identifying-label presence is evaluated per input series. Inputs containing only <code>job</code>, only{" "}
+        <code>instance</code>, or both can therefore gain data labels from the corresponding info-series group; a
+        missing identifying label is not treated as a wildcard.
+      </p>
+
+      <p>
         These limitations are partially defeating the purpose of the <code>info</code> function. At the current stage,
         this is an experiment to find out how useful the approach turns out to be in practice. A final version of the{" "}
         <code>info</code> function will indeed consider all matching info series and with their appropriate identifying


### PR DESCRIPTION
`info()` currently builds one storage selector by combining every non-empty `job` and `instance` value in its input. For an input vector containing both job-only and instance-only series, that selector requires both labels and therefore never fetches the matching one-label info series.

This groups the prefetch selectors by identifying-label presence. Missing identifying labels are constrained to empty for each group, while the existing exact-signature join continues to discard cross-pairs admitted by the regular expression matchers.

Homogeneous one-label inputs already work; the regression test covers the mixed job-only, instance-only, and two-label case together.

#### Which issue(s) does the PR fix:

None.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] PromQL: Fix info() enrichment when input series use different subsets of identifying labels
```
