### PR TITLE
scrape: allow setting multiple URL parameter values via __param_ labels

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3581,6 +3581,22 @@ are set to the scheme and metrics path of the target respectively, as specified 
 
 The `__param_<name>`
 label is set to the value of the first passed URL parameter called `<name>`, as defined in `scrape_config`.
+Setting it during relabeling replaces the first value of that parameter, or adds
+the parameter if it is not configured; any further values from `scrape_config`
+are kept.
+
+Further values of a URL parameter can be set with `__param_<name>_<i>` labels,
+where `<i>` is the zero-based position of the value, written as a decimal
+integer greater than zero without leading zeros (`_1`, `_2`, ..., `_10`). Such
+a label replaces the configured value at that position if it exists and is
+appended to the parameter's values otherwise. Indexed labels are applied after
+`__param_<name>`, in ascending numeric order of `<i>` (so `_2` before `_10`).
+For example, setting `__param_match[]` and `__param_match[]_1` on a federation
+target results in `?match[]=<first value>&match[]=<second value>`. A suffix
+that is not a valid index (`_0`, `_01`, `_x`, or a trailing `_`) is not
+special and names the parameter literally. Consequently, a parameter whose own
+name ends in `_<i>` cannot have its first value set via labels. Only the first
+value of each parameter is exposed as a `__param_<name>` label.
 
 The `__scrape_interval__` and `__scrape_timeout__` labels are set to the target's
 interval and timeout, as specified in `scrape_config`.

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -7452,12 +7452,12 @@ func testTargetScrapeConfigWithLabels(t *testing.T, appV2 bool) {
 		jobName              = "test"
 	)
 
-	createTestServer := func(t *testing.T, done chan struct{}) *url.URL {
+	createTestServer := func(t *testing.T, done chan struct{}, wantParams []string) *url.URL {
 		server := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				defer close(done)
 				require.Equal(t, expectedTimeout, r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds"))
-				require.Equal(t, expectedParam, r.URL.Query().Get("param"))
+				require.Equal(t, wantParams, r.URL.Query()["param"])
 				require.Equal(t, expectedPath, r.URL.Path)
 
 				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
@@ -7470,9 +7470,9 @@ func testTargetScrapeConfigWithLabels(t *testing.T, appV2 bool) {
 		return serverURL
 	}
 
-	run := func(t *testing.T, cfg *config.ScrapeConfig, targets []*targetgroup.Group) chan struct{} {
+	run := func(t *testing.T, cfg *config.ScrapeConfig, targets []*targetgroup.Group, wantParams []string) chan struct{} {
 		done := make(chan struct{})
-		srvURL := createTestServer(t, done)
+		srvURL := createTestServer(t, done, wantParams)
 
 		// Update target addresses to use the dynamically created server URL.
 		for _, target := range targets {
@@ -7491,9 +7491,10 @@ func testTargetScrapeConfigWithLabels(t *testing.T, appV2 bool) {
 	}
 
 	cases := []struct {
-		name    string
-		cfg     *config.ScrapeConfig
-		targets []*targetgroup.Group
+		name       string
+		cfg        *config.ScrapeConfig
+		targets    []*targetgroup.Group
+		wantParams []string
 	}{
 		{
 			name: "Everything in scrape config",
@@ -7514,6 +7515,7 @@ func testTargetScrapeConfigWithLabels(t *testing.T, appV2 bool) {
 					},
 				},
 			},
+			wantParams: []string{expectedParam},
 		},
 		{
 			name: "Overridden in target",
@@ -7539,6 +7541,32 @@ func testTargetScrapeConfigWithLabels(t *testing.T, appV2 bool) {
 					},
 				},
 			},
+			wantParams: []string{expectedParam},
+		},
+		{
+			name: "Multiple values overridden in target",
+			cfg: &config.ScrapeConfig{
+				ScrapeInterval:             model.Duration(2 * time.Second),
+				ScrapeTimeout:              model.Duration(configTimeout),
+				JobName:                    jobName,
+				Scheme:                     httpScheme,
+				MetricsPath:                expectedPath,
+				MetricNameValidationScheme: model.UTF8Validation,
+				MetricNameEscapingScheme:   model.AllowUTF8,
+				Params:                     url.Values{"param": []string{secondParam}},
+			},
+			targets: []*targetgroup.Group{
+				{
+					Targets: []model.LabelSet{
+						{
+							model.AddressLabel: model.LabelValue(""),
+							paramLabel:         expectedParam,
+							paramLabel + "_1":  secondParam,
+						},
+					},
+				},
+			},
+			wantParams: []string{expectedParam, secondParam},
 		},
 		{
 			name: "Overridden in relabel_config",
@@ -7590,6 +7618,7 @@ func testTargetScrapeConfigWithLabels(t *testing.T, appV2 bool) {
 					},
 				},
 			},
+			wantParams: []string{expectedParam},
 		},
 	}
 
@@ -7597,7 +7626,7 @@ func testTargetScrapeConfigWithLabels(t *testing.T, appV2 bool) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			select {
-			case <-run(t, c.cfg, c.targets):
+			case <-run(t, c.cfg, c.targets, c.wantParams):
 			case <-time.After(10 * time.Second):
 				t.Fatal("timeout after 10 seconds")
 			}

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -14,10 +14,12 @@
 package scrape
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"hash/fnv"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -221,6 +223,29 @@ func (t *Target) SetScrapeConfig(scrapeConfig *config.ScrapeConfig, tLabels, tgL
 	t.tgLabels = tgLabels
 }
 
+// indexedParam is a URL query parameter value set via a __param_<name>_<i> label.
+type indexedParam struct {
+	name  string
+	idx   int
+	value string
+}
+
+// parseParamIndex splits a __param_ label suffix of the form <name>_<i> into
+// the parameter name and the index i. The index must be a decimal integer
+// greater than zero without leading zeros; the name must be non-empty. Any
+// other suffix is reported as not indexed and names the parameter literally.
+func parseParamIndex(ks string) (string, int, bool) {
+	sep := strings.LastIndexByte(ks, '_')
+	if sep <= 0 || sep == len(ks)-1 || ks[sep+1] < '1' || ks[sep+1] > '9' {
+		return "", 0, false
+	}
+	idx, err := strconv.Atoi(ks[sep+1:])
+	if err != nil {
+		return "", 0, false
+	}
+	return ks[:sep], idx, true
+}
+
 // URL returns a copy of the target's URL.
 func (t *Target) URL() *url.URL {
 	t.mtx.RLock()
@@ -232,18 +257,36 @@ func (t *Target) URL() *url.URL {
 		params[k] = make([]string, len(v))
 		copy(params[k], v)
 	}
+	// Indexed __param_<name>_<i> labels are collected and applied after the
+	// bare __param_<name> labels, in ascending numeric order of <i>. Labels are
+	// iterated in lexicographic order, which would otherwise apply _10 before _2.
+	var indexed []indexedParam
 	t.labels.Range(func(l labels.Label) {
 		if !strings.HasPrefix(l.Name, model.ParamLabelPrefix) {
 			return
 		}
 		ks := l.Name[len(model.ParamLabelPrefix):]
 
+		if name, idx, ok := parseParamIndex(ks); ok {
+			indexed = append(indexed, indexedParam{name: name, idx: idx, value: l.Value})
+			return
+		}
 		if len(params[ks]) > 0 {
 			params[ks][0] = l.Value
 		} else {
 			params[ks] = []string{l.Value}
 		}
 	})
+	slices.SortFunc(indexed, func(a, b indexedParam) int {
+		return cmp.Or(strings.Compare(a.name, b.name), cmp.Compare(a.idx, b.idx))
+	})
+	for _, p := range indexed {
+		if p.idx < len(params[p.name]) {
+			params[p.name][p.idx] = p.value
+		} else {
+			params[p.name] = append(params[p.name], p.value)
+		}
+	}
 
 	host := t.labels.Get(model.AddressLabel)
 	scheme := t.labels.Get(model.SchemeLabel)

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -17,6 +17,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -106,36 +107,109 @@ func TestTargetOffset(t *testing.T) {
 }
 
 func TestTargetURL(t *testing.T) {
-	scrapeConfig := &config.ScrapeConfig{
-		Params: url.Values{
-			"abc": []string{"foo", "bar", "baz"},
-			"xyz": []string{"hoo"},
+	for _, tc := range []struct {
+		name     string
+		params   url.Values
+		labels   map[string]string
+		expected url.Values
+	}{
+		{
+			// The first value for each URL query parameter can be set/modified via labels.
+			name: "first value overridden by bare label",
+			params: url.Values{
+				"abc": []string{"foo", "bar", "baz"},
+				"xyz": []string{"hoo"},
+			},
+			labels: map[string]string{
+				"__param_abc": "overwrite",
+				"__param_cde": "huu",
+			},
+			expected: url.Values{
+				"abc": []string{"overwrite", "bar", "baz"},
+				"cde": []string{"huu"},
+				"xyz": []string{"hoo"},
+			},
 		},
-	}
-	labels := labels.FromMap(map[string]string{
-		model.AddressLabel:     "example.com:1234",
-		model.SchemeLabel:      "https",
-		model.MetricsPathLabel: "/metricz",
-		"__param_abc":          "overwrite",
-		"__param_cde":          "huu",
-	})
-	target := NewTarget(labels, scrapeConfig, nil, nil)
+		{
+			name:     "indexed label overrides configured value",
+			params:   url.Values{"abc": []string{"foo", "bar", "baz"}},
+			labels:   map[string]string{"__param_abc_1": "overwrite"},
+			expected: url.Values{"abc": []string{"foo", "overwrite", "baz"}},
+		},
+		{
+			name:   "indexed label beyond configured values is appended",
+			params: url.Values{"abc": []string{"foo", "bar", "baz"}},
+			labels: map[string]string{
+				"__param_abc":   "first",
+				"__param_abc_1": "second",
+				"__param_abc_5": "appended",
+			},
+			expected: url.Values{"abc": []string{"first", "second", "baz", "appended"}},
+		},
+		{
+			name:   "indexed labels applied in numeric order",
+			params: url.Values{"abc": []string{"foo"}},
+			labels: map[string]string{
+				"__param_abc_10": "ten",
+				"__param_abc_2":  "two",
+			},
+			expected: url.Values{"abc": []string{"foo", "two", "ten"}},
+		},
+		{
+			name: "indexed labels with gaps and without configured params",
+			labels: map[string]string{
+				"__param_abc_3": "three",
+				"__param_abc_1": "one",
+			},
+			expected: url.Values{"abc": []string{"one", "three"}},
+		},
+		{
+			name: "bare and indexed labels without configured params",
+			labels: map[string]string{
+				"__param_abc":   "first",
+				"__param_abc_1": "second",
+			},
+			expected: url.Values{"abc": []string{"first", "second"}},
+		},
+		{
+			name:   "invalid index suffix names the parameter literally",
+			params: url.Values{"abc": []string{"foo"}},
+			labels: map[string]string{
+				"__param_abc_0":  "zero",
+				"__param_abc_01": "leading-zero",
+				"__param_abc_x":  "letter",
+				"__param_abc_":   "trailing",
+				"__param__1":     "no-name",
+			},
+			expected: url.Values{
+				"abc":    []string{"foo"},
+				"abc_0":  []string{"zero"},
+				"abc_01": []string{"leading-zero"},
+				"abc_x":  []string{"letter"},
+				"abc_":   []string{"trailing"},
+				"_1":     []string{"no-name"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lbls := map[string]string{
+				model.AddressLabel:     "example.com:1234",
+				model.SchemeLabel:      "https",
+				model.MetricsPathLabel: "/metricz",
+			}
+			maps.Copy(lbls, tc.labels)
+			target := NewTarget(labels.FromMap(lbls), &config.ScrapeConfig{Params: tc.params}, nil, nil)
 
-	// The reserved labels are concatenated into a full URL. The first value for each
-	// URL query parameter can be set/modified via labels as well.
-	expectedParams := url.Values{
-		"abc": []string{"overwrite", "bar", "baz"},
-		"cde": []string{"huu"},
-		"xyz": []string{"hoo"},
+			// The reserved labels are concatenated into a full URL.
+			expectedURL := &url.URL{
+				Scheme:   "https",
+				Host:     "example.com:1234",
+				Path:     "/metricz",
+				RawQuery: tc.expected.Encode(),
+			}
+			require.Equal(t, expectedURL, target.URL())
+		})
 	}
-	expectedURL := &url.URL{
-		Scheme:   "https",
-		Host:     "example.com:1234",
-		Path:     "/metricz",
-		RawQuery: expectedParams.Encode(),
-	}
-
-	require.Equal(t, expectedURL, target.URL())
 }
 
 func TestTargetURL_Unix(t *testing.T) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #18348

#### What this PR does
A `__param_<name>` target label carries a single string, so a URL query parameter that
takes a list of values (e.g. `match[]` when federating) cannot be fully configured via
service discovery or relabeling; only the first value can be set.

This adds `__param_<name>_<i>` labels, where `<i>` is the zero-based position of the
value (a decimal integer >= 1 without leading zeros):

- The value replaces the configured value at position `<i>` if it exists, otherwise it
  is appended.
- Indexed labels are applied after the bare `__param_<name>` label, in ascending numeric
  order of `<i>` (`_2` before `_10`).
- Any other suffix (`_0`, `_01`, `_x`, trailing `_`) is not special and names the
  parameter literally, so existing behaviour is unchanged. The only new collision is a
  parameter whose own name ends in `_<i>`; this is documented.

Example, from a file_sd target:
```yaml
labels:
  __param_match[]: '{job="node"}'
  __param_match[]_1: '{job="prometheus"}'
```
produces `?match[]={job="node"}&match[]={job="prometheus"}`.

Bare `__param_<name>` semantics, `PopulateDiscoveredLabels` (which still exposes only the
first value) and the config schema are untouched. No feature flag is added since behaviour
only changes for label names matching `__param_<name>_<i>`; happy to gate it if preferred.

Changes:
- `scrape/target.go`: parse indexed `__param_` labels in `Target.URL()`.
- `scrape/target_test.go`, `scrape/scrape_test.go`: table cases for override, append,
  gaps, numeric ordering, invalid suffixes and the end-to-end scrape request.
- `docs/configuration/configuration.md`: document the indexed form.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[ENHANCEMENT] Scrape: Allow setting multiple values of a URL query parameter via `__param_<name>_<i>` target labels.
```

