### PR TITLE
web: remove old React UI and use Mantine UI as default

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -318,8 +318,7 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 				c.parserOpts.EnableBinopFillModifiers = true
 				logger.Info("Experimental PromQL binary operator fill modifiers enabled.")
 			case "old-ui":
-				c.web.UseOldUI = true
-				logger.Info("Serving previous version of the Prometheus web UI.")
+				logger.Warn("The old React UI has been removed in Prometheus 4.0. The --enable-feature=old-ui flag is now a no-op.")
 			case "otlp-deltatocumulative":
 				c.web.ConvertOTLPDelta = true
 				logger.Info("Converting delta OTLP metrics to cumulative")

--- a/cmd/prometheus/testdata/features.json
+++ b/cmd/prometheus/testdata/features.json
@@ -270,7 +270,6 @@
     "xor2_encoding": true
   },
   "ui": {
-    "ui_v2": false,
     "ui_v3": true
   }
 }

--- a/web/web.go
+++ b/web/web.go
@@ -69,15 +69,8 @@ import (
 
 // Paths handled by the React router that should all serve the main React app's index.html,
 // no matter if agent mode is enabled or not.
-var oldUIReactRouterPaths = []string{
-	"/config",
-	"/flags",
-	"/service-discovery",
-	"/status",
-	"/targets",
-}
 
-var newUIReactRouterPaths = []string{
+var reactRouterPaths = []string{
 	"/config",
 	"/flags",
 	"/service-discovery",
@@ -92,14 +85,7 @@ var reactRouterAgentPaths = []string{
 }
 
 // Paths that are handled by the React router when the Agent mode is not set.
-var oldUIReactRouterServerPaths = []string{
-	"/alerts",
-	"/graph",
-	"/rules",
-	"/tsdb-status",
-}
-
-var newUIReactRouterServerPaths = []string{
+var reactRouterServerPaths = []string{
 	"/alerts",
 	"/query", // The old /graph redirects to /query on the server side.
 	"/rules",
@@ -461,8 +447,7 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		r.Enable(features.API, "exclude_alerts")     // exclude_alerts parameter for /rules endpoint.
 		r.Enable(features.API, "openapi_3.1")        // OpenAPI 3.1 specification support.
 		r.Enable(features.API, "openapi_3.2")        // OpenAPI 3.2 specification support.
-		r.Set(features.UI, "ui_v3", !o.UseOldUI)
-		r.Set(features.UI, "ui_v2", o.UseOldUI)
+		r.Enable(features.UI, "ui_v3")
 	}
 
 	if o.RoutePrefix != "/" {
@@ -474,9 +459,6 @@ func New(logger *slog.Logger, o *Options) *Handler {
 	}
 
 	homePage := "/query"
-	if o.UseOldUI {
-		homePage = "/graph"
-	}
 	if o.IsAgent {
 		homePage = "/agent"
 	}
@@ -487,16 +469,11 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		http.Redirect(w, r, path.Join(o.ExternalURL.Path, homePage), http.StatusFound)
 	})
 
-	if !o.UseOldUI {
-		router.Get("/graph", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, path.Join(o.ExternalURL.Path, "/query?"+r.URL.RawQuery), http.StatusFound)
-		})
-	}
+	router.Get("/graph", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, path.Join(o.ExternalURL.Path, "/query?"+r.URL.RawQuery), http.StatusFound)
+	})
 
-	reactAssetsRoot := "/static/mantine-ui"
-	if h.options.UseOldUI {
-		reactAssetsRoot = "/static/react-app"
-	}
+	const reactAssetsRoot = "/static/mantine-ui"
 
 	router.Get("/version", h.version)
 	router.Get("/metrics", promhttp.Handler().ServeHTTP)
@@ -530,14 +507,6 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		w.Write(replacedIdx)
 	}
 
-	// Serve the React app.
-	reactRouterPaths := newUIReactRouterPaths
-	reactRouterServerPaths := newUIReactRouterServerPaths
-	if h.options.UseOldUI {
-		reactRouterPaths = oldUIReactRouterPaths
-		reactRouterServerPaths = oldUIReactRouterServerPaths
-	}
-
 	for _, p := range reactRouterPaths {
 		router.Get(p, serveReactApp)
 	}
@@ -563,10 +532,7 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		})
 	}
 
-	reactStaticAssetsDir := "/assets"
-	if h.options.UseOldUI {
-		reactStaticAssetsDir = "/static"
-	}
+	const reactStaticAssetsDir = "/assets"
 	// Static files required by the React app.
 	router.Get(reactStaticAssetsDir+"/*filepath", func(w http.ResponseWriter, r *http.Request) {
 		r.URL.Path = path.Join(reactAssetsRoot+reactStaticAssetsDir, route.Param(r.Context(), "filepath"))


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #19082

#### Description
Removes the deprecated old React UI router paths and configuration options for Prometheus 4.0. The `--enable-feature=old-ui` flag is now deprecated and logs a warning.

Signed-off-by: Sundeep <sundeep8967@gmail.com>

#### Release notes for end users
```release-notes
[CHANGE] UI: Remove the legacy React UI routes and make Mantine UI the standard default web interface.
```