### PR TITLE
api: reject durations that overflow int64 at the exact boundary

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -2406,7 +2406,8 @@ func parseTime(s string) (time.Time, error) {
 func parseDuration(s string) (time.Duration, error) {
 	if d, err := strconv.ParseFloat(s, 64); err == nil {
 		ts := d * float64(time.Second)
-		if ts > float64(math.MaxInt64) || ts < float64(math.MinInt64) {
+		// float64(math.MaxInt64) is 2^63, which int64 cannot hold, and NaN passes every comparison.
+		if math.IsNaN(ts) || ts >= float64(math.MaxInt64) || ts < float64(math.MinInt64) {
 			return 0, fmt.Errorf("cannot parse %q to a valid duration. It overflows int64", s)
 		}
 		return time.Duration(ts), nil

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -4568,6 +4568,22 @@ func TestParseDuration(t *testing.T) {
 			input: "148966367200.372",
 			fail:  true,
 		}, {
+			// Exactly 2^63 nanoseconds, the value float64(math.MaxInt64) rounds to.
+			input: "9223372036.854776",
+			fail:  true,
+		}, {
+			input: "NaN",
+			fail:  true,
+		}, {
+			// Largest duration that still fits in int64.
+			input:  "9223372036.85477",
+			result: time.Duration(9223372036854770688),
+		}, {
+			// float64(math.MinInt64) is exactly -2^63, which int64 does hold,
+			// so the lower bound stays exclusive.
+			input:  "-9223372036.854775808",
+			result: time.Duration(-9223372036854775808),
+		}, {
 			input:  "123",
 			result: 123 * time.Second,
 		}, {


### PR DESCRIPTION
## Description

`parseDuration` guards its float64 to int64 conversion with `ts > float64(math.MaxInt64)` (`web/api/v1/api.go:2409`). `float64(math.MaxInt64)` rounds up to exactly 2^63, which int64 cannot hold, so `ts == 2^63` passes the guard and `time.Duration(ts)` overflows. NaN passes both comparisons too, since every comparison against NaN is false.

Measured on `main`, showing what the request handler then does with the value at `web/api/v1/api.go:568`:

```
?timeout=              parse          duration                   deadline vs now
30                     accepted       30s                        in the future
9223372036             accepted       2562047h47m16s             in the future
9223372036.85477       accepted       2562047h47m16.854770688s   in the future
9223372036.854776      accepted       -2562047h47m16.854775808s  IN THE PAST
NaN                    accepted       -2562047h47m16.854775808s  IN THE PAST
148966367200.372       rejected       -                          -
```

So `?timeout=9223372036.854776` — one ULP above the largest duration that fits — and `?timeout=NaN` are accepted and turn into a *negative* timeout, which puts `context.WithDeadline(ctx, api.now().Add(timeout))` about 292 years in the past and returns an immediate `query timed out in query execution`. The user asked for the longest possible timeout and got the shortest. `?lookback_delta=NaN` reaches the same parser and is then swallowed by the `lookbackDelta <= 0` fallback in `promql/engine.go`. `?step` is the only caller already protected, by its own `step <= 0` check.

With this change both are rejected with the existing "It overflows int64" error, and `9223372036.85477` still parses.

## Motivation and Context

`promql/parser.(*parser).setTimestamp` (`promql/parser/parse.go:1132-1133`) performs the identical float64 to int64 conversion and guards it correctly, checking `math.IsNaN` and comparing with `>=`. These are the only two sites of that conversion in the tree, and `parseDuration` is the one that does neither.

The lower bound deliberately stays exclusive. Unlike the upper one, `float64(math.MinInt64)` is exactly -2^63 and *is* representable, so `-9223372036.854775808` is a valid duration; the added test row pins that so the two sides do not get "fixed" into symmetry.

Note on platforms: the Go spec makes an out-of-range float to int conversion implementation-defined. On amd64 it yields `MinInt64`, which is what the table above shows; arm64 saturates to `MaxInt64` instead. The guard is wrong either way, and the added tests assert only that an error is returned, so they are platform-independent.

## How Has This Been Tested

Rows added to the existing `TestParseDuration` table, which already carries two `// Internal int64 overflow.` cases — both far outside the range, so nothing exercised the boundary itself or NaN.

- New rows fail on `main` and pass here.
- Mutation-checked, all four caught: `>=` weakened back to `>`; the `math.IsNaN` check removed; the bound made over-restrictive by one ULP; and the lower bound changed from `<` to `<=`, which the new negative-boundary row rejects.
- `go test ./web/...` passes; `GOARCH=386 go test -parallel=1 ./web/api/v1/` and `go test --tags=dedupelabels ./web/api/v1/` pass.
- `gofmt` clean, `golangci-lint run ./web/api/v1/...` clean, `go build ./...` clean. `go vet ./web/...` reports two `stdmethods` findings in `web/api/testhelpers/mocks.go`, identical on `main` and in a file this PR does not touch.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

```release-notes
[BUGFIX] API: Reject `timeout` and `lookback_delta` values that overflow int64 instead of turning them into a negative duration
```

---

AI assistance disclosure: this patch was found and written with Claude Code. The measurements and command output quoted above are verbatim from running them against `main`.
