### PR TITLE
promql: fix histogram_fraction for custom buckets bounded at zero

### DIFF
--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -136,6 +136,45 @@ eval instant at 50m histogram_fraction(0, 3.5, testhistogram2_bucket)
 	expect no_warn
 	{} 0.5833333333333334
 
+# A populated le="0" bucket belongs to the (-Inf, 0] side, as it does for the
+# classic histogram this was converted from.
+load_with_nhcb 5m
+	testhistogram4_bucket{le="0"}	 0+4x10
+	testhistogram4_bucket{le="1"}	 0+7x10
+	testhistogram4_bucket{le="2"}	 0+9x10
+	testhistogram4_bucket{le="+Inf"} 0+10x10
+
+eval instant at 50m histogram_fraction(-Inf, 0, testhistogram4)
+	expect no_warn
+	{} 0.4
+
+eval instant at 50m histogram_fraction(-Inf, 0, testhistogram4_bucket)
+	expect no_warn
+	{} 0.4
+
+eval instant at 50m histogram_fraction(0, Inf, testhistogram4)
+	expect no_warn
+	{} 0.6
+
+eval instant at 50m histogram_fraction(0, Inf, testhistogram4_bucket)
+	expect no_warn
+	{} 0.6
+
+# A custom bucket that spans zero is an ordinary bucket, not an exponential
+# zero bucket, so its bounds must not be rewritten to 0.
+load_with_nhcb 5m
+	testhistogram5_bucket{le="-5"}	 0+1x10
+	testhistogram5_bucket{le="1"}	 0+3x10
+	testhistogram5_bucket{le="+Inf"} 0+4x10
+
+eval instant at 50m histogram_fraction(-Inf, 0, testhistogram5)
+	expect no_warn
+	{} 0.6666666666666666
+
+eval instant at 50m histogram_fraction(-Inf, 0, testhistogram5_bucket)
+	expect no_warn
+	{} 0.6666666666666666
+
 
 eval instant at 50m histogram_fraction(0, 0.2, testhistogram3)
 	expect no_warn

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -441,7 +441,15 @@ func HistogramFraction(lower, upper float64, h *histogram.FloatHistogram, metric
 			return rank + b.Count*b.FractionBelow(v, false)
 		}
 
-		if b.Lower <= 0 && b.Upper >= 0 {
+		if h.UsesCustomBuckets() {
+			// Custom buckets have no zero bucket. Only the first bucket has a
+			// lower bound of -Inf, and 0 is its lower bound if its upper bound
+			// is positive, as done for classic histograms and in
+			// HistogramQuantile above.
+			if b.Lower == math.Inf(-1) && b.Upper > 0 {
+				b.Lower = 0
+			}
+		} else if b.Lower <= 0 && b.Upper >= 0 {
 			zeroBucket = true
 			switch {
 			case len(h.NegativeBuckets) == 0 && len(h.PositiveBuckets) > 0:


### PR DESCRIPTION
## Description

`histogram_fraction()` over a native histogram with custom buckets (NHCB) disagrees with the classic histogram it was converted from whenever a bucket boundary is exactly `0`.

`HistogramFraction` treats any bucket with `Lower <= 0 && Upper >= 0` as an exponential zero bucket and rewrites its lower bound to `0` (`promql/quantile.go:444`). Custom buckets have no zero bucket, so the first bucket of an NHCB converted from a classic histogram with `le="0"` has its range `(-Inf, 0]` collapsed to `[0, 0]`, and every observation at or below zero disappears from the "below" side of the fraction.

Measured with the existing `load_with_nhcb` harness, which loads both representations of the same data side by side (`le="0"` -> 4, `le="1"` -> 7, `le="2"` -> 9, `le="+Inf"` -> 10):

```
histogram_fraction(-Inf, 0, testhistogram4)         expected 0.4  got 0
histogram_fraction(-Inf, 0, testhistogram4_bucket)  0.4           pass
histogram_fraction(0, Inf, testhistogram4)          expected 0.6  got 1
histogram_fraction(0, Inf, testhistogram4_bucket)   0.6           pass
```

The classic series passes in the same run, so it is the reference for the expected values rather than an assumption.

## Motivation and Context

Two places in the tree already apply the opposite rule at this boundary, and they agree with each other:

- `HistogramQuantile` (`promql/quantile.go:266`) gates the zero-bucket branch on `!h.UsesCustomBuckets()` and handles the `-Inf` first bucket separately.
- `BucketFraction`, the classic path (`promql/quantile.go:552`), sets the first bucket's lower bound to `-Inf` when its upper bound is not positive.

So `le="0"` belongs on the `-Inf` side everywhere except `HistogramFraction`. This patch applies the same rule there. It also covers an interior custom bucket that spans zero, which the old condition collapsed the same way.

The affected users are anyone running `convert_classic_histograms_to_nhcb`, or ingesting OTLP explicit-bucket histograms whose default boundaries begin with `0`: the same data returns a different fraction depending on which representation is queried, with no annotation.

`zeroBucket` is only read to choose linear versus exponential interpolation, and that branch already tests `h.UsesCustomBuckets()` first, so interpolation behaviour is unchanged.

## How Has This Been Tested

Cases added to the existing table in `promql/promqltest/testdata/histograms.test`, next to the current `histogram_fraction` block, each asserted against both the NHCB and the classic series.

- First commit adds the tests and fails; second commit fixes and passes.
- Mutation checks, all caught: dropping the `UsesCustomBuckets` gate, widening `Upper > 0` to `>= 0`, removing the `b.Lower = 0` assignment, and dropping the `-Inf` first-bucket test.
- `go test ./promql/... ./model/histogram/... ./util/convertnhcb/...` pass.
- `GOARCH=386 go test -parallel=1 ./promql/` and `go test --tags=dedupelabels ./promql/` pass.
- `gofmt` clean, `golangci-lint run ./promql/` clean. `go vet ./promql/` reports 3 findings in `histogram_stats_iterator.go` and `value.go`, identical on `main` and in files this PR does not touch.

The existing fixture `testhistogram2` already has a `le="0"` bucket, but it is loaded as `0+0x10`, so the bucket is always empty and the current `histogram_fraction` cases never exercised this path.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

```release-notes
[BUGFIX] PromQL: Fix histogram_fraction returning wrong results for native histograms with custom buckets when a bucket boundary is exactly 0.
```

---

AI assistance disclosure: this patch was found and written with Claude Code. The measurements and command output quoted above are verbatim from running them against `main`.
