### PR TITLE
storage: apply configured float chunk encoding to in-memory chunks

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -952,7 +952,7 @@ func main() {
 		localStorage  = &readyStorage{stats: tsdb.NewDBStats()}
 		scraper       = &readyScrapeManager{}
 		remoteStorage = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, cfg.scrape.EnableTypeAndUnitLabels)
-		fanoutStorage = storage.NewFanout(logger, localStorage, remoteStorage)
+		fanoutStorage = newFanoutStorage(logger, localStorage, remoteStorage, cfg.tsdb.FloatChunkEncoding)
 	)
 
 	var (
@@ -1906,6 +1906,16 @@ func (s *readyStorage) StartTime() (int64, error) {
 	return math.MaxInt64, tsdb.ErrNotReady
 }
 
+// floatChunkEncoding returns the float chunk encoding currently used by the
+// underlying TSDB, or EncNone if the storage is not ready yet or does not
+// store chunks (agent mode).
+func (s *readyStorage) floatChunkEncoding() chunkenc.Encoding {
+	if db, ok := s.get().(*tsdb.DB); ok {
+		return db.FloatChunkEncoding()
+	}
+	return chunkenc.EncNone
+}
+
 // Querier implements the Storage interface.
 func (s *readyStorage) Querier(mint, maxt int64) (storage.Querier, error) {
 	if x := s.get(); x != nil {
@@ -1950,6 +1960,37 @@ func (s *readyStorage) AppenderV2(ctx context.Context) storage.AppenderV2 {
 		return x.AppenderV2(ctx)
 	}
 	return notReadyAppenderV2{}
+}
+
+// newFloatChunkEncodingFn returns a getter for the float chunk encoding used
+// when chunks are encoded in memory rather than read from disk, e.g. from
+// remote read samples, or while compacting overlaps between the local TSDB and
+// a remote read endpoint. It follows the local TSDB, which tracks runtime
+// configuration reloads.
+//
+// The fallback is defensive: it applies while the local storage is not ready or
+// does not store chunks (agent mode), which no chunk query reaches today, as
+// fanout.ChunkQuerier returns early when the primary errors with tsdb.ErrNotReady
+// or with agent.ErrUnsupported.
+func newFloatChunkEncodingFn(localStorage *readyStorage, fallback chunkenc.Encoding) storage.FloatEncodingFunc {
+	return func() chunkenc.Encoding {
+		if enc := localStorage.floatChunkEncoding(); enc != chunkenc.EncNone {
+			return enc
+		}
+		return fallback
+	}
+}
+
+// newFanoutStorage returns the storage fanout used by the Prometheus server,
+// with the float chunk encoding getter wired into both halves of the read path:
+// the fanout, which re-encodes overlaps between the local TSDB and the remote
+// read endpoints, and the remote storage, whose read queryables encode the
+// samples they read into chunks. Both must see the same getter, otherwise a
+// single chunk query can mix encodings.
+func newFanoutStorage(logger *slog.Logger, localStorage *readyStorage, remoteStorage *remote.Storage, fallbackFloatChunkEncoding chunkenc.Encoding) storage.Storage {
+	floatChunkEncoding := newFloatChunkEncodingFn(localStorage, fallbackFloatChunkEncoding)
+	remoteStorage.SetFloatEncoding(floatChunkEncoding)
+	return storage.NewFanoutWithOptions(logger, storage.FanoutOptions{FloatEncoding: floatChunkEncoding}, localStorage, remoteStorage)
 }
 
 type notReadyAppender struct{}

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,6 +39,7 @@ import (
 	"github.com/grafana/regexp"
 	remoteapi "github.com/prometheus/client_golang/exp/api/remote"
 	"github.com/prometheus/client_golang/prometheus"
+	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
@@ -47,6 +49,11 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/rules"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/agent"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -1314,4 +1321,169 @@ func TestFeatureFlagsDocumented(t *testing.T) {
 	require.NotEmpty(t, docFlags)
 	require.True(t, slices.IsSorted(helpFlags))
 	require.ElementsMatch(t, helpFlags, docFlags)
+}
+
+func TestReadyStorageFloatChunkEncoding(t *testing.T) {
+	// floatEncodingConfig returns a config setting chunk_encoding.floats to the
+	// given value, as a runtime configuration reload would.
+	floatEncodingConfig := func(floats string) *config.Config {
+		return &config.Config{
+			StorageConfig: config.StorageConfig{
+				TSDBConfig: &config.TSDBConfig{
+					ChunkEncoding: config.ChunkEncodingConfig{Floats: floats},
+				},
+			},
+		}
+	}
+
+	s := &readyStorage{}
+	// The encoding is unknown until the local storage is ready.
+	require.Equal(t, chunkenc.EncNone, s.floatChunkEncoding())
+
+	// While the local storage is not ready, the getter serves the fallback.
+	require.Equal(t, chunkenc.EncXOR, newFloatChunkEncodingFn(s, chunkenc.EncXOR)())
+	require.Equal(t, chunkenc.EncXOR2, newFloatChunkEncodingFn(s, chunkenc.EncXOR2)())
+
+	// Agent mode does not store chunks, so the fallback keeps applying.
+	agentDB, err := agent.Open(promslog.NewNopLogger(), nil, nil, t.TempDir(), agent.DefaultOptions())
+	require.NoError(t, err)
+	s.Set(agentDB, 0)
+	require.Equal(t, chunkenc.EncNone, s.floatChunkEncoding())
+	require.Equal(t, chunkenc.EncXOR2, newFloatChunkEncodingFn(s, chunkenc.EncXOR2)())
+
+	// readyStorage.ApplyConfig is a no-op in agent mode, so the encoding stays
+	// frozen at the startup fallback and never follows a reload.
+	require.NoError(t, s.ApplyConfig(floatEncodingConfig(config.FloatChunkEncodingXOR2)))
+	require.Equal(t, chunkenc.EncNone, s.floatChunkEncoding())
+	require.Equal(t, chunkenc.EncXOR, newFloatChunkEncodingFn(s, chunkenc.EncXOR)())
+	require.NoError(t, agentDB.Close())
+
+	// Once the TSDB is ready it wins over the fallback.
+	opts := tsdb.DefaultOptions()
+	opts.FloatChunkEncoding = chunkenc.EncXOR2
+	db, err := tsdb.Open(t.TempDir(), nil, nil, opts, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	s.Set(db, 0)
+	require.Equal(t, chunkenc.EncXOR2, s.floatChunkEncoding())
+	require.Equal(t, chunkenc.EncXOR2, newFloatChunkEncodingFn(s, chunkenc.EncXOR)())
+
+	// The getter follows runtime configuration reloads, which is why it is a
+	// getter and not a value.
+	reloadOpts := tsdb.DefaultOptions()
+	reloadOpts.FloatChunkEncoding = chunkenc.EncXOR
+	reloadDB, err := tsdb.Open(t.TempDir(), nil, nil, reloadOpts, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reloadDB.Close()) })
+
+	s.Set(reloadDB, 0)
+	require.Equal(t, chunkenc.EncXOR, s.floatChunkEncoding())
+
+	require.NoError(t, s.ApplyConfig(floatEncodingConfig(config.FloatChunkEncodingXOR2)))
+	require.Equal(t, chunkenc.EncXOR2, s.floatChunkEncoding())
+	require.Equal(t, chunkenc.EncXOR2, newFloatChunkEncodingFn(s, chunkenc.EncXOR)())
+
+	// An absent chunk_encoding.floats reverts to the encoding resolved at startup.
+	require.NoError(t, s.ApplyConfig(floatEncodingConfig("")))
+	require.Equal(t, chunkenc.EncXOR, s.floatChunkEncoding())
+
+	// And it flips back on the next reload.
+	require.NoError(t, s.ApplyConfig(floatEncodingConfig(config.FloatChunkEncodingXOR2)))
+	require.Equal(t, chunkenc.EncXOR2, s.floatChunkEncoding())
+	require.NoError(t, s.ApplyConfig(floatEncodingConfig(config.FloatChunkEncodingXOR)))
+	require.Equal(t, chunkenc.EncXOR, s.floatChunkEncoding())
+}
+
+// TestFanoutStorageFloatChunkEncoding covers the wiring newFanoutStorage does
+// for main: both the fanout, which re-encodes the overlap between the local
+// TSDB and a remote read endpoint, and the remote read queryables, which encode
+// the samples they read into chunks, must follow the local TSDB encoding.
+func TestFanoutStorageFloatChunkEncoding(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		encoding chunkenc.Encoding
+	}{
+		{name: "xor", encoding: chunkenc.EncXOR},
+		{name: "xor2", encoding: chunkenc.EncXOR2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			overlapping := labels.FromStrings("__name__", "overlapping", "job", "test")
+			remoteOnly := labels.FromStrings("__name__", "remote_only", "job", "test")
+			appendSamples := func(t *testing.T, db *tsdb.DB, lbls labels.Labels, ts ...int64) {
+				t.Helper()
+				app := db.Appender(ctx)
+				for _, s := range ts {
+					_, err := app.Append(0, lbls, s, float64(s))
+					require.NoError(t, err)
+				}
+				require.NoError(t, app.Commit())
+			}
+
+			// The remote read endpoint holds samples interleaved with the local
+			// ones, so that the compacting merger has an overlap to re-encode.
+			remoteDB, err := tsdb.Open(t.TempDir(), nil, nil, tsdb.DefaultOptions(), nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, remoteDB.Close()) })
+			appendSamples(t, remoteDB, overlapping, 150, 250, 350)
+			// remote_only exists on the remote side only, so its chunk reaches the
+			// caller as the remote read queryable encoded it, without going
+			// through the fanout merger.
+			appendSamples(t, remoteDB, remoteOnly, 150, 250, 350)
+
+			srv := httptest.NewServer(remote.NewReadHandler(
+				promslog.NewNopLogger(), nil, remoteDB,
+				func() config.Config { return config.Config{GlobalConfig: config.DefaultGlobalConfig} },
+				1e6, 1, 1e6,
+			))
+			t.Cleanup(srv.Close)
+			srvURL, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+
+			localOpts := tsdb.DefaultOptions()
+			localOpts.FloatChunkEncoding = tc.encoding
+			localDB, err := tsdb.Open(t.TempDir(), nil, nil, localOpts, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, localDB.Close()) })
+			appendSamples(t, localDB, overlapping, 100, 200, 300, 400)
+
+			// Wire the storage up the way main does. The fallback is deliberately
+			// EncXOR: the local TSDB is ready, so its encoding must win.
+			localStorage := &readyStorage{stats: tsdb.NewDBStats()}
+			remoteStorage := remote.NewStorage(promslog.NewNopLogger(), nil, localStorage.StartTime, t.TempDir(), time.Minute, &readyScrapeManager{}, false)
+			t.Cleanup(func() { require.NoError(t, remoteStorage.Close()) })
+			fanoutStorage := newFanoutStorage(promslog.NewNopLogger(), localStorage, remoteStorage, chunkenc.EncXOR)
+			localStorage.Set(localDB, 0)
+			rrConf := config.DefaultRemoteReadConfig
+			rrConf.URL = &config_util.URL{URL: srvURL}
+			rrConf.ReadRecent = true
+			require.NoError(t, remoteStorage.ApplyConfig(&config.Config{
+				GlobalConfig:      config.DefaultGlobalConfig,
+				RemoteReadConfigs: []*config.RemoteReadConfig{&rrConf},
+			}))
+
+			q, err := fanoutStorage.ChunkQuerier(0, 1000)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, q.Close()) })
+
+			ss := q.Select(ctx, true, &storage.SelectHints{Start: 0, End: 1000}, labels.MustNewMatcher(labels.MatchEqual, "job", "test"))
+			samples := map[string]int{}
+			for ss.Next() {
+				series := ss.At()
+				it := series.Iterator(nil)
+				for it.Next() {
+					meta := it.At()
+					require.Equal(t, tc.encoding, meta.Chunk.Encoding(), "series %s", series.Labels())
+					samples[series.Labels().Get("__name__")] += meta.Chunk.NumSamples()
+				}
+				require.NoError(t, it.Err())
+			}
+			require.NoError(t, ss.Err())
+			require.Empty(t, ss.Warnings())
+			// The overlapping series carries all samples of both sides, proving the
+			// remote read endpoint was queried and its overlap actually merged.
+			require.Equal(t, map[string]int{"overlapping": 7, "remote_only": 3}, samples)
+		})
+	}
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -4165,6 +4165,11 @@ with this feature.
 # it yet (e.g. blocks uploaded by the Thanos sidecar). Once XOR2 chunks have been
 # written, downgrading to a version without XOR2 support requires deleting the affected
 # blocks from disk manually, otherwise Prometheus returns an error on all queries.
+# The same holds on the wire: the remote read protocol does not negotiate chunk
+# encodings, as accepted_response_types only selects between SAMPLES and
+# STREAMED_XOR_CHUNKS, so a chunked remote read response carries whichever encoding the
+# server used. A remote read client that does not understand XOR2 fails the whole query
+# with an 'invalid chunk encoding' error.
 #
 # When absent, the encoding is 'xor2' if --enable-feature=xor2-encoding or
 # --enable-feature=st-storage is set, and 'xor' otherwise.
@@ -4177,6 +4182,11 @@ with this feature.
 # When --enable-feature=st-storage is enabled, XOR and XOR2 are not compatible
 # (XOR chunks do not store start timestamps), so an in-progress chunk is cut
 # on the next append after the encoding changes.
+# The encoding also applies to the float chunks that Prometheus encodes in memory
+# instead of reading them from disk: the chunks built from the samples that a remote
+# read client receives from its remote read endpoint, and the chunks re-encoded when
+# the chunk querier compacts overlapping series. Both affect every chunk querier
+# consumer, in particular the chunked remote read responses this Prometheus serves.
 # For the equivalent ST-capable encoding for native histograms, see the experimental
 # histograms-st-encoding feature flag. The st-storage feature enables that encoding too.
 [ chunk_encoding:

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -31,6 +31,17 @@ type fanout struct {
 
 	primary     Storage
 	secondaries []Storage
+
+	// floatEncoding is consulted on every Iterator call of a merged series in
+	// the chunk querier.
+	floatEncoding FloatEncodingFunc
+}
+
+// FanoutOptions holds the optional settings of a fanout Storage.
+type FanoutOptions struct {
+	// FloatEncoding returns the encoding used for float chunks re-encoded while
+	// compacting overlaps in the chunk querier. See FloatEncodingFunc.
+	FloatEncoding FloatEncodingFunc
 }
 
 // NewFanout returns a new fanout Storage, which proxies reads and writes
@@ -43,10 +54,17 @@ type fanout struct {
 //
 // NOTE: In the case of Prometheus, it treats all remote storages as secondary / best effort.
 func NewFanout(logger *slog.Logger, primary Storage, secondaries ...Storage) Storage {
+	return NewFanoutWithOptions(logger, FanoutOptions{}, primary, secondaries...)
+}
+
+// NewFanoutWithOptions is like NewFanout, with additional options. The options
+// precede primary because of the variadic secondaries.
+func NewFanoutWithOptions(logger *slog.Logger, opts FanoutOptions, primary Storage, secondaries ...Storage) Storage {
 	return &fanout{
-		logger:      logger,
-		primary:     primary,
-		secondaries: secondaries,
+		logger:        logger,
+		primary:       primary,
+		secondaries:   secondaries,
+		floatEncoding: opts.FloatEncoding,
 	}
 }
 
@@ -120,7 +138,7 @@ func (f *fanout) ChunkQuerier(mint, maxt int64) (ChunkQuerier, error) {
 		}
 		secondaries = append(secondaries, querier)
 	}
-	return NewMergeChunkQuerier([]ChunkQuerier{primary}, secondaries, NewCompactingChunkSeriesMerger(ChainedSeriesMerge)), nil
+	return NewMergeChunkQuerier([]ChunkQuerier{primary}, secondaries, NewCompactingChunkSeriesMergerWithFloatEncoding(ChainedSeriesMerge, f.floatEncoding)), nil
 }
 
 func (f *fanout) Appender(ctx context.Context) Appender {

--- a/storage/fanout_test.go
+++ b/storage/fanout_test.go
@@ -602,3 +602,67 @@ func BenchmarkFanoutAppenderV2(b *testing.B) {
 		})
 	}
 }
+
+func TestFanout_ChunkQuerierFloatEncoding(t *testing.T) {
+	ctx := context.Background()
+	lbls := labels.FromStrings(model.MetricNameLabel, "a")
+
+	// The primary and the secondary hold interleaved samples for the same
+	// series, so their chunks overlap and have to be re-encoded on merge.
+	newStorage := func(timestamps ...int64) storage.Storage {
+		s := teststorage.New(t)
+		app := s.Appender(ctx)
+		for _, ts := range timestamps {
+			_, err := app.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app.Commit())
+		return s
+	}
+
+	for name, tc := range map[string]struct {
+		newFanout func(primary, secondary storage.Storage) storage.Storage
+		expected  chunkenc.Encoding
+	}{
+		"nil getter defaults to xor": {
+			newFanout: func(primary, secondary storage.Storage) storage.Storage {
+				return storage.NewFanout(nil, primary, secondary)
+			},
+			expected: chunkenc.EncXOR,
+		},
+		"xor": {
+			newFanout: func(primary, secondary storage.Storage) storage.Storage {
+				return storage.NewFanoutWithOptions(nil, storage.FanoutOptions{FloatEncoding: func() chunkenc.Encoding { return chunkenc.EncXOR }}, primary, secondary)
+			},
+			expected: chunkenc.EncXOR,
+		},
+		"xor2": {
+			newFanout: func(primary, secondary storage.Storage) storage.Storage {
+				return storage.NewFanoutWithOptions(nil, storage.FanoutOptions{FloatEncoding: func() chunkenc.Encoding { return chunkenc.EncXOR2 }}, primary, secondary)
+			},
+			expected: chunkenc.EncXOR2,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := tc.newFanout(newStorage(0, 2000, 4000), newStorage(1000, 3000, 5000))
+
+			q, err := f.ChunkQuerier(0, 5000)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, q.Close()) })
+
+			ss := q.Select(ctx, true, nil, labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "a"))
+			require.True(t, ss.Next())
+			chks, err := storage.ExpandChunks(ss.At().Iterator(nil))
+			require.NoError(t, err)
+			require.Len(t, chks, 1)
+			require.Equal(t, tc.expected, chks[0].Chunk.Encoding())
+
+			samples, err := storage.ExpandSamples(chks[0].Chunk.Iterator(nil), nil)
+			require.NoError(t, err)
+			require.Len(t, samples, 6)
+
+			require.False(t, ss.Next())
+			require.NoError(t, ss.Err())
+		})
+	}
+}

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -727,9 +727,10 @@ func NewCompactingChunkSeriesMerger(mergeFunc VerticalSeriesMergeFunc) VerticalC
 
 // NewCompactingChunkSeriesMergerWithFloatEncoding is like
 // NewCompactingChunkSeriesMerger, but chunks re-encoded while compacting overlaps
-// use the float encoding returned by floatEncoding. It is consulted once per merged
-// series, so it may be backed by runtime-reloadable configuration. Nil means EncXOR.
-// Samples carrying a start timestamp always use XOR2 regardless of floatEncoding.
+// use the encoding returned by floatEncoding, consulted on every Iterator call of
+// a merged series. The parameter is left as a plain func because FloatEncodingFunc
+// would reject a caller passing its own named func type; it carries the contract
+// documented on FloatEncodingFunc.
 func NewCompactingChunkSeriesMergerWithFloatEncoding(mergeFunc VerticalSeriesMergeFunc, floatEncoding func() chunkenc.Encoding) VerticalChunkSeriesMergeFunc {
 	return func(series ...ChunkSeries) ChunkSeries {
 		if len(series) == 0 {
@@ -742,14 +743,10 @@ func NewCompactingChunkSeriesMergerWithFloatEncoding(mergeFunc VerticalSeriesMer
 				for _, s := range series {
 					iterators = append(iterators, s.Iterator(nil))
 				}
-				enc := chunkenc.EncXOR
-				if floatEncoding != nil {
-					enc = floatEncoding()
-				}
 				return &compactChunkIterator{
 					mergeFunc:     mergeFunc,
 					iterators:     iterators,
-					floatEncoding: enc,
+					floatEncoding: resolveFloatEncoding(floatEncoding),
 				}
 			},
 		}

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -29,6 +29,17 @@ type sampleAndChunkQueryableClient struct {
 	requiredMatchers []*labels.Matcher
 	readRecent       bool
 	callback         startTimeCallback
+	floatEncoding    storage.FloatEncodingFunc
+}
+
+// SampleAndChunkQueryableClientOptions holds the optional settings of the
+// storage.SampleAndChunkQueryable returned by
+// NewSampleAndChunkQueryableClientWithOptions.
+type SampleAndChunkQueryableClientOptions struct {
+	// FloatEncoding returns the encoding used for the float chunks encoded from
+	// the samples returned by the client, in chunk queries. See
+	// storage.FloatEncodingFunc.
+	FloatEncoding storage.FloatEncodingFunc
 }
 
 // NewSampleAndChunkQueryableClient returns a storage.SampleAndChunkQueryable which queries the given client to select series sets.
@@ -39,6 +50,19 @@ func NewSampleAndChunkQueryableClient(
 	readRecent bool,
 	callback startTimeCallback,
 ) storage.SampleAndChunkQueryable {
+	return NewSampleAndChunkQueryableClientWithOptions(c, externalLabels, requiredMatchers, readRecent, callback, SampleAndChunkQueryableClientOptions{})
+}
+
+// NewSampleAndChunkQueryableClientWithOptions is like
+// NewSampleAndChunkQueryableClient, with additional options.
+func NewSampleAndChunkQueryableClientWithOptions(
+	c ReadClient,
+	externalLabels labels.Labels,
+	requiredMatchers []*labels.Matcher,
+	readRecent bool,
+	callback startTimeCallback,
+	opts SampleAndChunkQueryableClientOptions,
+) storage.SampleAndChunkQueryable {
 	return &sampleAndChunkQueryableClient{
 		client: c,
 
@@ -46,6 +70,7 @@ func NewSampleAndChunkQueryableClient(
 		requiredMatchers: requiredMatchers,
 		readRecent:       readRecent,
 		callback:         callback,
+		floatEncoding:    opts.FloatEncoding,
 	}
 }
 
@@ -84,6 +109,7 @@ func (c *sampleAndChunkQueryableClient) ChunkQuerier(mint, maxt int64) (storage.
 			externalLabels:   c.externalLabels,
 			requiredMatchers: c.requiredMatchers,
 		},
+		floatEncoding: c.floatEncoding,
 	}
 	if c.readRecent {
 		return cq, nil
@@ -229,13 +255,15 @@ func (*querier) Close() error {
 // chunkQuerier is an adapter to make a client usable as a storage.ChunkQuerier.
 type chunkQuerier struct {
 	querier
+	// floatEncoding is consulted once per series encoded.
+	floatEncoding storage.FloatEncodingFunc
 }
 
 // Select implements storage.ChunkQuerier and uses the given matchers to read chunk series sets from the client.
 // It uses remote.querier.Select so it supports external labels and required matchers if specified.
 func (q *chunkQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
 	// TODO(bwplotka) Support remote read chunked and allow returning chunks directly (TODO ticket).
-	return storage.NewSeriesSetToChunkSet(q.querier.Select(ctx, sortSeries, hints, matchers...))
+	return storage.NewSeriesSetToChunkSetWithFloatEncoding(q.querier.Select(ctx, sortSeries, hints, matchers...), q.floatEncoding)
 }
 
 // Note strings in toFilter must be sorted.

--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -106,7 +106,7 @@ func (h *readHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch responseType {
 	case prompb.ReadRequest_STREAMED_XOR_CHUNKS:
-		h.remoteReadStreamedXORChunks(ctx, w, req, externalLabels, sortedExternalLabels)
+		h.remoteReadStreamedChunks(ctx, w, req, externalLabels, sortedExternalLabels)
 	default:
 		// On empty or unknown types in req.AcceptedResponseTypes we default to non streamed, raw samples response.
 		h.remoteReadSamples(ctx, w, req, externalLabels, sortedExternalLabels)
@@ -186,7 +186,11 @@ func (h *readHandler) remoteReadSamples(
 	}
 }
 
-func (h *readHandler) remoteReadStreamedXORChunks(ctx context.Context, w http.ResponseWriter, req *prompb.ReadRequest, externalLabels map[string]string, sortedExternalLabels []prompb.Label) {
+// remoteReadStreamedChunks streams the chunks of the queried series to the client.
+// The chunks are sent with whichever encoding the underlying storage used, which is
+// not necessarily XOR: the STREAMED_XOR_CHUNKS response type name is historical and
+// wire-visible, and the protocol does not negotiate chunk encodings.
+func (h *readHandler) remoteReadStreamedChunks(ctx context.Context, w http.ResponseWriter, req *prompb.ReadRequest, externalLabels map[string]string, sortedExternalLabels []prompb.Label) {
 	w.Header().Set("Content-Type", "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse")
 
 	f, ok := w.(http.Flusher)

--- a/storage/remote/read_handler_test.go
+++ b/storage/remote/read_handler_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/util/teststorage"
 )
@@ -334,235 +336,360 @@ func TestStreamReadEndpoint(t *testing.T) {
 	// Second with 121 float samples, We expect 1 frame with 2 chunks.
 	// Third with 241 float samples. We expect 1 frame with 2 chunks, and 1 frame with 1 chunk for the same series due to bytes limit.
 	// Fourth with 25 histogram samples. We expect 1 frame with 1 chunk.
-	store := promqltest.LoadedStorage(t, `
-		load 1m
-			test_metric1{foo="bar1",baz="qux"} 0+100x119
-			test_metric1{foo="bar2",baz="qux"} 0+100x120
-			test_metric1{foo="bar3",baz="qux"} 0+100x240
-	`)
-	defer store.Close()
+	for _, tc := range []struct {
+		name string
+		// floatEncoding is the float chunk encoding the storage is configured with.
+		floatEncoding chunkenc.Encoding
+		// wantFloatChunkType is the chunk type every float chunk must carry on the wire.
+		wantFloatChunkType prompb.Chunk_Encoding
+		// wantResults, when set, pins the whole response byte for byte.
+		wantResults []*prompb.ChunkedReadResponse
+	}{
+		{
+			name:               "xor",
+			floatEncoding:      chunkenc.EncXOR,
+			wantFloatChunkType: prompb.Chunk_XOR,
+			wantResults: []*prompb.ChunkedReadResponse{
+				{
+					ChunkedSeries: []*prompb.ChunkedSeries{
+						{
+							Labels: []prompb.Label{
+								{Name: "__name__", Value: "test_metric1"},
+								{Name: "b", Value: "c"},
+								{Name: "baz", Value: "qux"},
+								{Name: "d", Value: "e"},
+								{Name: "foo", Value: "bar1"},
+							},
+							Chunks: []prompb.Chunk{
+								{
+									Type:      prompb.Chunk_XOR,
+									MaxTimeMs: 7140000,
+									Data:      []byte("\000x\000\000\000\000\000\000\000\000\000\340\324\003\302|\005\224\000\301\254}\351z2\320O\355\264n[\007\316\224\243md\371\320\375\032Pm\nS\235\016Q\255\006P\275\250\277\312\201Z\003(3\240R\207\332\005(\017\240\322\201\332=(\023\2402\203Z\007(w\2402\201Z\017(\023\265\227\364P\033@\245\007\364\nP\033C\245\002t\036P+@e\036\364\016Pk@e\002t:P;A\245\001\364\nS\373@\245\006t\006P+C\345\002\364\006Pk@\345\036t\nP\033A\245\003\364:P\033@\245\006t\016ZJ\377\\\205\313\210\327\270\017\345+F[\310\347E)\355\024\241\366\342}(v\215(N\203)\326\207(\336\203(V\332W\362\202t4\240m\005(\377AJ\006\320\322\202t\374\240\255\003(oA\312:\3202"),
+								},
+							},
+						},
+					},
+				},
+				{
+					ChunkedSeries: []*prompb.ChunkedSeries{
+						{
+							Labels: []prompb.Label{
+								{Name: "__name__", Value: "test_metric1"},
+								{Name: "b", Value: "c"},
+								{Name: "baz", Value: "qux"},
+								{Name: "d", Value: "e"},
+								{Name: "foo", Value: "bar2"},
+							},
+							Chunks: []prompb.Chunk{
+								{
+									Type:      prompb.Chunk_XOR,
+									MaxTimeMs: 7140000,
+									Data:      []byte("\000x\000\000\000\000\000\000\000\000\000\340\324\003\302|\005\224\000\301\254}\351z2\320O\355\264n[\007\316\224\243md\371\320\375\032Pm\nS\235\016Q\255\006P\275\250\277\312\201Z\003(3\240R\207\332\005(\017\240\322\201\332=(\023\2402\203Z\007(w\2402\201Z\017(\023\265\227\364P\033@\245\007\364\nP\033C\245\002t\036P+@e\036\364\016Pk@e\002t:P;A\245\001\364\nS\373@\245\006t\006P+C\345\002\364\006Pk@\345\036t\nP\033A\245\003\364:P\033@\245\006t\016ZJ\377\\\205\313\210\327\270\017\345+F[\310\347E)\355\024\241\366\342}(v\215(N\203)\326\207(\336\203(V\332W\362\202t4\240m\005(\377AJ\006\320\322\202t\374\240\255\003(oA\312:\3202"),
+								},
+								{
+									Type:      prompb.Chunk_XOR,
+									MinTimeMs: 7200000,
+									MaxTimeMs: 7200000,
+									Data:      []byte("\000\001\200\364\356\006@\307p\000\000\000\000\000"),
+								},
+							},
+						},
+					},
+				},
+				{
+					ChunkedSeries: []*prompb.ChunkedSeries{
+						{
+							Labels: []prompb.Label{
+								{Name: "__name__", Value: "test_metric1"},
+								{Name: "b", Value: "c"},
+								{Name: "baz", Value: "qux"},
+								{Name: "d", Value: "e"},
+								{Name: "foo", Value: "bar3"},
+							},
+							Chunks: []prompb.Chunk{
+								{
+									Type:      prompb.Chunk_XOR,
+									MaxTimeMs: 7140000,
+									Data:      []byte("\000x\000\000\000\000\000\000\000\000\000\340\324\003\302|\005\224\000\301\254}\351z2\320O\355\264n[\007\316\224\243md\371\320\375\032Pm\nS\235\016Q\255\006P\275\250\277\312\201Z\003(3\240R\207\332\005(\017\240\322\201\332=(\023\2402\203Z\007(w\2402\201Z\017(\023\265\227\364P\033@\245\007\364\nP\033C\245\002t\036P+@e\036\364\016Pk@e\002t:P;A\245\001\364\nS\373@\245\006t\006P+C\345\002\364\006Pk@\345\036t\nP\033A\245\003\364:P\033@\245\006t\016ZJ\377\\\205\313\210\327\270\017\345+F[\310\347E)\355\024\241\366\342}(v\215(N\203)\326\207(\336\203(V\332W\362\202t4\240m\005(\377AJ\006\320\322\202t\374\240\255\003(oA\312:\3202"),
+								},
+								{
+									Type:      prompb.Chunk_XOR,
+									MinTimeMs: 7200000,
+									MaxTimeMs: 14340000,
+									Data:      []byte("\000x\200\364\356\006@\307p\000\000\000\000\000\340\324\003\340>\224\355\260\277\322\200\372\005(=\240R\207:\003(\025\240\362\201z\003(\365\240r\203:\005(\r\241\322\201\372\r(\r\240R\237:\007(5\2402\201z\037(\025\2402\203:\005(\375\240R\200\372\r(\035\241\322\201:\003(5\240r\326g\364\271\213\227!\253q\037\312N\340GJ\033E)\375\024\241\266\362}(N\217(V\203)\336\207(\326\203(N\334W\322\203\2644\240}\005(\373AJ\031\3202\202\264\374\240\275\003(kA\3129\320R\201\2644\240\375\264\277\322\200\332\005(3\240r\207Z\003(\027\240\362\201Z\003(\363\240R\203\332\005(\017\241\322\201\332\r(\023\2402\237Z\007(7\2402\201Z\037(\023\240\322\200\332\005(\377\240R\200\332\r "),
+								},
+							},
+						},
+					},
+				},
+				{
+					ChunkedSeries: []*prompb.ChunkedSeries{
+						{
+							Labels: []prompb.Label{
+								{Name: "__name__", Value: "test_metric1"},
+								{Name: "b", Value: "c"},
+								{Name: "baz", Value: "qux"},
+								{Name: "d", Value: "e"},
+								{Name: "foo", Value: "bar3"},
+							},
+							Chunks: []prompb.Chunk{
+								{
+									Type:      prompb.Chunk_XOR,
+									MinTimeMs: 14400000,
+									MaxTimeMs: 14400000,
+									Data:      []byte("\000\001\200\350\335\r@\327p\000\000\000\000\000"),
+								},
+							},
+						},
+					},
+				},
+				{
+					ChunkedSeries: []*prompb.ChunkedSeries{
+						{
+							Labels: []prompb.Label{
+								{Name: "__name__", Value: "test_metric1"},
+								{Name: "b", Value: "c"},
+								{Name: "baz", Value: "qux"},
+								{Name: "d", Value: "e"},
+								{Name: "foo", Value: "bar1"},
+							},
+							Chunks: []prompb.Chunk{
+								{
+									Type:      prompb.Chunk_XOR,
+									MaxTimeMs: 7140000,
+									Data:      []byte("\000x\000\000\000\000\000\000\000\000\000\340\324\003\302|\005\224\000\301\254}\351z2\320O\355\264n[\007\316\224\243md\371\320\375\032Pm\nS\235\016Q\255\006P\275\250\277\312\201Z\003(3\240R\207\332\005(\017\240\322\201\332=(\023\2402\203Z\007(w\2402\201Z\017(\023\265\227\364P\033@\245\007\364\nP\033C\245\002t\036P+@e\036\364\016Pk@e\002t:P;A\245\001\364\nS\373@\245\006t\006P+C\345\002\364\006Pk@\345\036t\nP\033A\245\003\364:P\033@\245\006t\016ZJ\377\\\205\313\210\327\270\017\345+F[\310\347E)\355\024\241\366\342}(v\215(N\203)\326\207(\336\203(V\332W\362\202t4\240m\005(\377AJ\006\320\322\202t\374\240\255\003(oA\312:\3202"),
+								},
+							},
+						},
+					},
+					QueryIndex: 1,
+				},
+				{
+					ChunkedSeries: []*prompb.ChunkedSeries{
+						{
+							Labels: []prompb.Label{
+								{Name: "__name__", Value: "test_histogram_metric1"},
+								{Name: "b", Value: "c"},
+								{Name: "baz", Value: "qux"},
+								{Name: "d", Value: "e"},
+							},
+							Chunks: []prompb.Chunk{
+								{
+									Type:      prompb.Chunk_FLOAT_HISTOGRAM,
+									MaxTimeMs: 1440000,
+									Data:      []byte("\x00\x19\x00\xff?PbM\xd2\xf1\xa9\xfc\x8c\xa4\x94e$\xa2@(\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00@2ffffff?\xf0\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00\xf8\xea`\xd6/v\x03\xd2\x1f\xc2_\xff\xd8\x0f\t\x7f\xff\t\x7f\xff\t\x7f\xff`<%\xff\xfc%\xff\xf4\xbda{4\x9f\xff\xff\xff\xff\xff\xfd\x80\xf5\x85\xec\a\xb0\x1e\xc0z\xc2\xf6\x03\xd8\r\xa4\x8f\xbd\xa0\xf5\xeb\x9f\xff\xff\xff\xff\xff\xfda{A\xeb\v\xd6\x17\xac/h=az\xc2о\xc0\xb8\xac\xcc\xcc\xcc\xcc\xcc\xdbA\xec\v\xda\x0fh=\xa0\xf6\x05\xed\a\xb4\x1a\t\x99\x9333333;\x02\xe7`^\xc0\xbd\x81s\xb0/`Z8\xd4'\xea\x1f\xbc\xea\x13\xe6gP\x9f2\xdc$\xee\a\xbb)\xff\xff\xff\xff\xff\xffP\x9f\xb8\x1e\xa1?P\x9f\xa8O\xdc\x0fP\x9f\xa8Om\x17\xfbB\xf6\xe7\xb5UUUUUw\x03\xda\x17\xb8\x1e\xe0{\x81\xed\v\xdc\x0fp4\x99\x9d\x99\x99\x99\x99\x99\x9eй\xda\x17\xb4/h\\\xed\v\xda\x16\xd87{\x03\xfb2\xe4\xcc\xcc\xcc\xcc\xcc\xe7`~fv\a\xe6Q1ݕ\xaa\xaa\xaa\xaa\xaa\xab\xb0?\x1d\x81\xfd\x81\xfd\x81\xf8\xec\x0f\xec\x0f\xa5\xe7\xb7<\xff\xff\xff\xff\xff\xff\x19\xc61\x9cb\xd4O\xc6:\xf5\xef\xff\xff\xff\xff\xff\xfc\xe39\xce3\x9a\x05\xeb\x13\xe0\xac\xcc\xcc\xcc\xcc\xcc\xc7X\x9f\x18\xc7X\x9f\x18\xa0\xce\xf0pə\x99\x99\x99\x99\xb5\x89\xfb\xc1\xeb\x13\xf5\x89\xfa\xc4\xfd\xe0\xf5\x89\xfa\xc4\xf4\x0f\xdc\x17\a\xaa\xaa\xaa\xaa\xaa\xabx=\xc1{\xc1\xef\a\xbc\x1e\xe0\xbd\xe0\xf7\x83C\x99\x8e\x7f\xff\xff\xff\xff\xff\xb8.w\x05\xee\v\xdc\x17;\x82\xf7\x05\xa0^\xd0\xfc\x16\xaa\xaa\xaa\xaa\xaa\xa9\xda\x1f\x99\x9d\xa1\xf9\x94\x19\x8c-\x99\x99\x99\x99\x99\x9d\xa1\xf8\xed\x0f\xed\x0f\xed\x0f\xc7h\x7fh}\x1d\xe7<\x99\x99\x99\x99\x99\x9a3\x8cc8\xc5\x02c\x05\xaa\xaa\xaa\xaa\xaa\xaaq\x9c\xe7\x19\xcd\x06\xf6\t\xf0\xcf\xff\xff\xff\xff\xff\xe3\xb0O\x8cc\xb0O\x8cP&\x18=UUUUU[\x04\xf8v\t\xfb\x04\xfd\x82|;\x04\xfd\x82z\x1f\xc7\x1c\x99\x99\x99\x99\x99\x9a\x18\xe1\x86\x18\xe1\x84"),
+								},
+							},
+						},
+					},
+					QueryIndex: 2,
+				},
+			},
+		},
+		{
+			// XOR2 chunks are opt-in and remote read has no chunk encoding
+			// negotiation: a storage configured for xor2 puts prompb.Chunk_XOR2
+			// on the wire, and the client has to know that encoding to decode it.
+			// The byte layout is not pinned here, only the encoding and the
+			// samples that come back out of it.
+			name:               "xor2",
+			floatEncoding:      chunkenc.EncXOR2,
+			wantFloatChunkType: prompb.Chunk_XOR2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newStreamReadTestStorage(t, tc.floatEncoding)
+
+			api := NewReadHandler(nil, nil, store, func() config.Config {
+				return config.Config{
+					GlobalConfig: config.GlobalConfig{
+						// We expect external labels to be added, with the source labels honored.
+						ExternalLabels: labels.FromStrings("baz", "a", "b", "c", "d", "e"),
+					},
+				}
+			},
+				1e6, 1,
+				// Labelset has 57 bytes. Full chunk in test data has roughly 240 bytes. This allows us to have at max 2 chunks in this test.
+				57+480,
+			)
+
+			// Encode the request.
+			matcher1, err := labels.NewMatcher(labels.MatchEqual, "__name__", "test_metric1")
+			require.NoError(t, err)
+
+			matcher2, err := labels.NewMatcher(labels.MatchEqual, "d", "e")
+			require.NoError(t, err)
+
+			matcher3, err := labels.NewMatcher(labels.MatchEqual, "foo", "bar1")
+			require.NoError(t, err)
+
+			matcher4, err := labels.NewMatcher(labels.MatchEqual, "__name__", "test_histogram_metric1")
+			require.NoError(t, err)
+
+			query1, err := ToQuery(0, 14400001, []*labels.Matcher{matcher1, matcher2}, &storage.SelectHints{
+				Step:  1,
+				Func:  "avg",
+				Start: 0,
+				End:   14400001,
+			})
+			require.NoError(t, err)
+
+			query2, err := ToQuery(0, 14400001, []*labels.Matcher{matcher1, matcher3}, &storage.SelectHints{
+				Step:  1,
+				Func:  "avg",
+				Start: 0,
+				End:   14400001,
+			})
+			require.NoError(t, err)
+
+			query3, err := ToQuery(0, 14400001, []*labels.Matcher{matcher4}, &storage.SelectHints{
+				Step:  1,
+				Func:  "avg",
+				Start: 0,
+				End:   14400001,
+			})
+			require.NoError(t, err)
+
+			req := &prompb.ReadRequest{
+				Queries:               []*prompb.Query{query1, query2, query3},
+				AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_STREAMED_XOR_CHUNKS},
+			}
+			data, err := proto.Marshal(req)
+			require.NoError(t, err)
+
+			compressed := snappy.Encode(nil, data)
+			request, err := http.NewRequest(http.MethodPost, "", bytes.NewBuffer(compressed))
+			require.NoError(t, err)
+
+			recorder := httptest.NewRecorder()
+			api.ServeHTTP(recorder, request)
+
+			require.Equal(t, 2, recorder.Code/100)
+
+			require.Equal(t, "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse", recorder.Result().Header.Get("Content-Type"))
+			require.Empty(t, recorder.Result().Header.Get("Content-Encoding"))
+
+			var results []*prompb.ChunkedReadResponse
+			stream := NewChunkedReader(recorder.Result().Body, config.DefaultChunkedReadLimit, nil)
+			for {
+				res := &prompb.ChunkedReadResponse{}
+				err := stream.NextProto(res)
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				require.NoError(t, err)
+				results = append(results, res)
+			}
+
+			if tc.wantResults != nil {
+				require.Len(t, results, 6, "Expected 6 results.")
+				require.Equal(t, tc.wantResults, results)
+			}
+
+			// Whatever the framing, every float chunk on the wire carries the
+			// configured encoding, histogram chunks are unaffected, and a client
+			// decoding the chunks with chunkenc.FromData gets the appended
+			// samples back.
+			type seriesKey struct {
+				queryIndex int64
+				name, foo  string
+			}
+			gotFloats := map[seriesKey][]floatSample{}
+			gotHistograms := map[seriesKey]int{}
+			for _, res := range results {
+				for _, series := range res.ChunkedSeries {
+					key := seriesKey{queryIndex: res.QueryIndex}
+					for _, l := range series.Labels {
+						switch l.Name {
+						case "__name__":
+							key.name = l.Value
+						case "foo":
+							key.foo = l.Value
+						}
+					}
+					for _, chunk := range series.Chunks {
+						isHistogram := chunk.Type == prompb.Chunk_FLOAT_HISTOGRAM
+						if isHistogram {
+							require.Equal(t, "test_histogram_metric1", key.name)
+						} else {
+							require.Equal(t, tc.wantFloatChunkType, chunk.Type, "unexpected chunk type for series %v", key)
+						}
+
+						decoded, err := chunkenc.FromData(chunkenc.Encoding(chunk.Type), chunk.Data)
+						require.NoError(t, err)
+						it := decoded.Iterator(nil)
+						for valType := it.Next(); valType != chunkenc.ValNone; valType = it.Next() {
+							if isHistogram {
+								require.Equal(t, chunkenc.ValFloatHistogram, valType)
+								gotHistograms[key]++
+								continue
+							}
+							require.Equal(t, chunkenc.ValFloat, valType)
+							ts, v := it.At()
+							gotFloats[key] = append(gotFloats[key], floatSample{t: ts, v: v})
+						}
+						require.NoError(t, it.Err())
+					}
+				}
+			}
+
+			wantFloats := map[seriesKey]int{
+				{queryIndex: 0, name: "test_metric1", foo: "bar1"}: 120,
+				{queryIndex: 0, name: "test_metric1", foo: "bar2"}: 121,
+				{queryIndex: 0, name: "test_metric1", foo: "bar3"}: 241,
+				{queryIndex: 1, name: "test_metric1", foo: "bar1"}: 120,
+			}
+			require.Len(t, gotFloats, len(wantFloats))
+			for key, count := range wantFloats {
+				samples := gotFloats[key]
+				require.Len(t, samples, count, "unexpected sample count for series %v", key)
+				for i, s := range samples {
+					require.Equal(t, floatSample{t: int64(i) * 60000, v: float64(i) * 100}, s, "unexpected sample %d for series %v", i, key)
+				}
+			}
+			require.Equal(t, map[seriesKey]int{
+				{queryIndex: 2, name: "test_histogram_metric1"}: 25,
+			}, gotHistograms)
+		})
+	}
+}
+
+// floatSample is a float sample decoded from a chunk on the wire.
+type floatSample struct {
+	t int64
+	v float64
+}
+
+// newStreamReadTestStorage returns the storage TestStreamReadEndpoint queries:
+// three float series of 120, 121 and 241 samples plus the native histogram
+// series, with float chunks encoded using floatEncoding.
+func newStreamReadTestStorage(t *testing.T, floatEncoding chunkenc.Encoding) *teststorage.TestStorage {
+	t.Helper()
+
+	store := teststorage.New(t, func(opts *tsdb.Options) {
+		opts.FloatChunkEncoding = floatEncoding
+	})
+
+	app := store.Appender(t.Context())
+	for _, series := range []struct {
+		foo     string
+		samples int
+	}{
+		{foo: "bar1", samples: 120},
+		{foo: "bar2", samples: 121},
+		{foo: "bar3", samples: 241},
+	} {
+		lbls := labels.FromStrings("__name__", "test_metric1", "baz", "qux", "foo", series.foo)
+		for i := range series.samples {
+			_, err := app.Append(0, lbls, int64(i)*60000, float64(i)*100)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, app.Commit())
 
 	addNativeHistogramsToTestSuite(t, store, 25)
 
-	api := NewReadHandler(nil, nil, store, func() config.Config {
-		return config.Config{
-			GlobalConfig: config.GlobalConfig{
-				// We expect external labels to be added, with the source labels honored.
-				ExternalLabels: labels.FromStrings("baz", "a", "b", "c", "d", "e"),
-			},
-		}
-	},
-		1e6, 1,
-		// Labelset has 57 bytes. Full chunk in test data has roughly 240 bytes. This allows us to have at max 2 chunks in this test.
-		57+480,
-	)
-
-	// Encode the request.
-	matcher1, err := labels.NewMatcher(labels.MatchEqual, "__name__", "test_metric1")
-	require.NoError(t, err)
-
-	matcher2, err := labels.NewMatcher(labels.MatchEqual, "d", "e")
-	require.NoError(t, err)
-
-	matcher3, err := labels.NewMatcher(labels.MatchEqual, "foo", "bar1")
-	require.NoError(t, err)
-
-	matcher4, err := labels.NewMatcher(labels.MatchEqual, "__name__", "test_histogram_metric1")
-	require.NoError(t, err)
-
-	query1, err := ToQuery(0, 14400001, []*labels.Matcher{matcher1, matcher2}, &storage.SelectHints{
-		Step:  1,
-		Func:  "avg",
-		Start: 0,
-		End:   14400001,
-	})
-	require.NoError(t, err)
-
-	query2, err := ToQuery(0, 14400001, []*labels.Matcher{matcher1, matcher3}, &storage.SelectHints{
-		Step:  1,
-		Func:  "avg",
-		Start: 0,
-		End:   14400001,
-	})
-	require.NoError(t, err)
-
-	query3, err := ToQuery(0, 14400001, []*labels.Matcher{matcher4}, &storage.SelectHints{
-		Step:  1,
-		Func:  "avg",
-		Start: 0,
-		End:   14400001,
-	})
-	require.NoError(t, err)
-
-	req := &prompb.ReadRequest{
-		Queries:               []*prompb.Query{query1, query2, query3},
-		AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_STREAMED_XOR_CHUNKS},
-	}
-	data, err := proto.Marshal(req)
-	require.NoError(t, err)
-
-	compressed := snappy.Encode(nil, data)
-	request, err := http.NewRequest(http.MethodPost, "", bytes.NewBuffer(compressed))
-	require.NoError(t, err)
-
-	recorder := httptest.NewRecorder()
-	api.ServeHTTP(recorder, request)
-
-	require.Equal(t, 2, recorder.Code/100)
-
-	require.Equal(t, "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse", recorder.Result().Header.Get("Content-Type"))
-	require.Empty(t, recorder.Result().Header.Get("Content-Encoding"))
-
-	var results []*prompb.ChunkedReadResponse
-	stream := NewChunkedReader(recorder.Result().Body, config.DefaultChunkedReadLimit, nil)
-	for {
-		res := &prompb.ChunkedReadResponse{}
-		err := stream.NextProto(res)
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		require.NoError(t, err)
-		results = append(results, res)
-	}
-
-	require.Len(t, results, 6, "Expected 6 results.")
-
-	require.Equal(t, []*prompb.ChunkedReadResponse{
-		{
-			ChunkedSeries: []*prompb.ChunkedSeries{
-				{
-					Labels: []prompb.Label{
-						{Name: "__name__", Value: "test_metric1"},
-						{Name: "b", Value: "c"},
-						{Name: "baz", Value: "qux"},
-						{Name: "d", Value: "e"},
-						{Name: "foo", Value: "bar1"},
-					},
-					Chunks: []prompb.Chunk{
-						{
-							Type:      prompb.Chunk_XOR,
-							MaxTimeMs: 7140000,
-							Data:      []byte("\000x\000\000\000\000\000\000\000\000\000\340\324\003\302|\005\224\000\301\254}\351z2\320O\355\264n[\007\316\224\243md\371\320\375\032Pm\nS\235\016Q\255\006P\275\250\277\312\201Z\003(3\240R\207\332\005(\017\240\322\201\332=(\023\2402\203Z\007(w\2402\201Z\017(\023\265\227\364P\033@\245\007\364\nP\033C\245\002t\036P+@e\036\364\016Pk@e\002t:P;A\245\001\364\nS\373@\245\006t\006P+C\345\002\364\006Pk@\345\036t\nP\033A\245\003\364:P\033@\245\006t\016ZJ\377\\\205\313\210\327\270\017\345+F[\310\347E)\355\024\241\366\342}(v\215(N\203)\326\207(\336\203(V\332W\362\202t4\240m\005(\377AJ\006\320\322\202t\374\240\255\003(oA\312:\3202"),
-						},
-					},
-				},
-			},
-		},
-		{
-			ChunkedSeries: []*prompb.ChunkedSeries{
-				{
-					Labels: []prompb.Label{
-						{Name: "__name__", Value: "test_metric1"},
-						{Name: "b", Value: "c"},
-						{Name: "baz", Value: "qux"},
-						{Name: "d", Value: "e"},
-						{Name: "foo", Value: "bar2"},
-					},
-					Chunks: []prompb.Chunk{
-						{
-							Type:      prompb.Chunk_XOR,
-							MaxTimeMs: 7140000,
-							Data:      []byte("\000x\000\000\000\000\000\000\000\000\000\340\324\003\302|\005\224\000\301\254}\351z2\320O\355\264n[\007\316\224\243md\371\320\375\032Pm\nS\235\016Q\255\006P\275\250\277\312\201Z\003(3\240R\207\332\005(\017\240\322\201\332=(\023\2402\203Z\007(w\2402\201Z\017(\023\265\227\364P\033@\245\007\364\nP\033C\245\002t\036P+@e\036\364\016Pk@e\002t:P;A\245\001\364\nS\373@\245\006t\006P+C\345\002\364\006Pk@\345\036t\nP\033A\245\003\364:P\033@\245\006t\016ZJ\377\\\205\313\210\327\270\017\345+F[\310\347E)\355\024\241\366\342}(v\215(N\203)\326\207(\336\203(V\332W\362\202t4\240m\005(\377AJ\006\320\322\202t\374\240\255\003(oA\312:\3202"),
-						},
-						{
-							Type:      prompb.Chunk_XOR,
-							MinTimeMs: 7200000,
-							MaxTimeMs: 7200000,
-							Data:      []byte("\000\001\200\364\356\006@\307p\000\000\000\000\000"),
-						},
-					},
-				},
-			},
-		},
-		{
-			ChunkedSeries: []*prompb.ChunkedSeries{
-				{
-					Labels: []prompb.Label{
-						{Name: "__name__", Value: "test_metric1"},
-						{Name: "b", Value: "c"},
-						{Name: "baz", Value: "qux"},
-						{Name: "d", Value: "e"},
-						{Name: "foo", Value: "bar3"},
-					},
-					Chunks: []prompb.Chunk{
-						{
-							Type:      prompb.Chunk_XOR,
-							MaxTimeMs: 7140000,
-							Data:      []byte("\000x\000\000\000\000\000\000\000\000\000\340\324\003\302|\005\224\000\301\254}\351z2\320O\355\264n[\007\316\224\243md\371\320\375\032Pm\nS\235\016Q\255\006P\275\250\277\312\201Z\003(3\240R\207\332\005(\017\240\322\201\332=(\023\2402\203Z\007(w\2402\201Z\017(\023\265\227\364P\033@\245\007\364\nP\033C\245\002t\036P+@e\036\364\016Pk@e\002t:P;A\245\001\364\nS\373@\245\006t\006P+C\345\002\364\006Pk@\345\036t\nP\033A\245\003\364:P\033@\245\006t\016ZJ\377\\\205\313\210\327\270\017\345+F[\310\347E)\355\024\241\366\342}(v\215(N\203)\326\207(\336\203(V\332W\362\202t4\240m\005(\377AJ\006\320\322\202t\374\240\255\003(oA\312:\3202"),
-						},
-						{
-							Type:      prompb.Chunk_XOR,
-							MinTimeMs: 7200000,
-							MaxTimeMs: 14340000,
-							Data:      []byte("\000x\200\364\356\006@\307p\000\000\000\000\000\340\324\003\340>\224\355\260\277\322\200\372\005(=\240R\207:\003(\025\240\362\201z\003(\365\240r\203:\005(\r\241\322\201\372\r(\r\240R\237:\007(5\2402\201z\037(\025\2402\203:\005(\375\240R\200\372\r(\035\241\322\201:\003(5\240r\326g\364\271\213\227!\253q\037\312N\340GJ\033E)\375\024\241\266\362}(N\217(V\203)\336\207(\326\203(N\334W\322\203\2644\240}\005(\373AJ\031\3202\202\264\374\240\275\003(kA\3129\320R\201\2644\240\375\264\277\322\200\332\005(3\240r\207Z\003(\027\240\362\201Z\003(\363\240R\203\332\005(\017\241\322\201\332\r(\023\2402\237Z\007(7\2402\201Z\037(\023\240\322\200\332\005(\377\240R\200\332\r "),
-						},
-					},
-				},
-			},
-		},
-		{
-			ChunkedSeries: []*prompb.ChunkedSeries{
-				{
-					Labels: []prompb.Label{
-						{Name: "__name__", Value: "test_metric1"},
-						{Name: "b", Value: "c"},
-						{Name: "baz", Value: "qux"},
-						{Name: "d", Value: "e"},
-						{Name: "foo", Value: "bar3"},
-					},
-					Chunks: []prompb.Chunk{
-						{
-							Type:      prompb.Chunk_XOR,
-							MinTimeMs: 14400000,
-							MaxTimeMs: 14400000,
-							Data:      []byte("\000\001\200\350\335\r@\327p\000\000\000\000\000"),
-						},
-					},
-				},
-			},
-		},
-		{
-			ChunkedSeries: []*prompb.ChunkedSeries{
-				{
-					Labels: []prompb.Label{
-						{Name: "__name__", Value: "test_metric1"},
-						{Name: "b", Value: "c"},
-						{Name: "baz", Value: "qux"},
-						{Name: "d", Value: "e"},
-						{Name: "foo", Value: "bar1"},
-					},
-					Chunks: []prompb.Chunk{
-						{
-							Type:      prompb.Chunk_XOR,
-							MaxTimeMs: 7140000,
-							Data:      []byte("\000x\000\000\000\000\000\000\000\000\000\340\324\003\302|\005\224\000\301\254}\351z2\320O\355\264n[\007\316\224\243md\371\320\375\032Pm\nS\235\016Q\255\006P\275\250\277\312\201Z\003(3\240R\207\332\005(\017\240\322\201\332=(\023\2402\203Z\007(w\2402\201Z\017(\023\265\227\364P\033@\245\007\364\nP\033C\245\002t\036P+@e\036\364\016Pk@e\002t:P;A\245\001\364\nS\373@\245\006t\006P+C\345\002\364\006Pk@\345\036t\nP\033A\245\003\364:P\033@\245\006t\016ZJ\377\\\205\313\210\327\270\017\345+F[\310\347E)\355\024\241\366\342}(v\215(N\203)\326\207(\336\203(V\332W\362\202t4\240m\005(\377AJ\006\320\322\202t\374\240\255\003(oA\312:\3202"),
-						},
-					},
-				},
-			},
-			QueryIndex: 1,
-		},
-		{
-			ChunkedSeries: []*prompb.ChunkedSeries{
-				{
-					Labels: []prompb.Label{
-						{Name: "__name__", Value: "test_histogram_metric1"},
-						{Name: "b", Value: "c"},
-						{Name: "baz", Value: "qux"},
-						{Name: "d", Value: "e"},
-					},
-					Chunks: []prompb.Chunk{
-						{
-							Type:      prompb.Chunk_FLOAT_HISTOGRAM,
-							MaxTimeMs: 1440000,
-							Data:      []byte("\x00\x19\x00\xff?PbM\xd2\xf1\xa9\xfc\x8c\xa4\x94e$\xa2@(\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00@2ffffff?\xf0\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00\xf8\xea`\xd6/v\x03\xd2\x1f\xc2_\xff\xd8\x0f\t\x7f\xff\t\x7f\xff\t\x7f\xff`<%\xff\xfc%\xff\xf4\xbda{4\x9f\xff\xff\xff\xff\xff\xfd\x80\xf5\x85\xec\a\xb0\x1e\xc0z\xc2\xf6\x03\xd8\r\xa4\x8f\xbd\xa0\xf5\xeb\x9f\xff\xff\xff\xff\xff\xfda{A\xeb\v\xd6\x17\xac/h=az\xc2о\xc0\xb8\xac\xcc\xcc\xcc\xcc\xcc\xdbA\xec\v\xda\x0fh=\xa0\xf6\x05\xed\a\xb4\x1a\t\x99\x9333333;\x02\xe7`^\xc0\xbd\x81s\xb0/`Z8\xd4'\xea\x1f\xbc\xea\x13\xe6gP\x9f2\xdc$\xee\a\xbb)\xff\xff\xff\xff\xff\xffP\x9f\xb8\x1e\xa1?P\x9f\xa8O\xdc\x0fP\x9f\xa8Om\x17\xfbB\xf6\xe7\xb5UUUUUw\x03\xda\x17\xb8\x1e\xe0{\x81\xed\v\xdc\x0fp4\x99\x9d\x99\x99\x99\x99\x99\x9eй\xda\x17\xb4/h\\\xed\v\xda\x16\xd87{\x03\xfb2\xe4\xcc\xcc\xcc\xcc\xcc\xe7`~fv\a\xe6Q1ݕ\xaa\xaa\xaa\xaa\xaa\xab\xb0?\x1d\x81\xfd\x81\xfd\x81\xf8\xec\x0f\xec\x0f\xa5\xe7\xb7<\xff\xff\xff\xff\xff\xff\x19\xc61\x9cb\xd4O\xc6:\xf5\xef\xff\xff\xff\xff\xff\xfc\xe39\xce3\x9a\x05\xeb\x13\xe0\xac\xcc\xcc\xcc\xcc\xcc\xc7X\x9f\x18\xc7X\x9f\x18\xa0\xce\xf0pə\x99\x99\x99\x99\xb5\x89\xfb\xc1\xeb\x13\xf5\x89\xfa\xc4\xfd\xe0\xf5\x89\xfa\xc4\xf4\x0f\xdc\x17\a\xaa\xaa\xaa\xaa\xaa\xabx=\xc1{\xc1\xef\a\xbc\x1e\xe0\xbd\xe0\xf7\x83C\x99\x8e\x7f\xff\xff\xff\xff\xff\xb8.w\x05\xee\v\xdc\x17;\x82\xf7\x05\xa0^\xd0\xfc\x16\xaa\xaa\xaa\xaa\xaa\xa9\xda\x1f\x99\x9d\xa1\xf9\x94\x19\x8c-\x99\x99\x99\x99\x99\x9d\xa1\xf8\xed\x0f\xed\x0f\xed\x0f\xc7h\x7fh}\x1d\xe7<\x99\x99\x99\x99\x99\x9a3\x8cc8\xc5\x02c\x05\xaa\xaa\xaa\xaa\xaa\xaaq\x9c\xe7\x19\xcd\x06\xf6\t\xf0\xcf\xff\xff\xff\xff\xff\xe3\xb0O\x8cc\xb0O\x8cP&\x18=UUUUU[\x04\xf8v\t\xfb\x04\xfd\x82|;\x04\xfd\x82z\x1f\xc7\x1c\x99\x99\x99\x99\x99\x9a\x18\xe1\x86\x18\xe1\x84"),
-						},
-					},
-				},
-			},
-			QueryIndex: 2,
-		},
-	}, results)
+	return store
 }
 
 func addNativeHistogramsToTestSuite(t *testing.T, storage *teststorage.TestStorage, n int) {

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/testutil"
 )
@@ -290,7 +291,57 @@ func (c *mockedRemoteClient) reset() {
 	c.gotMultiple = nil
 }
 
-// NOTE: We don't need to test ChunkQuerier as it's uses querier for all operations anyway.
+func TestChunkQuerierFloatEncoding(t *testing.T) {
+	for name, tc := range map[string]struct {
+		floatEncoding storage.FloatEncodingFunc
+		expected      chunkenc.Encoding
+	}{
+		"nil getter defaults to xor": {
+			floatEncoding: nil,
+			expected:      chunkenc.EncXOR,
+		},
+		"xor": {
+			floatEncoding: func() chunkenc.Encoding { return chunkenc.EncXOR },
+			expected:      chunkenc.EncXOR,
+		},
+		"xor2": {
+			floatEncoding: func() chunkenc.Encoding { return chunkenc.EncXOR2 },
+			expected:      chunkenc.EncXOR2,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := &mockedRemoteClient{
+				store: []*prompb.TimeSeries{
+					{
+						Labels:  []prompb.Label{{Name: "a", Value: "b"}},
+						Samples: []prompb.Sample{{Timestamp: 1, Value: 1}, {Timestamp: 2, Value: 2}},
+					},
+				},
+			}
+			c := NewSampleAndChunkQueryableClientWithOptions(
+				m,
+				labels.EmptyLabels(),
+				nil,
+				true,
+				func() (int64, error) { return 0, nil },
+				SampleAndChunkQueryableClientOptions{FloatEncoding: tc.floatEncoding},
+			)
+			q, err := c.ChunkQuerier(0, 10)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, q.Close()) })
+
+			ss := q.Select(context.Background(), true, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+			require.True(t, ss.Next())
+			chks, err := storage.ExpandChunks(ss.At().Iterator(nil))
+			require.NoError(t, err)
+			require.Len(t, chks, 1)
+			require.Equal(t, tc.expected, chks[0].Chunk.Encoding())
+			require.False(t, ss.Next())
+			require.NoError(t, ss.Err())
+		})
+	}
+}
+
 func TestSampleAndChunkQueryableClient(t *testing.T) {
 	m := &mockedRemoteClient{
 		// Samples does not matter for below tests.

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -216,7 +216,7 @@ func (s *Storage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
 		}
 		queriers = append(queriers, q)
 	}
-	return storage.NewMergeChunkQuerier(nil, queriers, storage.NewCompactingChunkSeriesMerger(storage.ChainedSeriesMerge)), nil
+	return storage.NewMergeChunkQuerier(nil, queriers, storage.NewCompactingChunkSeriesMergerWithFloatEncoding(storage.ChainedSeriesMerge, s.floatEncodingNow)), nil
 }
 
 // Appender implements storage.Storage.

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/logging"
 )
 
@@ -61,6 +62,9 @@ type Storage struct {
 	// For reads.
 	queryables             []storage.SampleAndChunkQueryable
 	localStartTimeCallback startTimeCallback
+	// floatEncoding is guarded by mtx. The queryables built by ApplyConfig read
+	// it through floatEncodingNow, so it may be set at any time.
+	floatEncoding storage.FloatEncodingFunc
 }
 
 var _ storage.Storage = &Storage{}
@@ -80,6 +84,30 @@ func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeC
 	}
 	s.rws = NewWriteStorage(s.logger, reg, walDir, flushDeadline, sm, enableTypeAndUnitLabels)
 	return s
+}
+
+// SetFloatEncoding sets the encoding used for the float chunks encoded from the
+// samples read from the configured remote read endpoints, in chunk queries. See
+// storage.FloatEncodingFunc. It takes effect on the queries that follow,
+// including on queryables that ApplyConfig has already built.
+func (s *Storage) SetFloatEncoding(f storage.FloatEncodingFunc) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.floatEncoding = f
+}
+
+// floatEncodingNow returns the encoding the float chunks encoded from remote
+// read samples currently use. It is a storage.FloatEncodingFunc, so that the
+// read path follows SetFloatEncoding instead of capturing whichever getter was
+// set when ApplyConfig built it.
+func (s *Storage) floatEncodingNow() chunkenc.Encoding {
+	s.mtx.Lock()
+	f := s.floatEncoding
+	s.mtx.Unlock()
+	if f == nil {
+		return chunkenc.EncXOR
+	}
+	return f()
 }
 
 func (s *Storage) Notify() {
@@ -133,12 +161,13 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		if !rrConf.FilterExternalLabels {
 			externalLabels = labels.EmptyLabels()
 		}
-		queryables = append(queryables, NewSampleAndChunkQueryableClient(
+		queryables = append(queryables, NewSampleAndChunkQueryableClientWithOptions(
 			c,
 			externalLabels,
 			labelsToEqualityMatchers(rrConf.RequiredMatchers),
 			rrConf.ReadRecent,
 			s.localStartTimeCallback,
+			SampleAndChunkQueryableClientOptions{FloatEncoding: s.floatEncodingNow},
 		))
 	}
 	s.queryables = queryables

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -14,6 +14,7 @@
 package remote
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"sync"
@@ -24,6 +25,9 @@ import (
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
 func TestStorageLifecycle(t *testing.T) {
@@ -189,4 +193,137 @@ func TestWriteStorageApplyConfigsDuringCommit(t *testing.T) {
 
 	close(start)
 	wg.Wait()
+}
+
+func TestStorageChunkQuerierFloatEncoding(t *testing.T) {
+	overlap := []prompb.Label{{Name: "a", Value: "overlap"}, {Name: "job", Value: "test"}}
+	single := []prompb.Label{{Name: "a", Value: "single"}, {Name: "job", Value: "test"}}
+
+	// storeA holds a series interleaved with the one in storeB, so that merging
+	// the two endpoints has to re-encode it, plus a series only it knows about,
+	// which the merger passes through untouched.
+	storeA := []*prompb.TimeSeries{
+		{Labels: overlap, Samples: []prompb.Sample{{Timestamp: 1, Value: 1}, {Timestamp: 3, Value: 3}, {Timestamp: 5, Value: 5}}},
+		{Labels: single, Samples: []prompb.Sample{{Timestamp: 1, Value: 1}, {Timestamp: 2, Value: 2}}},
+	}
+	storeB := []*prompb.TimeSeries{
+		{Labels: overlap, Samples: []prompb.Sample{{Timestamp: 2, Value: 2}, {Timestamp: 4, Value: 4}, {Timestamp: 6, Value: 6}}},
+	}
+
+	type wantSeries struct {
+		lset       labels.Labels
+		timestamps []int64
+	}
+
+	for name, tc := range map[string]struct {
+		stores        [][]*prompb.TimeSeries
+		floatEncoding storage.FloatEncodingFunc
+		// setLate calls SetFloatEncoding after ApplyConfig has already built the
+		// queryables, which must make no difference.
+		setLate  bool
+		expected chunkenc.Encoding
+		want     []wantSeries
+	}{
+		"one endpoint, nil getter defaults to xor": {
+			stores:        [][]*prompb.TimeSeries{storeA},
+			floatEncoding: nil,
+			expected:      chunkenc.EncXOR,
+			want: []wantSeries{
+				{lset: labels.FromStrings("a", "overlap", "job", "test"), timestamps: []int64{1, 3, 5}},
+				{lset: labels.FromStrings("a", "single", "job", "test"), timestamps: []int64{1, 2}},
+			},
+		},
+		"one endpoint, xor2": {
+			stores:        [][]*prompb.TimeSeries{storeA},
+			floatEncoding: func() chunkenc.Encoding { return chunkenc.EncXOR2 },
+			expected:      chunkenc.EncXOR2,
+			want: []wantSeries{
+				{lset: labels.FromStrings("a", "overlap", "job", "test"), timestamps: []int64{1, 3, 5}},
+				{lset: labels.FromStrings("a", "single", "job", "test"), timestamps: []int64{1, 2}},
+			},
+		},
+		"two overlapping endpoints, nil getter defaults to xor": {
+			stores:        [][]*prompb.TimeSeries{storeA, storeB},
+			floatEncoding: nil,
+			expected:      chunkenc.EncXOR,
+			want: []wantSeries{
+				{lset: labels.FromStrings("a", "overlap", "job", "test"), timestamps: []int64{1, 2, 3, 4, 5, 6}},
+				{lset: labels.FromStrings("a", "single", "job", "test"), timestamps: []int64{1, 2}},
+			},
+		},
+		"two overlapping endpoints, xor2": {
+			stores:        [][]*prompb.TimeSeries{storeA, storeB},
+			floatEncoding: func() chunkenc.Encoding { return chunkenc.EncXOR2 },
+			expected:      chunkenc.EncXOR2,
+			want: []wantSeries{
+				{lset: labels.FromStrings("a", "overlap", "job", "test"), timestamps: []int64{1, 2, 3, 4, 5, 6}},
+				{lset: labels.FromStrings("a", "single", "job", "test"), timestamps: []int64{1, 2}},
+			},
+		},
+		"two overlapping endpoints, xor2 set after ApplyConfig": {
+			stores:        [][]*prompb.TimeSeries{storeA, storeB},
+			floatEncoding: func() chunkenc.Encoding { return chunkenc.EncXOR2 },
+			setLate:       true,
+			expected:      chunkenc.EncXOR2,
+			want: []wantSeries{
+				{lset: labels.FromStrings("a", "overlap", "job", "test"), timestamps: []int64{1, 2, 3, 4, 5, 6}},
+				{lset: labels.FromStrings("a", "single", "job", "test"), timestamps: []int64{1, 2}},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := NewStorage(nil, nil, nil, t.TempDir(), defaultFlushDeadline, nil, false)
+			t.Cleanup(func() { require.NoError(t, s.Close()) })
+			if !tc.setLate {
+				s.SetFloatEncoding(tc.floatEncoding)
+			}
+
+			conf := &config.Config{GlobalConfig: config.DefaultGlobalConfig}
+			for i := range tc.stores {
+				rrConf := baseRemoteReadConfig(fmt.Sprintf("http://test-storage-%d.com", i))
+				rrConf.ReadRecent = true
+				conf.RemoteReadConfigs = append(conf.RemoteReadConfigs, rrConf)
+			}
+			require.NoError(t, s.ApplyConfig(conf))
+			require.Len(t, s.queryables, len(tc.stores))
+
+			// ApplyConfig builds HTTP read clients from the configured URLs, which
+			// no server backs here, so swap in fakes serving the wanted stores.
+			for i, store := range tc.stores {
+				s.queryables[i].(*sampleAndChunkQueryableClient).client = &mockedRemoteClient{store: store}
+			}
+
+			if tc.setLate {
+				s.SetFloatEncoding(tc.floatEncoding)
+			}
+
+			q, err := s.ChunkQuerier(0, 10)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, q.Close()) })
+
+			ss := q.Select(context.Background(), true, nil, labels.MustNewMatcher(labels.MatchEqual, "job", "test"))
+			var got []wantSeries
+			for ss.Next() {
+				series := wantSeries{lset: ss.At().Labels()}
+				chks, err := storage.ExpandChunks(ss.At().Iterator(nil))
+				require.NoError(t, err)
+				require.NotEmpty(t, chks)
+				for _, chk := range chks {
+					// Every float chunk of this response uses the configured
+					// encoding, whether it was re-encoded by the merger or
+					// passed through.
+					require.Equal(t, tc.expected, chk.Chunk.Encoding())
+					it := chk.Chunk.Iterator(nil)
+					for it.Next() == chunkenc.ValFloat {
+						ts, _ := it.At()
+						series.timestamps = append(series.timestamps, ts)
+					}
+					require.NoError(t, it.Err())
+				}
+				got = append(got, series)
+			}
+			require.NoError(t, ss.Err())
+			require.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/storage/series.go
+++ b/storage/series.go
@@ -24,6 +24,23 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
+// FloatEncodingFunc returns the chunk encoding to use for float chunks encoded
+// in memory. Only EncXOR and EncXOR2 are meaningful; any other value, and a nil
+// FloatEncodingFunc, behave like EncXOR. Implementations must be safe for
+// concurrent use and may return a different value on each call, e.g. when backed
+// by runtime-reloadable configuration. Samples carrying a start timestamp are
+// always encoded as XOR2, as plain XOR chunks cannot store start timestamps.
+type FloatEncodingFunc func() chunkenc.Encoding
+
+// resolveFloatEncoding returns the encoding f asks for, defaulting to EncXOR
+// when f is nil.
+func resolveFloatEncoding(f FloatEncodingFunc) chunkenc.Encoding {
+	if f == nil {
+		return chunkenc.EncXOR
+	}
+	return f()
+}
+
 type SeriesEntry struct {
 	Lset             labels.Labels
 	SampleIteratorFn func(chunkenc.Iterator) chunkenc.Iterator
@@ -289,11 +306,22 @@ func newChunkToSeriesDecoder(labels labels.Labels, chk chunks.Meta) Series {
 
 type seriesSetToChunkSet struct {
 	SeriesSet
+	// floatEncoding is consulted on every At call.
+	floatEncoding FloatEncodingFunc
 }
 
 // NewSeriesSetToChunkSet converts SeriesSet to ChunkSeriesSet by encoding chunks from samples.
 func NewSeriesSetToChunkSet(chk SeriesSet) ChunkSeriesSet {
-	return &seriesSetToChunkSet{SeriesSet: chk}
+	return NewSeriesSetToChunkSetWithFloatEncoding(chk, nil)
+}
+
+// NewSeriesSetToChunkSetWithFloatEncoding is like NewSeriesSetToChunkSet, but
+// float samples are encoded with the encoding returned by floatEncoding. Unlike
+// NewSeriesToChunkEncoderWithFloatEncoding, which encodes a single series and so
+// takes a plain encoding, this takes a FloatEncodingFunc: it is consulted on
+// every At call, so two series of one set may be encoded differently.
+func NewSeriesSetToChunkSetWithFloatEncoding(chk SeriesSet, floatEncoding FloatEncodingFunc) ChunkSeriesSet {
+	return &seriesSetToChunkSet{SeriesSet: chk, floatEncoding: floatEncoding}
 }
 
 func (c *seriesSetToChunkSet) Next() bool {
@@ -304,7 +332,7 @@ func (c *seriesSetToChunkSet) Next() bool {
 }
 
 func (c *seriesSetToChunkSet) At() ChunkSeries {
-	return NewSeriesToChunkEncoder(c.SeriesSet.At())
+	return NewSeriesToChunkEncoderWithFloatEncoding(c.SeriesSet.At(), resolveFloatEncoding(c.floatEncoding))
 }
 
 func (c *seriesSetToChunkSet) Err() error {

--- a/storage/series_test.go
+++ b/storage/series_test.go
@@ -889,6 +889,50 @@ func TestSeriesToChunkEncoderFloatEncoding(t *testing.T) {
 	}
 }
 
+func TestSeriesSetToChunkSetFloatEncoding(t *testing.T) {
+	samples := []chunks.Sample{fSample{0, 10, 1}, fSample{0, 20, 2}, fSample{0, 30, 3}}
+	series := []Series{
+		NewListSeries(labels.FromStrings("__name__", "up"), samples),
+		NewListSeries(labels.FromStrings("__name__", "down"), samples),
+	}
+
+	for name, tc := range map[string]struct {
+		floatEncoding func() chunkenc.Encoding
+		expected      chunkenc.Encoding
+	}{
+		"nil getter defaults to xor": {
+			floatEncoding: nil,
+			expected:      chunkenc.EncXOR,
+		},
+		"xor": {
+			floatEncoding: func() chunkenc.Encoding { return chunkenc.EncXOR },
+			expected:      chunkenc.EncXOR,
+		},
+		"xor2": {
+			floatEncoding: func() chunkenc.Encoding { return chunkenc.EncXOR2 },
+			expected:      chunkenc.EncXOR2,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			css := NewSeriesSetToChunkSetWithFloatEncoding(NewMockSeriesSet(series...), tc.floatEncoding)
+
+			var got int
+			for css.Next() {
+				got++
+				chks, err := ExpandChunks(css.At().Iterator(nil))
+				require.NoError(t, err)
+				require.Len(t, chks, 1)
+				require.Equal(t, tc.expected, chks[0].Chunk.Encoding())
+				actSamples, err := ExpandSamples(chks[0].Chunk.Iterator(nil), nil)
+				require.NoError(t, err)
+				require.Equal(t, samples, actSamples)
+			}
+			require.NoError(t, css.Err())
+			require.Equal(t, len(series), got)
+		})
+	}
+}
+
 func getCounterResetHint(chunk chunks.Meta) chunkenc.CounterResetHeader {
 	switch chk := chunk.Chunk.(type) {
 	case *chunkenc.HistogramChunk:

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -171,10 +171,10 @@ type LeveledCompactorOptions struct {
 	// MergeFunc is used for merging series together in vertical compaction. By default storage.NewCompactingChunkSeriesMergerWithFloatEncoding(storage.ChainedSeriesMerge, opts.FloatChunkEncoding) is used.
 	MergeFunc storage.VerticalChunkSeriesMergeFunc
 
-	// FloatChunkEncoding returns the encoding used for float chunks re-encoded during
-	// vertical (overlapping) compaction. Consulted at compaction time, so it may
-	// reflect runtime-reloaded configuration. Nil means EncXOR. Ignored when MergeFunc
-	// is set.
+	// FloatChunkEncoding returns the encoding used for float chunks re-encoded
+	// during vertical (overlapping) compaction. It is left as a plain func because
+	// storage.FloatEncodingFunc would reject a caller passing its own named func
+	// type; it carries the contract documented there. Ignored when MergeFunc is set.
 	FloatChunkEncoding func() chunkenc.Encoding
 
 	// BlockExcludeFilter is used to decide which blocks are excluded from compactions.

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1096,7 +1096,7 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 			PD:                          opts.PostingsDecoderFactory,
 			UseUncachedIO:               opts.UseUncachedIO,
 			BlockExcludeFilter:          opts.BlockCompactionExcludeFunc,
-			FloatChunkEncoding:          db.floatChunkEncoding,
+			FloatChunkEncoding:          db.FloatChunkEncoding,
 		})
 	}
 	if err != nil {
@@ -2735,11 +2735,12 @@ func (db *DB) blockChunkQuerierForRange(mint, maxt int64) (_ []storage.ChunkQuer
 	return blockQueriers, nil
 }
 
-// floatChunkEncoding returns the float chunk encoding currently in effect,
-// following runtime configuration reloads. Falls back to the startup option before
-// the head exists; only called from compaction and queries, which start after
-// open() has set db.head.
-func (db *DB) floatChunkEncoding() chunkenc.Encoding {
+// FloatChunkEncoding returns the float chunk encoding currently in effect,
+// following runtime configuration reloads. It is safe for concurrent use:
+// db.head is read without holding db.mtx because open() assigns it once, before
+// it returns the DB, and never reassigns it. The startup option is only reached
+// from open() itself, while it builds the head.
+func (db *DB) FloatChunkEncoding() chunkenc.Encoding {
 	if h := db.head; h != nil {
 		return chunkenc.Encoding(h.opts.FloatChunkEncoding.Load())
 	}
@@ -2752,7 +2753,7 @@ func (db *DB) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
 	if err != nil {
 		return nil, err
 	}
-	return storage.NewMergeChunkQuerier(blockQueriers, nil, storage.NewCompactingChunkSeriesMergerWithFloatEncoding(storage.ChainedSeriesMerge, db.floatChunkEncoding)), nil
+	return storage.NewMergeChunkQuerier(blockQueriers, nil, storage.NewCompactingChunkSeriesMergerWithFloatEncoding(storage.ChainedSeriesMerge, db.FloatChunkEncoding)), nil
 }
 
 func (db *DB) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {


### PR DESCRIPTION
Chunks encoded in memory rather than read from disk always used XOR, ignoring the configured `chunk_encoding`. This affects chunked remote read queries, whose chunks are encoded from the samples returned by the remote read endpoint, and the chunk querier compacting overlaps between the local TSDB and a remote read endpoint.

Thread a float encoding getter from the TSDB, which tracks runtime configuration reloads, through the fanout storage and the remote read queryable down to seriesSetToChunkSet. The getter falls back to the startup option while the local storage is not ready or does not store chunks (agent mode).

The existing constructors keep their signature and default to XOR, so external users are unaffected.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] TSDB: Apply configured float chunk encoding to in-memory chunks
```
