### PR TITLE
Add support for http debugging

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -119,6 +119,7 @@ func main() {
 	).Default("5m").Duration()
 
 	experimental := app.Flag("experimental", "Enable experimental commands.").Bool()
+	httpDebug := app.Flag("http.debug", "Log outgoing HTTP requests and responses to stderr (credentials are redacted). Useful for diagnosing connectivity and authentication issues.").Bool()
 
 	sdCheckCmd := checkCmd.Command("service-discovery", "Perform service discovery for the given job name and report the results, including relabeling.")
 	sdConfigFile := sdCheckCmd.Arg("config-file", "The prometheus config file.").Required().ExistingFile()
@@ -353,6 +354,9 @@ func main() {
 		if err != nil {
 			kingpin.Fatalf("Failed to create a new HTTP round tripper: %v", err)
 		}
+	}
+	if *httpDebug {
+		httpRoundTripper = promconfig.NewDebugRoundTripper(os.Stderr, httpRoundTripper)
 	}
 
 	for _, f := range *featureList {

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -12,6 +12,7 @@ Tooling for the Prometheus monitoring system.
 | <code class="text-nowrap">-h</code>, <code class="text-nowrap">--help</code> | Show context-sensitive help (also try --help-long and --help-man). |
 | <code class="text-nowrap">--version</code> | Show application version. |
 | <code class="text-nowrap">--experimental</code> | Enable experimental commands. |
+| <code class="text-nowrap">--http.debug</code> | Log outgoing HTTP requests and responses to stderr (credentials are redacted). Useful for diagnosing connectivity and authentication issues. |
 | <code class="text-nowrap">--enable-feature</code> <code class="text-nowrap">...</code> | Comma separated feature names to enable. Valid options: promql-experimental-functions, promql-delayed-name-removal, promql-extended-range-selectors. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details |
 
 


### PR DESCRIPTION
This depends on https://github.com/prometheus/common/pull/985 for the
infrastructure, but adds an --http.debug flag that uses the
prometheus/common debug roundtripper to provide debug logs with
credentials censored.

**NOTE**: Will fail tests until  https://github.com/prometheus/common/pull/985 is merged

Signed-off-by: Phil Dibowitz <phil@ipom.com>
