### PR TITLE
web: add /health and /healthz endpoint aliases (#19565)

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -605,13 +605,20 @@ func New(logger *slog.Logger, o *Options) *Handler {
 	router.Get("/debug/*subpath", serveDebug)
 	router.Post("/debug/*subpath", serveDebug)
 
-	router.Get("/-/healthy", func(w http.ResponseWriter, _ *http.Request) {
+	healthyHandler := func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "%s is Healthy.\n", o.AppName)
-	})
-	router.Head("/-/healthy", func(w http.ResponseWriter, _ *http.Request) {
+	}
+	healthyHeadHandler := func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	})
+	}
+
+	router.Get("/-/healthy", healthyHandler)
+	router.Head("/-/healthy", healthyHeadHandler)
+	router.Get("/health", healthyHandler)
+	router.Head("/health", healthyHeadHandler)
+	router.Get("/healthz", healthyHandler)
+	router.Head("/healthz", healthyHeadHandler)
 	router.Get("/-/ready", readyf(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "%s is Ready.\n", o.AppName)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -122,15 +122,20 @@ func TestReadyAndHealthy(t *testing.T) {
 
 	waitForServerReady(t, baseURL, 5*time.Second)
 
-	resp, err := http.Get(baseURL + "/-/healthy")
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	cleanupTestResponse(t, resp)
+	var resp *http.Response
+	var err error
 
-	resp, err = http.Head(baseURL + "/-/healthy")
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	cleanupTestResponse(t, resp)
+	for _, path := range []string{"/-/healthy", "/health", "/healthz"} {
+		resp, err = http.Get(baseURL + path)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		cleanupTestResponse(t, resp)
+
+		resp, err = http.Head(baseURL + path)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		cleanupTestResponse(t, resp)
+	}
 
 	for _, u := range []string{
 		baseURL + "/-/ready",
@@ -182,6 +187,8 @@ func TestReadyAndHealthy(t *testing.T) {
 
 	for _, u := range []string{
 		baseURL + "/-/healthy",
+		baseURL + "/health",
+		baseURL + "/healthz",
 		baseURL + "/-/ready",
 	} {
 		resp, err = http.Get(u)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -123,7 +123,6 @@ func TestReadyAndHealthy(t *testing.T) {
 	waitForServerReady(t, baseURL, 5*time.Second)
 
 	var resp *http.Response
-	var err error
 
 	for _, path := range []string{"/-/healthy", "/health", "/healthz"} {
 		resp, err = http.Get(baseURL + path)


### PR DESCRIPTION
Fixes #19565

Adds `/health` and `/healthz` HTTP endpoint aliases to `web/web.go` and corresponding unit tests in `web/web_test.go` for standard Kubernetes container liveness probes.

Signed-off-by: SHIVANSH-ux-ys <singaser78@gmail.com>

```release-notes
[FEATURE] web: add /health and /healthz endpoint aliases
```
