### PR TITLE
tsdb: wait for racing appends before compacting head range

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1615,6 +1615,22 @@ func (db *DB) CompactHead(head *RangeHead) error {
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 
+	// The periodic compaction loop in Compact never races with in-flight
+	// appends: by the time a range becomes head.compactable(), appendableMinValidTime()
+	// has already been rejecting new appends into it for a while (see the comment
+	// there), so the only appenders left to worry about are ones that validated
+	// against the old boundary before it moved; WaitForAppendersOverlapping waits
+	// those out. CompactHead lets a caller force-compact an arbitrary range,
+	// including one still inside the normally-protected appendable window, so it
+	// has to establish that same guarantee itself here. Skipping this allowed an
+	// in-flight append validated under the old minValidTime to commit after the
+	// block was already written, sliding the head's mint back below the block's
+	// maxt (updateMinMaxTime only ever moves bounds outward) and producing an
+	// overlapping block on the next compaction. See
+	// https://github.com/prometheus/prometheus/issues/8055.
+	db.head.raiseMinValidTime(head.BlockMaxTime())
+	db.head.WaitForAppendersOverlapping(head.MaxTime())
+
 	if err := db.compactHead(head); err != nil {
 		return fmt.Errorf("compact head: %w", err)
 	}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -35,6 +35,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -3503,6 +3504,89 @@ func TestCompactHeadWithDeletion(t *testing.T) {
 
 	// This recreates the bug.
 	require.NoError(t, db.CompactHead(NewRangeHead(db.Head(), 0, 100)))
+}
+
+// TestCompactHeadWaitsForRacingAppend reproduces
+// https://github.com/prometheus/prometheus/issues/8055: forcing compaction of
+// a range that reaches into the still-appendable portion of the head must
+// not let a concurrent append that started beforehand slide the head's mint
+// back into the block that compaction just wrote, which would make the next
+// compaction produce an overlapping block.
+func TestCompactHeadWaitsForRacingAppend(t *testing.T) {
+	t.Parallel()
+
+	// The whole DB lifecycle, including Close, is kept inside the synctest
+	// bubble below: compaction lazily touches internals (e.g. the
+	// compactor's context) that must not be created inside the bubble and
+	// then torn down from outside it once the bubble exits, which
+	// testing/synctest forbids.
+	synctest.Test(t, func(t *testing.T) {
+		db := newTestDB(t)
+		db.DisableCompactions()
+
+		ctx := context.Background()
+
+		app := db.Appender(ctx)
+		_, err := app.Append(0, labels.FromStrings("a", "b"), 0, 0)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		// Open (but do not commit) an appender for a sample inside the range
+		// about to be force-compacted below. It captures the head's current,
+		// low minValidTime when created: without CompactHead waiting for it
+		// to finish, compaction could write a block covering [0, 100] before
+		// this sample lands, and the sample's later commit would then widen
+		// the head's mint back down to 50 via updateMinMaxTime -- which only
+		// ever moves bounds outward -- landing it inside the block that was
+		// just persisted.
+		racingApp := db.Appender(ctx)
+		_, err = racingApp.Append(0, labels.FromStrings("a", "b"), 50, 0)
+		require.NoError(t, err)
+
+		var compactErr error
+		var compactDone atomic.Bool
+		go func() {
+			compactErr = db.CompactHead(NewRangeHead(db.Head(), 0, 100))
+			compactDone.Store(true)
+		}()
+
+		// Let the compaction goroutine run until it blocks waiting for racingApp.
+		synctest.Wait()
+		require.False(t, compactDone.Load(), "CompactHead must wait for the racing append to finish")
+		require.Empty(t, db.Blocks(), "no block should be written while an overlapping append is still open")
+
+		require.NoError(t, racingApp.Commit())
+
+		// Advance fake time past the 500ms poll interval used by WaitForAppendersOverlapping.
+		time.Sleep(time.Second)
+		synctest.Wait()
+		require.True(t, compactDone.Load(), "CompactHead should complete once the racing append finishes")
+		require.NoError(t, compactErr)
+
+		require.Len(t, db.Blocks(), 1)
+		block := db.Blocks()[0].Meta()
+		require.GreaterOrEqual(t, db.Head().MinTime(), block.MaxTime,
+			"head mint must not slide back into the block that was just compacted")
+
+		// The sample committed mid-compaction must not have been lost: it
+		// should still be readable, from either the block or the head.
+		q, err := db.Querier(0, 100)
+		require.NoError(t, err)
+		ss := q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+		var count int
+		for ss.Next() {
+			it := ss.At().Iterator(nil)
+			for it.Next() != chunkenc.ValNone {
+				count++
+			}
+			require.NoError(t, it.Err())
+		}
+		require.NoError(t, ss.Err())
+		require.Equal(t, 2, count) // Samples at t=0 and t=50.
+		require.NoError(t, q.Close())
+
+		require.NoError(t, db.Close())
+	})
 }
 
 func deleteNonBlocks(dbDir string) error {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1246,6 +1246,22 @@ func (h *Head) SetMinValidTime(minValidTime int64) {
 	h.minValidTime.Store(minValidTime)
 }
 
+// raiseMinValidTime advances the minimum timestamp the head can ingest to at
+// least minValidTime. Unlike SetMinValidTime, it never moves the bound
+// backwards, so it is safe to call concurrently with other code that may be
+// advancing minValidTime too, such as truncateMemory.
+func (h *Head) raiseMinValidTime(minValidTime int64) {
+	for {
+		cur := h.minValidTime.Load()
+		if minValidTime <= cur {
+			return
+		}
+		if h.minValidTime.CompareAndSwap(cur, minValidTime) {
+			return
+		}
+	}
+}
+
 // Truncate removes old data before mint from the head and WAL.
 func (h *Head) Truncate(mint int64) (err error) {
 	initialized := h.initialized()


### PR DESCRIPTION
## Summary

`DB.CompactHead` can force-compact a head range that overlaps an in-flight
append which was validated *before* compaction started. Unlike the periodic
compaction loop — which is safe because `appendableMinValidTime()` has
already been rejecting appends into a compactable range for a while, and
`WaitForAppendersOverlapping` drains any stragglers that validated just
before that boundary moved — `CompactHead` skipped both steps. A caller can
force-compact a range still inside the normally-protected appendable window,
so an append validated under the old, lower `minValidTime` can commit
*after* the block is written. Since `updateMinMaxTime` only ever widens the
head's bounds, that late commit slides `head.MinTime()` back down into the
block that was just persisted, producing an overlapping block on the next
compaction.

- Add `Head.raiseMinValidTime`, a CAS-based version of `SetMinValidTime`
  that only ever moves the bound forward (a plain overwrite could itself
  race backwards against `truncateMemory`).
- `CompactHead` now calls `raiseMinValidTime` and the existing
  `WaitForAppendersOverlapping` before compacting, establishing the same
  guarantee the periodic loop already has.

Fixes #8055

## Test plan

- Added `TestCompactHeadWaitsForRacingAppend` (`tsdb/db_test.go`), which
  deterministically reproduces the race using `testing/synctest`: it opens a
  racing appender, runs `CompactHead` in a goroutine, and asserts no block is
  written until the appender commits. Split across two commits per this
  repo's convention — the first commit adds the test only and it fails
  (reproducing the bug), the second commit adds the fix and it passes.
- `go test ./tsdb/...` (full suite): passes.
- `go test ./tsdb/... -race -run 'TestCompactHead|TestHeadCompact|OOOCompact|CompactOOO'`: passes.
- `make lint`: clean.

```release-notes
[BUGFIX] TSDB: Fix a race condition in forced head compaction that could produce overlapping blocks.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)