### PR TITLE
discovery/ionos: paginate DatacentersServersGet

### DIFF
--- a/discovery/ionos/server.go
+++ b/discovery/ionos/server.go
@@ -83,20 +83,52 @@ func newServerDiscovery(conf *SDConfig, _ *slog.Logger) (*serverDiscovery, error
 	return d, nil
 }
 
-func (d *serverDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+// serverPageLimit is the page size used when listing servers. The API
+// truncates results without pagination, so this must stay below the API's
+// own per-page maximum.
+const serverPageLimit = 100
+
+// listServers fetches all servers in the datacenter, following pagination
+// via the response's next link. It also returns the servers collection ID,
+// which is the same across pages.
+func (d *serverDiscovery) listServers(ctx context.Context) ([]ionoscloud.Server, *string, error) {
 	api := d.client.ServersApi
 
-	servers, _, err := api.DatacentersServersGet(ctx, d.datacenterID).
-		Depth(3).
-		Execute()
+	var (
+		items        []ionoscloud.Server
+		collectionID *string
+		offset       int32
+	)
+	for {
+		servers, _, err := api.DatacentersServersGet(ctx, d.datacenterID).
+			Depth(3).
+			Offset(offset).
+			Limit(serverPageLimit).
+			Execute()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if collectionID == nil {
+			collectionID = servers.Id
+		}
+		// Items is omitted from the response when the page holds no servers.
+		if servers.Items != nil {
+			items = append(items, *servers.Items...)
+		}
+
+		if servers.Links == nil || servers.Links.Next == nil {
+			break
+		}
+		offset += serverPageLimit
+	}
+	return items, collectionID, nil
+}
+
+func (d *serverDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	serverItems, collectionID, err := d.listServers(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	// Items is omitted from the response when the datacenter holds no servers.
-	var serverItems []ionoscloud.Server
-	if servers.Items != nil {
-		serverItems = *servers.Items
 	}
 
 	var targets []model.LabelSet
@@ -150,8 +182,8 @@ func (d *serverDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 		if props.CpuFamily != nil {
 			labels[serverCPUFamilyLabel] = model.LabelValue(*props.CpuFamily)
 		}
-		if servers.Id != nil {
-			labels[serverServersIDLabel] = model.LabelValue(*servers.Id)
+		if collectionID != nil {
+			labels[serverServersIDLabel] = model.LabelValue(*collectionID)
 		}
 		if server.Id != nil {
 			labels[serverIDLabel] = model.LabelValue(*server.Id)

--- a/discovery/ionos/server_test.go
+++ b/discovery/ionos/server_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -274,6 +275,50 @@ func TestIONOSServerRefreshNilContainers(t *testing.T) {
 			require.Equal(t, tc.expected, tgs[0].Targets)
 		})
 	}
+}
+
+// TestIONOSServerRefreshPagination covers a datacenter whose server count
+// exceeds one page: refresh() must follow the _links.next indicator and
+// collect servers from every page instead of silently truncating results.
+func TestIONOSServerRefreshPagination(t *testing.T) {
+	t.Parallel()
+
+	var gotOffsets []string
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotOffsets = append(gotOffsets, r.URL.Query().Get("offset"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("offset") == "0" {
+			_, _ = io.WriteString(w, `{
+				"id": "`+ionosTestDatacenterID+`/servers",
+				"type": "collection",
+				"items": [{"id": "srv-page1", "type": "server", "properties": {"name": "page1"},
+					"entities": {"nics": {"items": [{"id": "nic-1", "type": "nic", "properties": {"ips": ["10.0.0.1"]}}]}}}],
+				"_links": {"next": "ignored, only presence is checked"}
+			}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{
+			"id": "`+ionosTestDatacenterID+`/servers",
+			"type": "collection",
+			"items": [{"id": "srv-page2", "type": "server", "properties": {"name": "page2"},
+				"entities": {"nics": {"items": [{"id": "nic-2", "type": "nic", "properties": {"ips": ["10.0.0.2"]}}]}}}]
+		}`)
+	}))
+	t.Cleanup(mock.Close)
+
+	cfg := DefaultSDConfig
+	cfg.DatacenterID = ionosTestDatacenterID
+	cfg.HTTPClientConfig.BearerToken = ionosTestBearerToken
+	cfg.ionosEndpoint = mock.URL
+
+	d, err := newServerDiscovery(&cfg, nil)
+	require.NoError(t, err)
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Len(t, tgs[0].Targets, 2, "expected servers from both pages")
+	require.Equal(t, []string{"0", strconv.Itoa(serverPageLimit)}, gotOffsets)
 }
 
 func mockIONOSServers(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #10722

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] discovery/ionos: Fix silent truncation of results for datacenters with more servers than fit in one API page.
```
