### PR TITLE
discovery/aws: don't panic on MSK clusters with absent optional fields

### DIFF
--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -312,6 +312,12 @@ func (d *MSKDiscovery) describeClusters(ctx context.Context, clusterARNs []strin
 			if err != nil {
 				return fmt.Errorf("could not describe cluster %v: %w", clusterARN, err)
 			}
+			// The API may answer without any cluster information, which leaves
+			// nothing to build targets from.
+			if cluster.ClusterInfo == nil {
+				d.logger.Warn("Skipping MSK cluster described without cluster information", "cluster", clusterARN)
+				return nil
+			}
 			// Only provisioned clusters expose broker nodes; skip anything
 			// else (e.g. serverless clusters) that was explicitly configured.
 			if cluster.ClusterInfo.ClusterType != types.ClusterTypeProvisioned {
@@ -431,30 +437,48 @@ func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 
 		go func(cluster types.Cluster, nodes []types.NodeInfo) {
 			defer wg.Done()
+
+			// The provisioned configuration carries the broker software and
+			// monitoring details, and the API omits it for clusters it does
+			// not report as provisioned.
+			var (
+				brokerSoftware *types.BrokerSoftwareInfo
+				openMonitoring *types.OpenMonitoringInfo
+			)
+			if p := cluster.Provisioned; p != nil {
+				brokerSoftware = p.CurrentBrokerSoftwareInfo
+				openMonitoring = p.OpenMonitoring
+			}
+
 			for _, node := range nodes {
 				labels := model.LabelSet{
-					mskLabelClusterName:         model.LabelValue(aws.ToString(cluster.ClusterName)),
-					mskLabelClusterARN:          model.LabelValue(aws.ToString(cluster.ClusterArn)),
-					mskLabelClusterState:        model.LabelValue(string(cluster.State)),
-					mskLabelClusterType:         model.LabelValue(string(cluster.ClusterType)),
-					mskLabelClusterVersion:      model.LabelValue(aws.ToString(cluster.CurrentVersion)),
-					mskLabelNodeARN:             model.LabelValue(aws.ToString(node.NodeARN)),
-					mskLabelNodeAddedTime:       model.LabelValue(aws.ToString(node.AddedToClusterTime)),
-					mskLabelNodeInstanceType:    model.LabelValue(aws.ToString(node.InstanceType)),
-					mskLabelClusterKafkaVersion: model.LabelValue(aws.ToString(cluster.Provisioned.CurrentBrokerSoftwareInfo.KafkaVersion)),
+					mskLabelClusterName:      model.LabelValue(aws.ToString(cluster.ClusterName)),
+					mskLabelClusterARN:       model.LabelValue(aws.ToString(cluster.ClusterArn)),
+					mskLabelClusterState:     model.LabelValue(string(cluster.State)),
+					mskLabelClusterType:      model.LabelValue(string(cluster.ClusterType)),
+					mskLabelClusterVersion:   model.LabelValue(aws.ToString(cluster.CurrentVersion)),
+					mskLabelNodeARN:          model.LabelValue(aws.ToString(node.NodeARN)),
+					mskLabelNodeAddedTime:    model.LabelValue(aws.ToString(node.AddedToClusterTime)),
+					mskLabelNodeInstanceType: model.LabelValue(aws.ToString(node.InstanceType)),
 				}
 
-				// The configuration ARN and revision labels are omitted when the cluster is not using a custom configuration.
-				if cluster.Provisioned.CurrentBrokerSoftwareInfo.ConfigurationArn != nil {
-					labels[mskLabelClusterConfigurationARN] = model.LabelValue(aws.ToString(cluster.Provisioned.CurrentBrokerSoftwareInfo.ConfigurationArn))
-				}
-				if cluster.Provisioned.CurrentBrokerSoftwareInfo.ConfigurationRevision != nil {
-					labels[mskLabelClusterConfigurationRevision] = model.LabelValue(strconv.FormatInt(aws.ToInt64(cluster.Provisioned.CurrentBrokerSoftwareInfo.ConfigurationRevision), 10))
+				// The broker software labels are omitted when the API did not
+				// report the software running on the cluster.
+				if brokerSoftware != nil {
+					labels[mskLabelClusterKafkaVersion] = model.LabelValue(aws.ToString(brokerSoftware.KafkaVersion))
+
+					// The configuration ARN and revision labels are omitted when the cluster is not using a custom configuration.
+					if brokerSoftware.ConfigurationArn != nil {
+						labels[mskLabelClusterConfigurationARN] = model.LabelValue(aws.ToString(brokerSoftware.ConfigurationArn))
+					}
+					if brokerSoftware.ConfigurationRevision != nil {
+						labels[mskLabelClusterConfigurationRevision] = model.LabelValue(strconv.FormatInt(aws.ToInt64(brokerSoftware.ConfigurationRevision), 10))
+					}
 				}
 
 				// The JMX exporter label is omitted when Open Monitoring is
 				// not enabled on the cluster.
-				if om := cluster.Provisioned.OpenMonitoring; om != nil && om.Prometheus != nil && om.Prometheus.JmxExporter != nil {
+				if om := openMonitoring; om != nil && om.Prometheus != nil && om.Prometheus.JmxExporter != nil {
 					labels[mskLabelClusterJmxExporterEnabled] = model.LabelValue(strconv.FormatBool(aws.ToBool(om.Prometheus.JmxExporter.EnabledInBroker)))
 				}
 
@@ -471,7 +495,7 @@ func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					labels[mskLabelBrokerClientVPCIP] = model.LabelValue(aws.ToString(node.BrokerNodeInfo.ClientVpcIpAddress))
 					// The node exporter label is omitted when Open Monitoring
 					// is not enabled on the cluster.
-					if om := cluster.Provisioned.OpenMonitoring; om != nil && om.Prometheus != nil && om.Prometheus.NodeExporter != nil {
+					if om := openMonitoring; om != nil && om.Prometheus != nil && om.Prometheus.NodeExporter != nil {
 						labels[mskLabelBrokerNodeExporterEnabled] = model.LabelValue(strconv.FormatBool(aws.ToBool(om.Prometheus.NodeExporter.EnabledInBroker)))
 					}
 

--- a/discovery/aws/msk_test.go
+++ b/discovery/aws/msk_test.go
@@ -16,6 +16,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"testing"
 
@@ -34,6 +35,8 @@ type mskDataStore struct {
 	region   string
 	clusters []types.Cluster
 	nodes    map[string][]types.NodeInfo // keyed by cluster ARN
+	// ARNs DescribeClusterV2 answers without any cluster information.
+	clustersWithoutInfo []string
 }
 
 func TestMSKDiscoveryListClusters(t *testing.T) {
@@ -1305,6 +1308,188 @@ func TestNodeType(t *testing.T) {
 	}
 }
 
+const fullyPopulatedMSKClusterARN = "arn:aws:kafka:region-full:123456789012:cluster/cluster-full/abc-123"
+
+// mskTestDiscovery wires a discovery to the mock, configured to describe the
+// clusters held by data rather than list them.
+func mskTestDiscovery(data *mskDataStore) *MSKDiscovery {
+	clusterARNs := make([]string, 0, len(data.clusters))
+	for _, cluster := range data.clusters {
+		clusterARNs = append(clusterARNs, aws.ToString(cluster.ClusterArn))
+	}
+
+	return &MSKDiscovery{
+		logger: promslog.NewNopLogger(),
+		msk:    newMockMSKClient(data),
+		cfg: &MSKSDConfig{
+			Port:               4242,
+			Region:             data.region,
+			RequestConcurrency: 10,
+			Clusters:           clusterARNs,
+		},
+		region: data.region,
+	}
+}
+
+// fullyPopulatedMSKCluster is the shape the AWS API returns when every optional
+// field happens to be set. Each subtest below blanks exactly one of them.
+func fullyPopulatedMSKCluster() types.Cluster {
+	return types.Cluster{
+		ClusterName:    strptr("cluster-full"),
+		ClusterArn:     strptr(fullyPopulatedMSKClusterARN),
+		State:          types.ClusterStateActive,
+		ClusterType:    types.ClusterTypeProvisioned,
+		CurrentVersion: strptr("1.2.3"),
+		Provisioned: &types.Provisioned{
+			CurrentBrokerSoftwareInfo: &types.BrokerSoftwareInfo{
+				ConfigurationArn:      strptr("arn:aws:kafka:region-full:123456789012:configuration/config-full/def-456"),
+				ConfigurationRevision: aws.Int64(1),
+				KafkaVersion:          strptr("3.4.0"),
+			},
+			OpenMonitoring: &types.OpenMonitoringInfo{
+				Prometheus: &types.PrometheusInfo{
+					JmxExporter:  &types.JmxExporterInfo{EnabledInBroker: aws.Bool(true)},
+					NodeExporter: &types.NodeExporterInfo{EnabledInBroker: aws.Bool(true)},
+				},
+			},
+		},
+	}
+}
+
+func fullyPopulatedMSKDataStore() *mskDataStore {
+	return &mskDataStore{
+		region:   "region-full",
+		clusters: []types.Cluster{fullyPopulatedMSKCluster()},
+		nodes: map[string][]types.NodeInfo{
+			fullyPopulatedMSKClusterARN: {
+				{
+					NodeARN:            strptr("arn:aws:kafka:region-full:123456789012:node/broker-full"),
+					AddedToClusterTime: strptr("2023-01-01T00:00:00Z"),
+					InstanceType:       strptr("kafka.m5.large"),
+					BrokerNodeInfo: &types.BrokerNodeInfo{
+						BrokerId:           aws.Float64(1),
+						ClientSubnet:       strptr("subnet-full"),
+						ClientVpcIpAddress: strptr("10.0.0.1"),
+						Endpoints:          []string{"b-1.cluster-full.kafka.region-full.amazonaws.com"},
+						AttachedENIId:      strptr("eni-full"),
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestMSKDiscoveryRefreshFullyPopulated pins the happy path so the nil handling
+// added for the cases below cannot silently drop labels that used to be set.
+func TestMSKDiscoveryRefreshFullyPopulated(t *testing.T) {
+	t.Parallel()
+
+	tgs, err := mskTestDiscovery(fullyPopulatedMSKDataStore()).refresh(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []*targetgroup.Group{
+		{
+			Source: "region-full",
+			Targets: []model.LabelSet{
+				{
+					model.AddressLabel:                   model.LabelValue("b-1.cluster-full.kafka.region-full.amazonaws.com:4242"),
+					mskLabelClusterName:                  model.LabelValue("cluster-full"),
+					mskLabelClusterARN:                   model.LabelValue(fullyPopulatedMSKClusterARN),
+					mskLabelClusterState:                 model.LabelValue("ACTIVE"),
+					mskLabelClusterType:                  model.LabelValue("PROVISIONED"),
+					mskLabelClusterVersion:               model.LabelValue("1.2.3"),
+					mskLabelClusterKafkaVersion:          model.LabelValue("3.4.0"),
+					mskLabelClusterConfigurationARN:      model.LabelValue("arn:aws:kafka:region-full:123456789012:configuration/config-full/def-456"),
+					mskLabelClusterConfigurationRevision: model.LabelValue("1"),
+					mskLabelClusterJmxExporterEnabled:    model.LabelValue("true"),
+					mskLabelNodeType:                     model.LabelValue("BROKER"),
+					mskLabelNodeARN:                      model.LabelValue("arn:aws:kafka:region-full:123456789012:node/broker-full"),
+					mskLabelNodeAddedTime:                model.LabelValue("2023-01-01T00:00:00Z"),
+					mskLabelNodeInstanceType:             model.LabelValue("kafka.m5.large"),
+					mskLabelNodeAttachedENI:              model.LabelValue("eni-full"),
+					mskLabelBrokerID:                     model.LabelValue("1"),
+					mskLabelBrokerClientSubnet:           model.LabelValue("subnet-full"),
+					mskLabelBrokerClientVPCIP:            model.LabelValue("10.0.0.1"),
+					mskLabelBrokerNodeExporterEnabled:    model.LabelValue("true"),
+					mskLabelBrokerEndpointIndex:          model.LabelValue("0"),
+				},
+			},
+		},
+	}, tgs)
+}
+
+// TestMSKDiscoveryRefreshClusterNilOptionalFields covers clusters where the AWS
+// API omitted an optional field. Neither Provisioned nor
+// CurrentBrokerSoftwareInfo is marked required by the SDK, yet refresh()
+// dereferenced both without a nil check. The dereference happens inside a
+// goroutine, so a single missing field panicked the whole Prometheus process
+// during service discovery rather than degrading the target.
+func TestMSKDiscoveryRefreshClusterNilOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*types.Cluster)
+		absent []model.LabelName
+	}{
+		{
+			name:   "NilProvisioned",
+			mutate: func(c *types.Cluster) { c.Provisioned = nil },
+			absent: []model.LabelName{
+				mskLabelClusterKafkaVersion,
+				mskLabelClusterConfigurationARN,
+				mskLabelClusterConfigurationRevision,
+				mskLabelClusterJmxExporterEnabled,
+				mskLabelBrokerNodeExporterEnabled,
+			},
+		},
+		{
+			name:   "NilCurrentBrokerSoftwareInfo",
+			mutate: func(c *types.Cluster) { c.Provisioned.CurrentBrokerSoftwareInfo = nil },
+			absent: []model.LabelName{
+				mskLabelClusterKafkaVersion,
+				mskLabelClusterConfigurationARN,
+				mskLabelClusterConfigurationRevision,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := fullyPopulatedMSKDataStore()
+			tc.mutate(&data.clusters[0])
+
+			tgs, err := mskTestDiscovery(data).refresh(context.Background())
+			require.NoError(t, err)
+			require.Len(t, tgs, 1)
+			require.Len(t, tgs[0].Targets, 1,
+				"broker must still be discovered when an optional cluster field is absent")
+
+			target := tgs[0].Targets[0]
+			for _, label := range tc.absent {
+				require.NotContains(t, target, label,
+					"label sourced from the absent field should be omitted")
+			}
+			// The broker is still usable: the address is what makes it a target.
+			require.Equal(t, model.LabelValue("b-1.cluster-full.kafka.region-full.amazonaws.com:4242"), target[model.AddressLabel])
+		})
+	}
+}
+
+// TestMSKDiscoveryDescribeClustersNilClusterInfo covers a DescribeClusterV2
+// response carrying no cluster information. ClusterInfo is not marked required
+// by the SDK, and describeClusters read its ClusterType straight away, so such a
+// response panicked the process instead of leaving the cluster out.
+func TestMSKDiscoveryDescribeClustersNilClusterInfo(t *testing.T) {
+	t.Parallel()
+
+	data := fullyPopulatedMSKDataStore()
+	data.clustersWithoutInfo = []string{fullyPopulatedMSKClusterARN}
+
+	clusters, err := mskTestDiscovery(data).describeClusters(context.Background(), []string{fullyPopulatedMSKClusterARN})
+	require.NoError(t, err)
+	require.Empty(t, clusters, "a cluster described without information cannot be turned into targets")
+}
+
 // MSK client mock.
 type mockMSKClient struct {
 	mskData mskDataStore
@@ -1318,6 +1503,9 @@ func newMockMSKClient(mskData *mskDataStore) *mockMSKClient {
 
 func (m *mockMSKClient) DescribeClusterV2(_ context.Context, input *kafka.DescribeClusterV2Input, _ ...func(*kafka.Options)) (*kafka.DescribeClusterV2Output, error) {
 	inputARN := aws.ToString(input.ClusterArn)
+	if slices.Contains(m.mskData.clustersWithoutInfo, inputARN) {
+		return &kafka.DescribeClusterV2Output{}, nil
+	}
 	for i := range m.mskData.clusters {
 		cluster := &m.mskData.clusters[i]
 		if aws.ToString(cluster.ClusterArn) == inputARN {


### PR DESCRIPTION
`discovery/aws` dereferences three MSK response fields that the SDK declares optional - none carries `This member is required` in `kafka@v1.58.3`:

| Field | Dereferenced at |
|---|---|
| `DescribeClusterV2Output.ClusterInfo` | `msk.go:317`, `322` |
| `Cluster.Provisioned` | `msk.go:444`, `457`, `474` |
| `Provisioned.CurrentBrokerSoftwareInfo` | `msk.go:444`, `448`, `451` |

Both sites run inside a goroutine, so `recover()` in the caller does not help: one cluster missing one of these fields takes down the whole Prometheus process.

```
goroutine 40 [running]:
discovery/aws.(*MSKDiscovery).refresh.func1(...)
	discovery/aws/msk.go:444
created by discovery/aws.(*MSKDiscovery).refresh in goroutine 37
	discovery/aws/msk.go:432
```

The code is already inconsistent about this: `msk.go:457` checks every link of `OpenMonitoring` -> `Prometheus` -> `JmxExporter`, and `448`/`451` guard `ConfigurationArn` and `ConfigurationRevision`, while the parents those chains hang off are read unguarded.

**Fix.** A cluster described without `ClusterInfo` is skipped with a warning, as a non-provisioned cluster already is. The provisioned configuration is read once per cluster into nil-checked locals, so an absent field only omits the labels it feeds. No label changes for any input that did not previously panic.

**Tests.** The happy path is pinned first so the nil handling cannot silently drop labels that used to be set; the table test then blanks exactly one field per subtest. Each panics on the parent commit and passes on the fix.

Reachability is derived from the SDK type declarations, not from a run against live AWS.

```release-notes
[BUGFIX] discovery/aws: Do not panic on MSK clusters whose optional API fields are absent.
```
