### PR TITLE
tsdb: preserve WAL expiries in memory snapshots

### DIFF
--- a/tsdb/docs/format/memory_snapshot.md
+++ b/tsdb/docs/format/memory_snapshot.md
@@ -6,7 +6,15 @@ Below are the formats of the individual records.
 The order of records in the snapshot is always:
 1. Starts with series records, one per series, in an unsorted fashion.
 2. After all series are done, we write a tombstone record containing all the tombstones.
-3. At the end, we write one or more exemplar records while batching up the exemplars in each record. Exemplars are in the order they were written to the circular buffer.
+3. Exemplar records follow, batching up the exemplars in each record. Exemplars are in the order they were written to the circular buffer.
+4. At the end, we write one or more WAL series expiry records. An empty record is written even when there are no expiries.
+
+When the WAL is enabled, snapshots without WAL series expiry records are replayed from the WAL instead. This
+includes snapshots written by older versions, which did not preserve the state
+needed to keep series metadata during subsequent WAL checkpointing. Readers from
+older versions also fall back to the WAL when they encounter the new record type.
+Legacy snapshots remain usable when the WAL is disabled, since no WAL checkpoint
+can remove their series metadata in that configuration.
 
 ### Series records
 
@@ -91,3 +99,23 @@ A single exemplar record contains one or more exemplars, encoded in the same way
 │                               . . .                               │
 └───────────────────────────────────────────────────────────────────┘
 ```
+
+### WAL series expiry record
+
+Record type `4` preserves references that are no longer in the Head but whose
+series metadata must remain in the WAL. It contains up to 10,000 pairs, in no
+particular order, each consisting of a big-endian `uint64` series reference and
+a big-endian `int64` keep-until timestamp. There is no pair count; the record
+length determines the number of pairs. A one-byte record contains no expiries.
+
+The timestamp is inclusive: the series record is retained in a checkpoint whose
+minimum timestamp is less than or equal to the keep-until timestamp. Restoring
+these references also advances the series ID counter so that new series cannot
+reuse references still needed by WAL readers.
+
+| Field | Size |
+| --- | --- |
+| Record type (`4`) | 1 byte |
+| Series reference | 8 bytes |
+| Keep-until timestamp | 8 bytes |
+| Further reference/timestamp pairs | 16 bytes each |

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1256,41 +1256,106 @@ func TestHead_WALCheckpointMultiRef(t *testing.T) {
 	}
 
 	for _, enableSTStorage := range []bool{false, true} {
-		for _, tc := range cases {
-			t.Run(tc.name+",stStorage="+strconv.FormatBool(enableSTStorage), func(t *testing.T) {
-				h, w := newTestHead(t, 1000, compression.None, false)
-				populateTestWL(t, w, tc.walEntries, nil, enableSTStorage)
-				first, _, err := wlog.Segments(w.Dir())
-				require.NoError(t, err)
-
-				require.NoError(t, h.Init(0))
-
-				keepUntil, ok := h.getWALExpiry(2)
-				require.True(t, ok)
-				require.Equal(t, tc.expectedWalExpiry, keepUntil)
-
-				// Each truncation creates a new segment, so attempt truncations until a checkpoint is created
-				for {
-					h.lastWALTruncationTime.Store(0) // Reset so that it's always time to truncate the WAL
-					err := h.truncateWAL(tc.walTruncateMinT)
-					require.NoError(t, err)
-					f, _, err := wlog.Segments(w.Dir())
-					require.NoError(t, err)
-					if f > first {
-						break
+		for _, snapshot := range []bool{false, true} {
+			for _, tc := range cases {
+				t.Run(tc.name+",stStorage="+strconv.FormatBool(enableSTStorage)+",snapshot="+strconv.FormatBool(snapshot), func(t *testing.T) {
+					h, w := newTestHead(t, 1000, compression.None, false)
+					defer func() {
+						h.opts.EnableMemorySnapshotOnShutdown = false
+						_ = h.Close()
+					}()
+					reopen := func(mint int64) {
+						var err error
+						w, err = wlog.NewSize(nil, nil, w.Dir(), 32768, compression.None)
+						require.NoError(t, err)
+						h, err = NewHead(nil, nil, w, nil, h.opts, nil)
+						require.NoError(t, err)
+						require.NoError(t, h.Init(mint))
 					}
-				}
+					querySamples := func() map[string][]chunks.Sample {
+						q, err := NewBlockQuerier(h, tc.walTruncateMinT, math.MaxInt64)
+						require.NoError(t, err)
+						return query(t, q, labels.MustNewMatcher(labels.MatchEqual, "a", "1"))
+					}
+					populateTestWL(t, w, tc.walEntries, nil, enableSTStorage)
+					first, _, err := wlog.Segments(w.Dir())
+					require.NoError(t, err)
 
-				// Read test WAL , checkpoint first
-				checkpointDir, _, err := wlog.LastCheckpoint(w.Dir())
-				require.NoError(t, err)
-				cprecs := readTestWAL(t, checkpointDir)
-				recs := readTestWAL(t, w.Dir())
-				recs = append(cprecs, recs...)
+					require.NoError(t, h.Init(0))
 
-				// Use testutil.RequireEqual which handles labels properly with dedupelabels
-				testutil.RequireEqual(t, tc.expectedWalEntries, recs)
-			})
+					keepUntil, ok := h.getWALExpiry(2)
+					require.True(t, ok)
+					require.Equal(t, tc.expectedWalExpiry, keepUntil)
+					expectedSamples := querySamples()
+
+					if snapshot {
+						// Recover from the snapshot before the WAL aliases are checkpointed.
+						h.opts.EnableMemorySnapshotOnShutdown = true
+						require.NoError(t, h.Close())
+						reopen(0)
+						require.Zero(t, prom_testutil.ToFloat64(h.metrics.snapshotReplayErrorTotal))
+						require.Equal(t, expectedSamples, querySamples())
+					}
+
+					// Each truncation creates a new segment, so attempt truncations until a checkpoint is created.
+					for {
+						h.lastWALTruncationTime.Store(0) // Reset so that it's always time to truncate the WAL
+						err := h.truncateWAL(tc.walTruncateMinT)
+						require.NoError(t, err)
+						f, _, err := wlog.Segments(w.Dir())
+						require.NoError(t, err)
+						if f > first {
+							break
+						}
+					}
+
+					// Read the test WAL, checkpoint first.
+					checkpointDir, _, err := wlog.LastCheckpoint(w.Dir())
+					require.NoError(t, err)
+					cprecs := readTestWAL(t, checkpointDir)
+					recs := readTestWAL(t, w.Dir())
+					recs = append(cprecs, recs...)
+
+					// Use testutil.RequireEqual which handles labels properly with dedupelabels.
+					testutil.RequireEqual(t, tc.expectedWalEntries, recs)
+
+					if snapshot {
+						// An alias absent from the snapshot's live series must not be reused.
+						app := h.Appender(context.Background())
+						ref, err := app.Append(0, labels.FromStrings("a", "2"), 1000, 1)
+						require.NoError(t, err)
+						require.NoError(t, app.Commit())
+						require.Equal(t, storage.SeriesRef(3), ref)
+					}
+
+					// Recover from the checkpoint without a snapshot to verify that the
+					// retained samples still have the series records needed to replay them.
+					h.opts.EnableMemorySnapshotOnShutdown = false
+					require.NoError(t, h.Close())
+					reopen(tc.walTruncateMinT)
+					actualSamples := querySamples()
+					// Truncating earlier samples can remove the first histogram's
+					// information that no counter reset occurred. All sample data
+					// and subsequent counter reset hints must still match.
+					for lset, samples := range actualSamples {
+						if len(samples) == 0 || len(expectedSamples[lset]) == 0 {
+							continue
+						}
+						got, want := samples[0], expectedSamples[lset][0]
+						if got.H() != nil && want.H() != nil &&
+							got.H().CounterResetHint == histogram.UnknownCounterReset &&
+							want.H().CounterResetHint == histogram.NotCounterReset {
+							got.H().CounterResetHint = histogram.NotCounterReset
+						}
+						if got.FH() != nil && want.FH() != nil &&
+							got.FH().CounterResetHint == histogram.UnknownCounterReset &&
+							want.FH().CounterResetHint == histogram.NotCounterReset {
+							got.FH().CounterResetHint = histogram.NotCounterReset
+						}
+					}
+					require.Equal(t, expectedSamples, actualSamples)
+				})
+			}
 		}
 	}
 }
@@ -5352,89 +5417,176 @@ func TestSnapshotError(t *testing.T) {
 	require.Equal(t, 2.0, prom_testutil.ToFloat64(head.metrics.seriesCreated))
 }
 
-// TestSnapshotUnknownEncodingFallsBackToWAL verifies that a snapshot containing
-// an unknown chunk encoding causes the entire snapshot load to fail and fall back
-// to full WAL replay, recovering all series without data loss.
-func TestSnapshotUnknownEncodingFallsBackToWAL(t *testing.T) {
-	head, _ := newTestHead(t, 120*4, compression.None, false)
-	defer func() {
-		head.opts.EnableMemorySnapshotOnShutdown = false
-		require.NoError(t, head.Close())
-	}()
-
-	floatHist := tsdbutil.GenerateTestGaugeFloatHistograms(1)[0]
-	lblsFloatHist := labels.FromStrings("floathist", "bar")
-	lblsFloat := labels.FromStrings("foo", "bar")
-
-	app := head.Appender(context.Background())
-	_, err := app.AppendHistogram(0, lblsFloatHist, 99, nil, floatHist)
-	require.NoError(t, err)
-	_, err = app.Append(0, lblsFloat, 99, 99.0)
-	require.NoError(t, err)
-	require.NoError(t, app.Commit())
-
-	head.opts.EnableMemorySnapshotOnShutdown = true
-	require.NoError(t, head.Close())
-
-	// Find the snapshot and corrupt the encoding byte of the float histogram series.
-	snapDir, _, _, err := LastChunkSnapshot(head.opts.ChunkDirRoot)
-	require.NoError(t, err)
-
-	sr, err := wlog.NewSegmentsReader(snapDir)
-	require.NoError(t, err)
-	r := wlog.NewReader(sr)
-	syms := labels.NewSymbolTable()
-	rdec := record.NewDecoder(syms, promslog.NewNopLogger())
-	var (
-		records [][]byte
-		mutated bool
-	)
-	for r.Next() {
-		rec := append([]byte(nil), r.Record()...)
-		if rec[0] == chunkSnapshotRecordTypeSeries {
-			buf := encoding.Decbuf{B: rec}
-			_ = buf.Byte() // flag
-			_ = buf.Be64() // ref
-			lset := rdec.DecodeLabels(&buf)
-			_ = buf.Be64int64() // chunkRange
-			if buf.Uvarint() == 1 && lset.Get("floathist") == "bar" {
-				_ = buf.Be64int64() // minTime
-				_ = buf.Be64int64() // maxTime
-				encPos := len(rec) - buf.Len()
-				require.Equal(t, byte(chunkenc.EncFloatHistogram), rec[encPos],
-					"expected float histogram encoding at computed offset")
-				rec[encPos] = 0xFF
-				mutated = true
+// TestSnapshotInvalidRecordFallsBackToWAL verifies recovery from invalid or legacy
+// snapshots, falling back to full WAL replay when available.
+func TestSnapshotInvalidRecordFallsBackToWAL(t *testing.T) {
+	for _, corruption := range []string{
+		"unknown chunk encoding",
+		"missing WAL expiry record",
+		"truncated WAL expiry record",
+		"missing WAL expiry record without WAL",
+	} {
+		t.Run(corruption, func(t *testing.T) {
+			head, _ := newTestHead(t, 120*4, compression.None, false)
+			querySamples := func() map[string][]chunks.Sample {
+				q, err := NewBlockQuerier(head, math.MinInt64, math.MaxInt64)
+				require.NoError(t, err)
+				return query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
 			}
-		}
-		records = append(records, rec)
+			defer func() {
+				head.opts.EnableMemorySnapshotOnShutdown = false
+				require.NoError(t, head.Close())
+			}()
+
+			floatHist := tsdbutil.GenerateTestGaugeFloatHistograms(1)[0]
+			lblsFloatHist := labels.FromStrings("floathist", "bar")
+			lblsFloat := labels.FromStrings("foo", "bar")
+
+			app := head.Appender(context.Background())
+			_, err := app.AppendHistogram(0, lblsFloatHist, 99, nil, floatHist)
+			require.NoError(t, err)
+			_, err = app.Append(0, lblsFloat, 99, 99.0)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			expectedSamples := querySamples()
+			require.Len(t, expectedSamples, 2)
+
+			head.opts.EnableMemorySnapshotOnShutdown = true
+			require.NoError(t, head.Close())
+
+			// Find the snapshot and corrupt or remove the selected record.
+			snapDir, _, _, err := LastChunkSnapshot(head.opts.ChunkDirRoot)
+			require.NoError(t, err)
+
+			sr, err := wlog.NewSegmentsReader(snapDir)
+			require.NoError(t, err)
+			r := wlog.NewReader(sr)
+			syms := labels.NewSymbolTable()
+			rdec := record.NewDecoder(syms, promslog.NewNopLogger())
+			var (
+				records [][]byte
+				mutated bool
+			)
+			for r.Next() {
+				rec := append([]byte(nil), r.Record()...)
+				switch {
+				case corruption == "unknown chunk encoding" && rec[0] == chunkSnapshotRecordTypeSeries:
+					buf := encoding.Decbuf{B: rec}
+					_ = buf.Byte() // flag
+					_ = buf.Be64() // ref
+					lset := rdec.DecodeLabels(&buf)
+					_ = buf.Be64int64() // chunkRange
+					if buf.Uvarint() == 1 && lset.Get("floathist") == "bar" {
+						_ = buf.Be64int64() // minTime
+						_ = buf.Be64int64() // maxTime
+						encPos := len(rec) - buf.Len()
+						require.Equal(t, byte(chunkenc.EncFloatHistogram), rec[encPos],
+							"expected float histogram encoding at computed offset")
+						rec[encPos] = 0xFF
+						mutated = true
+					}
+				case strings.HasPrefix(corruption, "missing WAL expiry record") && rec[0] == chunkSnapshotRecordTypeWALExpiries:
+					mutated = true
+					continue
+				case corruption == "truncated WAL expiry record" && rec[0] == chunkSnapshotRecordTypeWALExpiries:
+					rec = append(rec, 0) // Incomplete reference/expiry pair.
+					mutated = true
+				}
+				records = append(records, rec)
+			}
+			require.NoError(t, r.Err())
+			require.NoError(t, sr.Close())
+			require.True(t, mutated, "expected to find the record to mutate")
+
+			// Rewrite the snapshot with the mutated records.
+			files, err := os.ReadDir(snapDir)
+			require.NoError(t, err)
+			for _, f := range files {
+				require.NoError(t, os.Remove(filepath.Join(snapDir, f.Name())))
+			}
+			cp, err := wlog.New(nil, nil, snapDir, compression.None)
+			require.NoError(t, err)
+			require.NoError(t, cp.Log(records...))
+			require.NoError(t, cp.Close())
+
+			// Legacy snapshots remain usable without a WAL. Otherwise invalid
+			// snapshots must fall back to replaying the WAL.
+			var w *wlog.WL
+			if corruption != "missing WAL expiry record without WAL" {
+				w, err = wlog.NewSize(nil, nil, head.wal.Dir(), 32768, compression.None)
+				require.NoError(t, err)
+			}
+			head, err = NewHead(prometheus.NewRegistry(), nil, w, nil, head.opts, nil)
+			require.NoError(t, err)
+			require.NoError(t, head.Init(math.MinInt64))
+
+			if w == nil {
+				require.Zero(t, prom_testutil.ToFloat64(head.metrics.snapshotReplayErrorTotal))
+			} else {
+				require.Equal(t, 1.0, prom_testutil.ToFloat64(head.metrics.snapshotReplayErrorTotal))
+			}
+			require.Equal(t, uint64(2), head.NumSeries(), "both series must be recovered")
+			require.NotNil(t, head.series.getByHash(lblsFloat.Hash(), lblsFloat))
+			require.NotNil(t, head.series.getByHash(lblsFloatHist.Hash(), lblsFloatHist))
+			require.Equal(t, expectedSamples, querySamples())
+		})
 	}
-	require.NoError(t, r.Err())
-	require.NoError(t, sr.Close())
-	require.True(t, mutated, "expected to find and corrupt the float histogram series record")
+}
 
-	// Rewrite the snapshot with the mutated records.
-	files, err := os.ReadDir(snapDir)
-	require.NoError(t, err)
-	for _, f := range files {
-		require.NoError(t, os.Remove(filepath.Join(snapDir, f.Name())))
+func TestChunkSnapshotWALExpiries(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		entries   int
+		keepUntil int64
+	}{
+		{name: "empty"},
+		{name: "negative timestamp", entries: 1, keepUntil: -1},
+		{name: "minimum timestamp", entries: 1, keepUntil: math.MinInt64},
+		{name: "maximum timestamp", entries: 1, keepUntil: math.MaxInt64},
+		{name: "multiple records", entries: 10001, keepUntil: 100},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			head, w := newTestHead(t, 1000, compression.None, false)
+			defer func() {
+				head.opts.EnableMemorySnapshotOnShutdown = false
+				_ = head.Close()
+			}()
+			require.NoError(t, head.Init(math.MinInt64))
+			// A committed sample advances the WAL so that shutdown takes a snapshot.
+			app := head.Appender(context.Background())
+			ref, err := app.Append(0, labels.FromStrings("a", "1"), 0, 1)
+			require.NoError(t, err)
+			require.Equal(t, storage.SeriesRef(1), ref)
+			require.NoError(t, app.Commit())
+
+			// GC can retain negative timestamps, unlike updateWALExpiry's zero floor.
+			head.walExpiriesMtx.Lock()
+			for i := range tc.entries {
+				head.walExpiries[chunks.HeadSeriesRef(i+2)] = tc.keepUntil
+			}
+			head.walExpiriesMtx.Unlock()
+			head.opts.EnableMemorySnapshotOnShutdown = true
+			require.NoError(t, head.Close())
+			_, _, _, err = LastChunkSnapshot(head.opts.ChunkDirRoot)
+			require.NoError(t, err)
+
+			w, err = wlog.NewSize(nil, nil, w.Dir(), 32768, compression.None)
+			require.NoError(t, err)
+			head, err = NewHead(nil, nil, w, nil, head.opts, nil)
+			require.NoError(t, err)
+			require.NoError(t, head.Init(math.MinInt64))
+
+			// Even an empty expiry map must carry the completeness marker.
+			require.Zero(t, prom_testutil.ToFloat64(head.metrics.snapshotReplayErrorTotal))
+			require.Len(t, head.walExpiries, tc.entries)
+			for i := range tc.entries {
+				keepUntil, ok := head.getWALExpiry(chunks.HeadSeriesRef(i + 2))
+				require.True(t, ok)
+				require.Equal(t, tc.keepUntil, keepUntil)
+			}
+			require.Equal(t, uint64(tc.entries+1), head.lastSeriesID.Load())
+		})
 	}
-	cp, err := wlog.New(nil, nil, snapDir, compression.None)
-	require.NoError(t, err)
-	require.NoError(t, cp.Log(records...))
-	require.NoError(t, cp.Close())
-
-	// Reload the head; snapshot should fail due to unknown encoding and fall back to WAL.
-	w, err := wlog.NewSize(nil, nil, head.wal.Dir(), 32768, compression.None)
-	require.NoError(t, err)
-	head, err = NewHead(prometheus.NewRegistry(), nil, w, nil, head.opts, nil)
-	require.NoError(t, err)
-	require.NoError(t, head.Init(math.MinInt64))
-
-	require.Equal(t, 1.0, prom_testutil.ToFloat64(head.metrics.snapshotReplayErrorTotal))
-	require.Equal(t, uint64(2), head.NumSeries(), "both series must be recovered from WAL")
-	require.NotNil(t, head.series.getByHash(lblsFloat.Hash(), lblsFloat))
-	require.NotNil(t, head.series.getByHash(lblsFloatHist.Hash(), lblsFloatHist))
 }
 
 func TestHistogramMetrics(t *testing.T) {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1290,9 +1290,10 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (map[chunks.HeadSeriesR
 }
 
 const (
-	chunkSnapshotRecordTypeSeries     uint8 = 1
-	chunkSnapshotRecordTypeTombstones uint8 = 2
-	chunkSnapshotRecordTypeExemplars  uint8 = 3
+	chunkSnapshotRecordTypeSeries      uint8 = 1
+	chunkSnapshotRecordTypeTombstones  uint8 = 2
+	chunkSnapshotRecordTypeExemplars   uint8 = 3
+	chunkSnapshotRecordTypeWALExpiries uint8 = 4
 )
 
 type chunkSnapshotRecord struct {
@@ -1439,8 +1440,8 @@ const chunkSnapshotPrefix = "chunk_snapshot."
 // M is the offset in segment N upto which data was written.
 //
 // The snapshot first contains all series (each in individual records and not sorted), followed by
-// tombstones (a single record), and finally exemplars (>= 1 record). Exemplars are in the order they
-// were written to the circular buffer.
+// tombstones (a single record), exemplars, and WAL series expiries (>= 1 record).
+// Exemplars are in the order they were written to the circular buffer.
 func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 	if h.wal == nil {
 		// If we are not storing any WAL, does not make sense to take a snapshot too.
@@ -1580,6 +1581,30 @@ func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 	// Flush remaining exemplars.
 	if err := flushExemplars(); err != nil {
 		return stats, fmt.Errorf("flush exemplars at the end: %w", err)
+	}
+
+	// Preserve references no longer in the Head which are still needed by WAL readers.
+	// Write bounded batches without copying the entire expiry map.
+	const maxWALExpiriesPerRecord = 10000
+	encbuf := encoding.Encbuf{B: buf[:0]}
+	encbuf.PutByte(chunkSnapshotRecordTypeWALExpiries)
+	h.walExpiriesMtx.Lock()
+	for ref, keepUntil := range h.walExpiries {
+		encbuf.PutBE64(uint64(ref))
+		encbuf.PutBE64int64(keepUntil)
+		if len(encbuf.Get()) >= 1+16*maxWALExpiriesPerRecord {
+			if err := cp.Log(encbuf.Get()); err != nil {
+				h.walExpiriesMtx.Unlock()
+				return stats, fmt.Errorf("flush WAL expiries: %w", err)
+			}
+			encbuf.Reset()
+			encbuf.PutByte(chunkSnapshotRecordTypeWALExpiries)
+		}
+	}
+	h.walExpiriesMtx.Unlock()
+	// Even an empty record marks the snapshot as preserving WAL expiry state.
+	if err := cp.Log(encbuf.Get()); err != nil {
+		return stats, fmt.Errorf("flush remaining WAL expiries: %w", err)
 	}
 
 	if err := cp.Close(); err != nil {
@@ -1804,6 +1829,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 
 	r := wlog.NewReader(sr)
 	var loopErr error
+	var walExpiriesLoaded bool
 Outer:
 	for r.Next() {
 		select {
@@ -1882,6 +1908,30 @@ Outer:
 				}
 			}
 
+		case chunkSnapshotRecordTypeWALExpiries:
+			if (len(rec)-1)%16 != 0 {
+				loopErr = errors.New("invalid WAL expiry record length")
+				break Outer
+			}
+			decbuf := encoding.Decbuf{B: rec[1:]}
+			var maxRef uint64
+			h.walExpiriesMtx.Lock()
+			for len(decbuf.B) > 0 {
+				ref := decbuf.Be64()
+				h.walExpiries[chunks.HeadSeriesRef(ref)] = decbuf.Be64int64()
+				maxRef = max(maxRef, ref)
+			}
+			h.walExpiriesMtx.Unlock()
+			// Snapshot series loaders also advance the counter. Do not reuse an
+			// alias reference that is absent from the snapshot's live series.
+			for {
+				lastSeriesID := h.lastSeriesID.Load()
+				if lastSeriesID >= maxRef || h.lastSeriesID.CompareAndSwap(lastSeriesID, maxRef) {
+					break
+				}
+			}
+			walExpiriesLoaded = true
+
 		default:
 			// This is a record type we don't understand. It is either an old format from earlier versions,
 			// or a new format and the code was rolled back to old version.
@@ -1908,6 +1958,12 @@ Outer:
 
 	if err := r.Err(); err != nil {
 		return -1, -1, nil, fmt.Errorf("read records: %w", err)
+	}
+
+	if !walExpiriesLoaded && h.wal != nil {
+		// Legacy snapshots omit the state needed to retain series in future
+		// checkpoints. Recover it by falling back to a complete WAL replay.
+		return -1, -1, nil, errors.New("snapshot is missing WAL series expiries")
 	}
 
 	if len(refSeries) == 0 {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Addresses the full-TSDB memory-snapshot reports in #15574. The original issue also contains agent-mode reports; this change is limited to the snapshot path.

WAL replay retains expiry timestamps for series references that are no longer in the Head, including aliases created when identical labels have multiple references. Snapshot recovery previously lost those expiries while skipping the WAL records that could reconstruct them. A later checkpoint could keep samples for an alias but drop its series record, leaving those samples unresolvable on subsequent WAL recovery.

Persist the expiries in bounded snapshot records and restore them before WAL replay. Restored references also advance the series ID counter, preventing an unrelated series from reusing an alias still present in the WAL. At least one expiry record is emitted, even when empty, so readers can detect snapshots that omit this state. With the WAL enabled, legacy snapshots fall back to full WAL recovery; legacy snapshots remain readable when the WAL is disabled. The snapshot format documentation describes the new record and fallback behavior.

The regression extends existing checkpoint fixtures across normal WAL and snapshot recovery, then checks query results after another WAL-only restart. It covers reference allocation, invalid/legacy snapshots, WAL-disabled recovery, signed expiry boundaries and multiple expiry batches. On unchanged main, all 14 normal-WAL controls pass and all 14 snapshot variants fail; with this change, all 37 targeted cases pass.

Local validation (Ubuntu WSL, Go 1.27.1, `GOMAXPROCS=2`, `GOFLAGS=-p=2`):

- `go test -race -parallel=2 -timeout=15m ./tsdb -run '^(TestHead_WALCheckpointMultiRef|TestHead_KeepSeriesInWALCheckpoint|TestChunkSnapshot.*|TestSnapshot.*)$' -count=1 -v`: passed (13 parent tests, 47 subtests).
- `go test -parallel=2 -timeout=20m ./tsdb/... ./storage/remote/...`: passed (14 packages, three without tests; no exclusions). The `make test` wrapper subsequently needed `jq` for its version check; after installing it, `make check-go-mod-version` passed separately.
- Whole-repository `make lint` passed with golangci-lint 2.13.1 and `GOLANGCI_LINT_OPTS=--timeout=40m`. Formatting also passed. The initial 20-minute lint attempt timed out while loading cold dependencies.

The broader race attempt over `./tsdb/... ./storage/remote/...` did not pass: `tsdb` and `tsdb/agent` reached the default 10-minute package timeout, and `storage/remote` failed the 30-second sample-count assertion in `TestReshard/prometheus.WriteRequest` (514,000/600,000 samples). No race-detector warning was reported. That queue-manager test does not use Head snapshot recovery. After lint finished, isolated sequential race runs of the failing case passed on both exact baseline code (33.332s) and this change (34.285s). The broad race run remains a validation limit.

OpenAI Codex was used for investigation, implementation, test execution, code review and this description.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] TSDB: Preserve WAL series references across memory-snapshot recovery to prevent checkpointing from dropping metadata needed by retained samples.
```
