### PR TITLE
discovery/aws: describe each ElastiCache resource once per refresh

### DIFF
--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -521,47 +521,50 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 		return nil, err
 	}
 
-	var clusters []string
-	clustersMu := sync.Mutex{}
 	serverlessCacheIDs, cacheClusterIDs := splitCacheDeploymentOptions(d.cfg.Clusters, d.logger)
 
-	clusterErrg, clusterCtx := errgroup.WithContext(ctx)
-	clusterErrg.Go(func() error {
-		caches, err := d.describeServerlessCaches(clusterCtx, serverlessCacheIDs)
+	// Both deployment options are described once and the results are reused to
+	// build the targets below: asking the API again for what is already in hand
+	// would only spend the account's request quota twice over.
+	var (
+		caches        []types.ServerlessCache
+		cacheClusters []types.CacheCluster
+	)
+	describeErrg, describeCtx := errgroup.WithContext(ctx)
+	describeErrg.Go(func() error {
+		var err error
+		caches, err = d.describeServerlessCaches(describeCtx, serverlessCacheIDs)
 		if err != nil {
 			return fmt.Errorf("failed to describe serverless caches: %w", err)
 		}
-		for _, cache := range caches {
-			// ARN is optional in the ElastiCache API and is only used to look
-			// up tags, so a cache without one is still discovered below.
-			if cache.ARN == nil {
-				continue
-			}
-			clustersMu.Lock()
-			clusters = append(clusters, *cache.ARN)
-			clustersMu.Unlock()
-		}
 		return nil
 	})
 
-	clusterErrg.Go(func() error {
-		cacheClusters, err := d.describeCacheClusters(clusterCtx, cacheClusterIDs)
+	describeErrg.Go(func() error {
+		var err error
+		cacheClusters, err = d.describeCacheClusters(describeCtx, cacheClusterIDs)
 		if err != nil {
 			return fmt.Errorf("failed to describe cache clusters: %w", err)
 		}
-		for _, cluster := range cacheClusters {
-			if cluster.ARN == nil {
-				continue
-			}
-			clustersMu.Lock()
-			clusters = append(clusters, *cluster.ARN)
-			clustersMu.Unlock()
-		}
 		return nil
 	})
 
-	if err := clusterErrg.Wait(); err != nil {
+	if err := describeErrg.Wait(); err != nil {
 		return nil, err
+	}
+
+	// ARN is optional in the ElastiCache API and is only used to look up tags,
+	// so a resource without one is still discovered below.
+	clusters := make([]string, 0, len(caches)+len(cacheClusters))
+	for _, cache := range caches {
+		if cache.ARN != nil {
+			clusters = append(clusters, *cache.ARN)
+		}
+	}
+	for _, cluster := range cacheClusters {
+		if cluster.ARN != nil {
+			clusters = append(clusters, *cluster.ARN)
+		}
 	}
 
 	tagsByResourceARN, err := d.listTagsForResource(ctx, clusters)
@@ -572,39 +575,11 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 	tg := &targetgroup.Group{
 		Source: d.region,
 	}
-	// Both goroutines below append to tg.Targets, so the append must be
-	// serialised.
-	targetsMu := sync.Mutex{}
-
-	errg, ectx := errgroup.WithContext(ctx)
-	errg.Go(func() error {
-		caches, err := d.describeServerlessCaches(ectx, serverlessCacheIDs)
-		if err != nil {
-			return fmt.Errorf("failed to describe serverless caches: %w", err)
-		}
-		for _, cache := range caches {
-			targetsMu.Lock()
-			addServerlessCacheTargets(tg, &cache, tagsByResourceARN[aws.ToString(cache.ARN)])
-			targetsMu.Unlock()
-		}
-		return nil
-	})
-
-	errg.Go(func() error {
-		cacheClusters, err := d.describeCacheClusters(ectx, cacheClusterIDs)
-		if err != nil {
-			return fmt.Errorf("failed to describe cache clusters: %w", err)
-		}
-		for _, cluster := range cacheClusters {
-			targetsMu.Lock()
-			addCacheClusterTargets(tg, &cluster, tagsByResourceARN[aws.ToString(cluster.ARN)])
-			targetsMu.Unlock()
-		}
-		return nil
-	})
-
-	if err := errg.Wait(); err != nil {
-		return nil, err
+	for _, cache := range caches {
+		addServerlessCacheTargets(tg, &cache, tagsByResourceARN[aws.ToString(cache.ARN)])
+	}
+	for _, cluster := range cacheClusters {
+		addCacheClusterTargets(tg, &cluster, tagsByResourceARN[aws.ToString(cluster.ARN)])
 	}
 
 	return []*targetgroup.Group{tg}, nil

--- a/discovery/aws/elasticache_test.go
+++ b/discovery/aws/elasticache_test.go
@@ -15,6 +15,8 @@ package aws
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -476,6 +478,10 @@ func TestAddCacheClusterTargets(t *testing.T) {
 // Mock Elasticache client.
 type mockElasticacheClient struct {
 	data *elasticacheDataStore
+
+	// onDescribe, when set, runs at the start of every DescribeServerlessCaches
+	// and DescribeCacheClusters call.
+	onDescribe func()
 }
 
 func newMockElasticacheClient(data *elasticacheDataStore) *mockElasticacheClient {
@@ -483,6 +489,9 @@ func newMockElasticacheClient(data *elasticacheDataStore) *mockElasticacheClient
 }
 
 func (m *mockElasticacheClient) DescribeServerlessCaches(_ context.Context, input *elasticache.DescribeServerlessCachesInput, _ ...func(*elasticache.Options)) (*elasticache.DescribeServerlessCachesOutput, error) {
+	if m.onDescribe != nil {
+		m.onDescribe()
+	}
 	if input.ServerlessCacheName != nil {
 		// Filter by name
 		for _, cache := range m.data.serverlessCaches {
@@ -503,6 +512,9 @@ func (m *mockElasticacheClient) DescribeServerlessCaches(_ context.Context, inpu
 }
 
 func (m *mockElasticacheClient) DescribeCacheClusters(_ context.Context, input *elasticache.DescribeCacheClustersInput, _ ...func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error) {
+	if m.onDescribe != nil {
+		m.onDescribe()
+	}
 	if input.CacheClusterId != nil {
 		// Single cluster lookup
 		for _, cluster := range m.data.cacheClusters {
@@ -841,5 +853,128 @@ func TestElasticacheRefreshCacheClusterNilOptionalFields(t *testing.T) {
 				require.Equal(t, model.LabelValue("my-cluster-001.abc123.0001.use1.cache.amazonaws.com:6379"), target[model.AddressLabel])
 			}
 		})
+	}
+}
+
+// elasticacheFixture builds a data store holding serverlessCount serverless
+// caches and clusterCount cache clusters, every cluster carrying nodeCount
+// nodes.
+func elasticacheFixture(serverlessCount, clusterCount, nodeCount int) *elasticacheDataStore {
+	data := &elasticacheDataStore{
+		region: "us-east-1",
+		tags:   make(map[string][]types.Tag, serverlessCount+clusterCount),
+	}
+
+	for s := range serverlessCount {
+		name := "serverless-" + strconv.Itoa(s)
+		arn := "arn:aws:elasticache:us-east-1:123456789012:serverlesscache:" + name
+		cache := fullyPopulatedServerlessCache()
+		cache.ARN = strptr(arn)
+		cache.ServerlessCacheName = strptr(name)
+		cache.Endpoint = &types.Endpoint{
+			Address: strptr(name + ".serverless.use1.cache.amazonaws.com"),
+			Port:    aws.Int32(6379),
+		}
+		data.serverlessCaches = append(data.serverlessCaches, cache)
+		data.tags[arn] = []types.Tag{{Key: strptr("Environment"), Value: strptr("bench")}}
+	}
+
+	for c := range clusterCount {
+		id := "cluster-" + strconv.Itoa(c)
+		arn := "arn:aws:elasticache:us-east-1:123456789012:cluster:" + id
+		cluster := fullyPopulatedCacheCluster()
+		cluster.ARN = strptr(arn)
+		cluster.CacheClusterId = strptr(id)
+		cluster.CacheNodes = make([]types.CacheNode, 0, nodeCount)
+		for n := range nodeCount {
+			cluster.CacheNodes = append(cluster.CacheNodes, types.CacheNode{
+				CacheNodeId: strptr(fmt.Sprintf("%04d", n+1)),
+				Endpoint: &types.Endpoint{
+					Address: strptr(fmt.Sprintf("%s-%04d.use1.cache.amazonaws.com", id, n+1)),
+					Port:    aws.Int32(6379),
+				},
+			})
+		}
+		data.cacheClusters = append(data.cacheClusters, cluster)
+		data.tags[arn] = []types.Tag{{Key: strptr("Environment"), Value: strptr("bench")}}
+	}
+
+	return data
+}
+
+// distinctTargetAddresses counts the unique addresses in a target group, which
+// is what the fixture size predicts however many times the API reported the
+// same resource.
+func distinctTargetAddresses(tg *targetgroup.Group) int {
+	addresses := make(map[model.LabelValue]struct{}, len(tg.Targets))
+	for _, target := range tg.Targets {
+		addresses[target[model.AddressLabel]] = struct{}{}
+	}
+	return len(addresses)
+}
+
+func BenchmarkElasticacheRefresh(b *testing.B) {
+	benchmarks := []struct {
+		name       string
+		serverless int
+		clusters   int
+		nodes      int
+	}{
+		{"1Serverless/1Cluster", 1, 1, 1},
+		{"8Serverless/8Clusters", 8, 8, 1},
+		{"20Serverless/20Clusters", 20, 20, 2},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			d := elasticacheTestDiscovery(elasticacheFixture(bm.serverless, bm.clusters, bm.nodes))
+			want := bm.serverless + bm.clusters*bm.nodes
+
+			b.ReportAllocs()
+			for b.Loop() {
+				tgs, err := d.refresh(context.Background())
+				if err != nil {
+					b.Fatal(err)
+				}
+				if got := distinctTargetAddresses(tgs[0]); got != want {
+					b.Fatalf("got %d distinct targets, want %d", got, want)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkElasticacheRefreshAPILatency models the describe round trip, which
+// dominates a refresh and which BenchmarkElasticacheRefresh cannot show because
+// its client answers instantly. The absolute latency is arbitrary; the ratio
+// between the two benchmarks is what the number says.
+func BenchmarkElasticacheRefreshAPILatency(b *testing.B) {
+	const (
+		resourceCount = 20
+		roundTrip     = time.Millisecond
+	)
+	data := elasticacheFixture(resourceCount, resourceCount, 1)
+
+	client := newMockElasticacheClient(data)
+	client.onDescribe = func() { time.Sleep(roundTrip) }
+	d := &ElasticacheDiscovery{
+		logger:            promslog.NewNopLogger(),
+		elasticacheClient: client,
+		cfg: &ElasticacheSDConfig{
+			Region:             data.region,
+			RequestConcurrency: 10,
+		},
+		region: data.region,
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		tgs, err := d.refresh(context.Background())
+		if err != nil {
+			b.Fatal(err)
+		}
+		if got := distinctTargetAddresses(tgs[0]); got != resourceCount*2 {
+			b.Fatalf("got %d distinct targets, want %d", got, resourceCount*2)
+		}
 	}
 }

--- a/discovery/aws/elasticache_test.go
+++ b/discovery/aws/elasticache_test.go
@@ -16,7 +16,9 @@ package aws
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -482,6 +484,19 @@ type mockElasticacheClient struct {
 	// onDescribe, when set, runs at the start of every DescribeServerlessCaches
 	// and DescribeCacheClusters call.
 	onDescribe func()
+
+	// describeRequests records one entry per describe call, so a test can show
+	// which requests a single refresh issues.
+	describeMu       sync.Mutex
+	describeRequests []string
+}
+
+// recordDescribe stores a describe request, identified by the input fields the
+// discovery varies between calls.
+func (m *mockElasticacheClient) recordDescribe(request string) {
+	m.describeMu.Lock()
+	m.describeRequests = append(m.describeRequests, request)
+	m.describeMu.Unlock()
 }
 
 func newMockElasticacheClient(data *elasticacheDataStore) *mockElasticacheClient {
@@ -492,6 +507,8 @@ func (m *mockElasticacheClient) DescribeServerlessCaches(_ context.Context, inpu
 	if m.onDescribe != nil {
 		m.onDescribe()
 	}
+	m.recordDescribe(fmt.Sprintf("DescribeServerlessCaches name=%s token=%s",
+		aws.ToString(input.ServerlessCacheName), aws.ToString(input.NextToken)))
 	if input.ServerlessCacheName != nil {
 		// Filter by name
 		for _, cache := range m.data.serverlessCaches {
@@ -515,6 +532,9 @@ func (m *mockElasticacheClient) DescribeCacheClusters(_ context.Context, input *
 	if m.onDescribe != nil {
 		m.onDescribe()
 	}
+	m.recordDescribe(fmt.Sprintf("DescribeCacheClusters id=%s marker=%s notInReplicationGroups=%t",
+		aws.ToString(input.CacheClusterId), aws.ToString(input.Marker),
+		aws.ToBool(input.ShowCacheClustersNotInReplicationGroups)))
 	if input.CacheClusterId != nil {
 		// Single cluster lookup
 		for _, cluster := range m.data.cacheClusters {
@@ -977,4 +997,42 @@ func BenchmarkElasticacheRefreshAPILatency(b *testing.B) {
 			b.Fatalf("got %d distinct targets, want %d", got, resourceCount*2)
 		}
 	}
+}
+
+// TestElasticacheRefreshDescribesEachResourceOnce covers refresh() asking the
+// API for the same resources twice: once to collect the ARNs the tag lookup
+// needs, and once more to build the targets. Both rounds send identical
+// requests and get identical answers, so the second one only spends the
+// account's API quota.
+func TestElasticacheRefreshDescribesEachResourceOnce(t *testing.T) {
+	t.Parallel()
+
+	data := elasticacheFixture(2, 2, 1)
+	client := newMockElasticacheClient(data)
+	d := &ElasticacheDiscovery{
+		logger:            promslog.NewNopLogger(),
+		elasticacheClient: client,
+		cfg: &ElasticacheSDConfig{
+			Region:             data.region,
+			RequestConcurrency: 10,
+		},
+		region: data.region,
+	}
+
+	_, err := d.refresh(context.Background())
+	require.NoError(t, err)
+
+	counts := make(map[string]int, len(client.describeRequests))
+	for _, request := range client.describeRequests {
+		counts[request]++
+	}
+
+	var repeated []string
+	for request, count := range counts {
+		if count > 1 {
+			repeated = append(repeated, fmt.Sprintf("%s: %d times", request, count))
+		}
+	}
+	slices.Sort(repeated)
+	require.Empty(t, repeated, "a refresh must not issue the same describe request more than once")
 }


### PR DESCRIPTION
`refresh()` describes both deployment options twice per cycle: the first round only collects the ARNs that the `ListTagsForResource` lookup needs, and the second asks for the very same resources again to build the targets. Both rounds send identical requests and get identical answers, so the second one only spends the account's request quota.

The describe results are now kept and reused. Target building no longer runs in two goroutines, so the mutex guarding `tg.Targets` goes away together with the shared state it protected, and the targets come out in a deterministic order. The two describes still run concurrently with each other, which is where the round trips are.

## Benchmarks

`go test ./discovery/aws/ -run '^$' -count=6 -benchmem -bench BenchmarkElasticache`

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/discovery/aws
cpu: Apple M3 Pro
                                              │   before    │                after                │
                                              │   sec/op    │    sec/op     vs base               │
ElasticacheRefresh/1Serverless/1Cluster-12      16.23µ ± 2%   12.27µ ±  8%  -24.40% (p=0.002 n=6)
ElasticacheRefresh/8Serverless/8Clusters-12     53.31µ ± 3%   46.65µ ±  6%  -12.50% (p=0.002 n=6)
ElasticacheRefresh/20Serverless/20Clusters-12   143.3µ ± 5%   126.0µ ±  4%  -12.09% (p=0.002 n=6)
ElasticacheRefreshAPILatency-12                 2.824m ± 8%   1.515m ± 11%  -46.36% (p=0.002 n=6)
geomean                                         136.8µ        102.2µ        -25.27%

                                              │    before     │                after                │
                                              │     B/op      │     B/op      vs base               │
ElasticacheRefresh/1Serverless/1Cluster-12      11.675Ki ± 1%   8.341Ki ± 0%  -28.55% (p=0.002 n=6)
ElasticacheRefresh/8Serverless/8Clusters-12      65.43Ki ± 0%   49.64Ki ± 0%  -24.14% (p=0.002 n=6)
ElasticacheRefresh/20Serverless/20Clusters-12    206.4Ki ± 1%   168.0Ki ± 0%  -18.62% (p=0.002 n=6)
ElasticacheRefreshAPILatency-12                  161.3Ki ± 1%   129.0Ki ± 1%  -20.03% (p=0.002 n=6)
geomean                                          71.01Ki        54.73Ki       -22.94%

                                              │   before    │               after                │
                                              │  allocs/op  │  allocs/op   vs base               │
ElasticacheRefresh/1Serverless/1Cluster-12       157.0 ± 0%    113.0 ± 0%  -28.03% (p=0.002 n=6)
ElasticacheRefresh/8Serverless/8Clusters-12      528.0 ± 0%    481.0 ± 0%   -8.90% (p=0.002 n=6)
ElasticacheRefresh/20Serverless/20Clusters-12   1.467k ± 0%   1.419k ± 0%   -3.27% (p=0.002 n=6)
ElasticacheRefreshAPILatency-12                 1.152k ± 0%   1.102k ± 0%   -4.34% (p=0.002 n=6)
geomean                                          611.8         539.9       -11.74%
```

`BenchmarkElasticacheRefreshAPILatency` holds each describe open for a 1ms round trip, which is what a refresh actually spends its time on; `BenchmarkElasticacheRefresh` answers instantly and measures label building alone. The absolute latency is arbitrary, the ratio is the point.
No case regresses.

## Tests

`TestElasticacheRefreshDescribesEachResourceOnce` records every describe request the mock receives and fails if a refresh issues any of them more than once. On the parent commit it fails listing all three:

```
DescribeCacheClusters id= marker= notInReplicationGroups=false: 2 times
DescribeCacheClusters id= marker= notInReplicationGroups=true: 2 times
DescribeServerlessCaches name= token=: 2 times
```

The two `DescribeCacheClusters` signatures are a separate issue, fixed by [#19434](https://redirect.github.com/prometheus/prometheus/pull/19434).

```release-notes
[PERF] AWS SD: Describe each ElastiCache resource once per refresh instead of twice.
```
