### PR TITLE
ui: restore react-app version bump and fix bump-version idempotency

### DIFF
--- a/scripts/ui_release.sh
+++ b/scripts/ui_release.sh
@@ -160,8 +160,16 @@ function bumpVersion() {
   if [[ "${version}" == v* ]]; then
     version="${version:1}"
   fi
-  # increase the version on all packages in the pnpm workspace
-  pnpm -r --include-workspace-root version "${version}" --no-git-tag-version --git-checks=false
+  # increase the version on all packages in the pnpm workspace. --allow-same-version
+  # keeps this idempotent if the release script is re-run for the same version,
+  # instead of failing with ERR_PNPM_VERSION_NOT_CHANGED.
+  pnpm -r --include-workspace-root version "${version}" --no-git-tag-version --git-checks=false --allow-same-version
+  # bump the react-app version. its @prometheus-io/* dependencies use the
+  # "link:" protocol to consume the locally built workspace packages, so they
+  # carry no version to rewrite and must be left untouched.
+  cd react-app
+  pnpm version "${version}" --no-git-tag-version --git-checks=false --allow-same-version
+  cd "${root_ui_folder}"
 }
 
 if [[ "$1" == "--copy" ]]; then


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None filed; found while reviewing #19621, where `web/ui/react-app/package.json` was left at the previous release's version.

#### What this fixes

`scripts/ui_release.sh`'s `bumpVersion` used to also bump `react-app`'s version, but that step was removed in #18975 to work around:

```
[ERR_PNPM_VERSION_NOT_CHANGED] Version was not changed: 0.313.0-rc.0
```

That error isn't specific to `react-app`: it's `pnpm version`'s normal behaviour when asked to set a package to the version it's already at (e.g. `ui-bump-version` re-run for a version that was already applied). The primary `pnpm -r --include-workspace-root version` call has the exact same failure mode, it just wasn't hit in that instance.

Since `react-app` isn't part of the pnpm workspace (it's deliberately isolated, see `web/ui/react-app/pnpm-workspace.yaml`), dropping its bump step meant `make ui-bump-version` silently stopped keeping it in sync. It's been bumped by hand in the 3.13.1 and 3.13.2 release-prep commits, and missed for 3.13.3 (#19621).

This adds `--allow-same-version` to both `pnpm version` invocations, which:
- restores the `react-app` bump
- makes the whole `bumpVersion` step idempotent, fixing the root cause instead of only removing the symptom

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```