### PR TITLE
histogram: keep span gaps empty when unrolling an integer NHCB

### DIFF
--- a/model/histogram/convert.go
+++ b/model/histogram/convert.go
@@ -66,10 +66,8 @@ func ConvertNHCBToClassic(nhcb any, lset labels.Labels, lsetBuilder *labels.Buil
 		// Histograms are in delta format so we first bring them to absolute format.
 		acc := int64(0)
 		for _, s := range h.PositiveSpans {
-			for i := 0; i < int(s.Offset); i++ {
-				positiveBuckets[idx] = float64(acc)
-				idx++
-			}
+			// Skipped buckets are empty, so leave them at zero.
+			idx += int(s.Offset)
 			for i := 0; i < int(s.Length); i++ {
 				acc += h.PositiveBuckets[currIdx]
 				positiveBuckets[idx] = float64(acc)

--- a/model/histogram/convert_test.go
+++ b/model/histogram/convert_test.go
@@ -16,6 +16,7 @@ package histogram
 import (
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -239,23 +240,23 @@ func TestConvertNHCBToClassicHistogram(t *testing.T) {
 					{4, 1},
 					{1, 2},
 				},
-				PositiveBuckets: []int64{1, 2, 3, 4, 5}, // 1 -> 3 -> 3 -> 3 -> 3 -> 3 -> 6 ->6 ->10 -> 15
-				Count:           35,                     // 1 -> 4 -> 7 -> 10 -> 13 -> 16 -> 22 -> 28 -> 38 -> 53
+				PositiveBuckets: []int64{1, 2, 3, 4, 5}, // 1 -> 3 -> 0 -> 0 -> 0 -> 0 -> 6 -> 0 -> 10 -> 15
+				Count:           35,                     // 1 -> 4 -> 4 -> 4 -> 4 -> 4 -> 10 -> 10 -> 20 -> 35
 				Sum:             123,
 			},
 			labels: labels.FromStrings("__name__", "test_metric"),
 			expected: []sample{
 				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "1.0"), val: 1},
 				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "2.0"), val: 4},
-				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "3.0"), val: 7},
-				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "4.0"), val: 10},
-				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "5.0"), val: 13},
-				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "6.0"), val: 16},
-				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "7.0"), val: 22},
-				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "8.0"), val: 28},
-				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "9.0"), val: 38},
-				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "10.0"), val: 53},
-				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "+Inf"), val: 53},
+				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "3.0"), val: 4},
+				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "4.0"), val: 4},
+				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "5.0"), val: 4},
+				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "6.0"), val: 4},
+				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "7.0"), val: 10},
+				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "8.0"), val: 10},
+				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "9.0"), val: 20},
+				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "10.0"), val: 35},
+				{lset: labels.FromStrings("__name__", "test_metric_bucket", "le", "+Inf"), val: 35},
 				{lset: labels.FromStrings("__name__", "test_metric_count"), val: 35},
 				{lset: labels.FromStrings("__name__", "test_metric_sum"), val: 123},
 			},
@@ -311,4 +312,57 @@ func TestConvertNHCBToClassicHistogram(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConvertNHCBToClassicIntFloatAgreement checks that an integer NHCB and its
+// exact FloatHistogram representation convert to the same classic series, and
+// that the +Inf bucket matches the count.
+func TestConvertNHCBToClassicIntFloatAgreement(t *testing.T) {
+	h := &Histogram{
+		Schema:       CustomBucketsSchema,
+		CustomValues: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		PositiveSpans: []Span{
+			{Offset: 0, Length: 2},
+			{Offset: 4, Length: 1},
+			{Offset: 1, Length: 2},
+		},
+		PositiveBuckets: []int64{1, 2, 3, 4, 5},
+		Count:           35,
+		Sum:             123,
+	}
+	require.NoError(t, h.Validate())
+
+	convert := func(nhcb any) []sample {
+		var got []sample
+		lb := labels.NewBuilder(labels.EmptyLabels())
+		require.NoError(t, ConvertNHCBToClassic(nhcb, labels.FromStrings("__name__", "test_metric"), lb,
+			func(l labels.Labels, v float64) error {
+				got = append(got, sample{lset: l, val: v})
+				return nil
+			}))
+		return got
+	}
+
+	fromInt := convert(h)
+	fromFloat := convert(h.ToFloat(nil))
+
+	require.Len(t, fromInt, len(fromFloat))
+	for i := range fromInt {
+		require.True(t, labels.Equal(fromInt[i].lset, fromFloat[i].lset), "labels mismatch at index %d", i)
+		require.Equal(t, fromFloat[i].val, fromInt[i].val, "value mismatch at index %d for %s", i, fromInt[i].lset)
+	}
+
+	// In a classic histogram the +Inf bucket holds every observation.
+	var infBucket, count float64
+	for _, s := range fromInt {
+		switch s.lset.Get(model.MetricNameLabel) {
+		case "test_metric_bucket":
+			if s.lset.Get(model.BucketLabel) == "+Inf" {
+				infBucket = s.val
+			}
+		case "test_metric_count":
+			count = s.val
+		}
+	}
+	require.Equal(t, count, infBucket)
 }


### PR DESCRIPTION
## Description

The two branches of `ConvertNHCBToClassic` disagree on span gaps.

`model/histogram/convert.go:92-95` (`*FloatHistogram`) skips them with `idx += int(span.Offset)` and explains why: "keep the sparse buckets empty so we jump and go to next filled bucket index". `model/histogram/convert.go:68-71` (`*Histogram`) instead writes `acc`, the running absolute count of the previous bucket, into every gap bucket. `positiveBuckets` is then cumulatively summed to emit the classic `le` series (`convert.go:107-110`), so each empty bucket re-adds the previous bucket's count.

Feeding the repo's own sparse fixture and its exact float form (`h.ToFloat(nil)`) through both branches on `main`:

```
le      *Histogram  *FloatHistogram
1.0     1           1
2.0     4           4
3.0     7           4
7.0     22          10
9.0     38          20
10.0    53          35
+Inf    53          35
_count  35          35
```

An integer NHCB whose spans have gaps therefore yields a classic histogram whose `+Inf` bucket contradicts its own `_count` — 53 against 35. `h.Validate()` accepts the input.

## Motivation and Context

The sparse case in `convert_test.go` encoded this output, with a comment spelling out the inflated sequence `1 -> 4 -> 7 -> 10 -> 13 -> 16 -> 22 -> 28 -> 38 -> 53` next to `Count: 35`, so the expectations are corrected here too.

Both the gap loop and that test came in with `1df1f53ea` ("Added Unroll support to Sparse NHCBs"); the float branch in the same commit got it right, which is what this change aligns the integer branch to.

The input shape is not hypothetical: `prompb/codec.go` and `prompb/io/prometheus/write/v2/codec.go` build `PositiveSpans` straight from the wire, and `model/textparse/protobufparse.go` calls `Compact(0)`, which splits spans at every empty bucket.

To be upfront about scope: `ConvertNHCBToClassic` has no in-tree caller today — the wiring was split into a separate PR (`c8e3f8c97`). It is exported API, and the reason to fix it now is that the current test blesses the wrong output, so wiring it up later would confirm the behaviour rather than catch it.

## How Has This Been Tested

- The corrected expectations fail on `main` and pass here.
- New `TestConvertNHCBToClassicIntFloatAgreement` asserts that an integer NHCB and its exact `FloatHistogram` representation convert to identical series, and that `+Inf` equals `_count`.
- Mutation-checked, all three caught: reverting the gap loop; skipping one bucket too many; and resetting `acc` per span.
- `go test ./model/...` passes, as do the `--tags=dedupelabels`, `--tags=slicelabels` and `GOARCH=386` legs for `./model/histogram/`.
- `gofmt` clean, `golangci-lint run ./model/histogram/...` clean, `go build ./...` clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

```release-notes
[BUGFIX] Histograms: Fix ConvertNHCBToClassic inflating classic bucket counts for integer native histograms whose spans have gaps.
```

---

AI assistance disclosure: this patch was found and written with Claude Code. The table above is verbatim from running both branches against `main`.
