### PR TITLE
tsdb: preserve concurrent commits during selected-series compaction

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1794,9 +1794,12 @@ type headViewFactory func(head *Head, mint, maxt int64) BlockReader
 // after compaction began and may not be present in any block.
 //
 // When isolation is disabled, appendIDWatermark is always 0 and the
-// append-ID check becomes a no-op. In that mode, the caller must ensure
-// that no concurrent writes target the selected series.
-type headSeriesEvictor func(maxt int64, appendIDWatermark uint64) error
+// append-ID check becomes a no-op.
+//
+// appendSeqWatermark is captured under commitBarrier before writing blocks.
+// Series stamped above it must not be evicted because their commits may not
+// be present in those blocks. This also works with isolation disabled.
+type headSeriesEvictor func(maxt int64, appendIDWatermark, appendSeqWatermark uint64) error
 
 // compactHeadViewLocked writes a block (or sequence of blocks, one per chunk range) for the
 // restricted head view produced by viewFactory, then runs evictor to remove those series from the
@@ -1822,6 +1825,12 @@ func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSerie
 	// could evict a series whose newest sample is present in neither the block nor
 	// the head, causing that sample to be lost on WAL replay.
 	appendIDWatermark := db.head.iso.committedAppendID()
+	// Drain in-flight sample application before capturing the watermark. Later
+	// commits stamp their series above it, so eviction keeps those series even
+	// if their samples missed the block snapshot.
+	db.head.commitBarrier.Lock()
+	appendSeqWatermark := db.head.appendSeq.Load()
+	db.head.commitBarrier.Unlock()
 	// The bound is inclusive so that a sample sitting exactly on a chunk-range boundary
 	// (mint == maxt) still gets a block written before its series is evicted.
 	for ; mint <= maxt; mint += db.head.chunkRange.Load() {
@@ -1861,7 +1870,7 @@ func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSerie
 		compactHeadViewBeforeEvictTestingCallback = nil
 	}
 
-	if err := evict(maxt, appendIDWatermark); err != nil {
+	if err := evict(maxt, appendIDWatermark, appendSeqWatermark); err != nil {
 		return fmt.Errorf("head truncate: %w", err)
 	}
 	db.head.RebuildSymbolTable(db.logger)
@@ -1893,8 +1902,8 @@ func (db *DB) CompactStaleHead() (err error) {
 		func(h *Head, mint, maxt int64) BlockReader {
 			return NewSelectedSeriesHead(h, mint, maxt, staleSeriesRefs)
 		},
-		func(maxt int64, appendIDWatermark uint64) error {
-			return db.head.truncateStaleSeries(staleSeriesRefs.sortedByRef, maxt, appendIDWatermark)
+		func(maxt int64, appendIDWatermark, appendSeqWatermark uint64) error {
+			return db.head.truncateStaleSeries(staleSeriesRefs.sortedByRef, maxt, appendIDWatermark, appendSeqWatermark)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetStaleSeries() },
 	); err != nil {
@@ -1976,8 +1985,8 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 		func(h *Head, mint, maxt int64) BlockReader {
 			return NewSelectedSeriesHead(h, mint, maxt, selectedSeriesRefs)
 		},
-		func(maxt int64, appendIDWatermark uint64) error {
-			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, appendIDWatermark)
+		func(maxt int64, appendIDWatermark, appendSeqWatermark uint64) error {
+			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, appendIDWatermark, appendSeqWatermark)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetSelectedSeries() },
 	); err != nil {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -10622,6 +10622,188 @@ func TestCompactSelectedSeries(t *testing.T) {
 	require.Equal(t, float64(0), prom_testutil.ToFloat64(db.metrics.selectedSeriesCompactionsFailed))
 }
 
+func TestCompactHeadView_ConcurrentCommitSurvivesRestart(t *testing.T) {
+	for _, compact := range []string{"selected", "stale"} {
+		for _, v2 := range []bool{false, true} {
+			for _, kind := range []string{"float", "histogram", "float_histogram"} {
+				t.Run(fmt.Sprintf("%s/v2=%t/%s", compact, v2, kind), func(t *testing.T) {
+					opts := DefaultOptions()
+					opts.MinBlockDuration, opts.MaxBlockDuration = 1000, 1000
+					db := newTestDB(t, withOpts(opts))
+					db.DisableCompactions()
+					t.Cleanup(func() {
+						compactHeadViewBeforeEvictTestingCallback = nil
+						require.NoError(t, db.Close())
+					})
+
+					// Keep the late sample in order but below the compaction's max time.
+					filler := labels.FromStrings("name", "filler")
+					app := db.Appender(context.Background())
+					_, err := app.Append(0, filler, 100, 1)
+					require.NoError(t, err)
+					_, err = app.Append(0, filler, 700, 7)
+					require.NoError(t, err)
+					require.NoError(t, app.Commit())
+
+					lset := labels.FromStrings("name", "compacted")
+					appendSample := func(ts int64) storage.SeriesRef {
+						v := float64(ts)
+						h := &histogram.Histogram{CounterResetHint: histogram.GaugeType, Schema: 0, ZeroThreshold: 0.001, Count: 1, ZeroCount: 1}
+						if compact == "stale" {
+							// Remain stale after the late commit, so staleness alone cannot prevent eviction.
+							v = math.Float64frombits(value.StaleNaN)
+							h = &histogram.Histogram{Sum: v}
+						}
+						var fh *histogram.FloatHistogram
+						switch kind {
+						case "float":
+							h = nil
+						case "float_histogram":
+							fh, h = h.ToFloat(nil), nil
+						}
+						if v2 {
+							app := db.AppenderV2(context.Background())
+							ref, err := app.Append(0, lset, 0, ts, v, h, fh, storage.AOptions{})
+							require.NoError(t, err)
+							require.NoError(t, app.Commit())
+							return ref
+						}
+						app := db.Appender(context.Background())
+						var ref storage.SeriesRef
+						var err error
+						if kind == "float" {
+							ref, err = app.Append(0, lset, ts, v)
+						} else {
+							ref, err = app.AppendHistogram(0, lset, ts, h, fh)
+						}
+						require.NoError(t, err)
+						require.NoError(t, app.Commit())
+						return ref
+					}
+
+					ref := appendSample(300)
+					compactHeadViewBeforeEvictTestingCallback = func() {
+						appendSample(400)
+					}
+					if compact == "selected" {
+						require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{ref}))
+					} else {
+						require.NoError(t, db.CompactStaleHead())
+					}
+
+					check := func() {
+						q, err := db.Querier(0, 1000)
+						require.NoError(t, err)
+						got := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "compacted"))
+						var timestamps []int64
+						for _, s := range got[lset.String()] {
+							timestamps = append(timestamps, s.T())
+						}
+						require.Equal(t, []int64{300, 400}, timestamps)
+					}
+					check()
+					require.NoError(t, db.Close())
+					db, err = Open(db.Dir(), nil, nil, opts, nil)
+					require.NoError(t, err)
+					db.DisableCompactions()
+					check()
+				})
+			}
+		}
+	}
+}
+
+func TestCompactSelectedSeries_CommitsRacingCompactionNotLost(t *testing.T) {
+	for _, isolationDisabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("isolation disabled=%t", isolationDisabled), func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.MinBlockDuration = 1000
+			opts.MaxBlockDuration = 1000
+			opts.IsolationDisabled = isolationDisabled
+			db := newTestDB(t, withOpts(opts))
+			db.DisableCompactions()
+			t.Cleanup(func() {
+				compactHeadViewBeforeEvictTestingCallback = nil
+				require.NoError(t, db.Close())
+			})
+
+			filler := labels.FromStrings("name", "filler")
+			sel := labels.FromStrings("name", "selected")
+
+			app := db.Appender(context.Background())
+			_, err := app.Append(0, filler, 700, 0.7)
+			require.NoError(t, err)
+			selRef, err := app.Append(0, sel, 200, 2.0)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			// The writer commits one in-order sample per iteration, racing the
+			// compaction. Timestamps stay below the head max time (700) so the
+			// series-maxTime guard never protects them.
+			const maxTS = 690
+			var (
+				committed atomic.Int64 // highest successfully committed timestamp
+				writerErr error
+				stop      = make(chan struct{})
+				done      = make(chan struct{})
+			)
+			committed.Store(200)
+			go func() {
+				defer close(done)
+				for ts := int64(201); ts <= maxTS; ts++ {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					app := db.Appender(context.Background())
+					if _, err := app.Append(0, sel, ts, float64(ts)); err != nil {
+						writerErr = fmt.Errorf("append ts=%d: %w", ts, err)
+						_ = app.Rollback()
+						return
+					}
+					if err := app.Commit(); err != nil {
+						writerErr = fmt.Errorf("commit ts=%d: %w", ts, err)
+						return
+					}
+					committed.Store(ts)
+				}
+			}()
+
+			// Hold the window between block write and eviction open until several
+			// commits have landed inside it (bounded so the test cannot hang if the
+			// writer finishes early).
+			compactHeadViewBeforeEvictTestingCallback = func() {
+				target := committed.Load() + 5
+				for committed.Load() < target && committed.Load() < maxTS {
+					select {
+					case <-done:
+						return
+					default:
+						runtime.Gosched()
+					}
+				}
+			}
+
+			require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{selRef}))
+			close(stop)
+			<-done
+			require.NoError(t, writerErr)
+
+			q, err := db.Querier(math.MinInt64, math.MaxInt64)
+			require.NoError(t, err)
+			res := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "selected"))
+			present := map[int64]bool{}
+			for _, s := range res[sel.String()] {
+				present[s.T()] = true
+			}
+			for ts := int64(200); ts <= committed.Load(); ts++ {
+				require.True(t, present[ts], "committed sample ts=%d must not be lost", ts)
+			}
+		})
+	}
+}
+
 // TestCompactSelectedSeries_UnsortedDuplicateRefs verifies that CompactSelectedSeries
 // tolerates an input slice that is unsorted and contains duplicate refs:
 //   - The postings list backing the selected-series view must observe sorted, unique refs,
@@ -10943,35 +11125,19 @@ func TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart(t *test
 
 	require.Len(t, db.Blocks(), 1)
 
-	// The watermark guard only fires when isolation is enabled, because it
-	// relies on per-sample append-IDs that s.txs only tracks in that mode.
-	//   - isolation enabled: hasAppendIDAbove catches the post-watermark
-	//     commit, sel survives eviction, and all three samples are queryable.
-	//   - isolation disabled: per-sample append-IDs aren't tracked, the guard
-	//     is a no-op, sel gets evicted along with the late sample, and the
-	//     WAL tombstone drops the late sample permanently on replay. Only the
-	//     two samples the block captured remain queryable.
-	var (
-		expectedHeadSeries uint64
-		expectedSamples    []chunks.Sample
-	)
-	if defaultIsolationDisabled {
-		expectedHeadSeries = 1 // only filler remains; sel was evicted
-		expectedSamples = []chunks.Sample{
-			sample{t: 100, f: 10.0},
-			sample{t: 200, f: 20.0},
-		}
-	} else {
-		expectedHeadSeries = 2 // filler + sel
-		expectedSamples = []chunks.Sample{
-			sample{t: 100, f: 10.0},
-			sample{t: 200, f: 20.0},
-			sample{t: lateT, f: lateV},
-		}
+	// The late commit lands after the watermark capture, so the eviction skips sel in
+	// both isolation modes: with isolation enabled hasAppendIDAbove catches it, and with
+	// isolation disabled the appendSeq stamp does. Sel survives eviction and all three
+	// samples stay queryable.
+	expectedHeadSeries := uint64(2) // filler + sel
+	expectedSamples := []chunks.Sample{
+		sample{t: 100, f: 10.0},
+		sample{t: 200, f: 20.0},
+		sample{t: lateT, f: lateV},
 	}
 
 	require.Equal(t, expectedHeadSeries, db.Head().NumSeries(),
-		"head series count must match the expected watermark-guard outcome for this isolation mode")
+		"a series appended to during the compaction must be skipped by the eviction")
 
 	querySelected := func(d *DB) []chunks.Sample {
 		q, err := d.Querier(0, chunkRange)
@@ -11006,10 +11172,6 @@ func TestCompactSelectedSeries_LateAppendDuringCompactionSurvivesRestart(t *test
 // The test verifies that the sample remains queryable both immediately after
 // compaction and after a restart.
 func TestCompactSelectedSeries_OpenAppenderCommittingDuringCompaction(t *testing.T) {
-	if defaultIsolationDisabled {
-		t.Skip("watermark guard relies on per-sample append-IDs that s.txs only tracks when isolation is enabled")
-	}
-
 	const chunkRange = 1000
 	opts := DefaultOptions()
 	opts.MinBlockDuration = chunkRange

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -130,6 +130,12 @@ type Head struct {
 
 	iso *isolation
 
+	// Commits hold commitBarrier for reading while assigning appendSeq and applying
+	// samples. Compaction takes it for writing to capture a watermark after all
+	// preceding commits have applied their samples, even with isolation disabled.
+	commitBarrier sync.RWMutex
+	appendSeq     atomic.Uint64
+
 	oooIso *oooIsolation
 
 	cardinalityMutex      sync.Mutex
@@ -1338,9 +1344,10 @@ func isStaleSeries(s *memSeries) bool {
 // appendIDWatermark is the lastAppendID captured before the upstream block write. Series that
 // have received samples with greater appendIDs are skipped, because those samples may not be
 // present in the generated block.
-func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64) error {
+// appendSeqWatermark provides the same protection when isolation is disabled.
+func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark, appendSeqWatermark uint64) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !hasAppendIDAbove(s, appendIDWatermark)
+		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !hasAppendIDAbove(s, appendIDWatermark) && s.lastAppendSeq <= appendSeqWatermark
 	})
 	return err
 }
@@ -1351,18 +1358,18 @@ func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, a
 // appendIDWatermark is the lastAppendID captured before the upstream block write. Series that
 // have received samples with greater appendIDs are skipped, because those samples may not be
 // present in the generated block.
-func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64) error {
+// appendSeqWatermark provides the same protection when isolation is disabled.
+func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark, appendSeqWatermark uint64) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && !hasAppendIDAbove(s, appendIDWatermark)
+		return isSeriesWithoutOOO(s) && !hasAppendIDAbove(s, appendIDWatermark) && s.lastAppendSeq <= appendSeqWatermark
 	})
 	return err
 }
 
 // hasAppendIDAbove reports whether s contains any in-memory sample with an appendID
 // greater than watermark.
-// When isolation is disabled (s.txs == nil), it always returns false;  in that mode,
-// CompactSelectedSeries and CompactStaleHead rely on their existing requirement that
-// no concurrent writes target the affected series.
+// When isolation is disabled (s.txs == nil), it always returns false;
+// selected- and stale-series eviction use lastAppendSeq instead.
 // Must be called with s.Lock held.
 func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
 	if s.txs == nil {
@@ -2783,6 +2790,8 @@ type memSeries struct {
 	mmMaxTime int64 // Max time of any mmapped chunk, only used during WAL replay.
 
 	nextAt int64 // Timestamp at which to cut the next chunk.
+	// Commit sequence of the last sample application, protected by the series lock.
+	lastAppendSeq uint64
 	// The state packs the pending-sample count and infrequent flags to avoid increasing memSeries size.
 	state uint32
 	// headChunkCount tracks the number of head chunks. All mutations of the

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -426,6 +426,7 @@ type headAppenderBase struct {
 	typesInBatch map[chunks.HeadSeriesRef]sampleType // Which (one) sample type each series holds in the most recent batch.
 
 	appendID, cleanupAppendIDsBelow uint64
+	appendSeq                       uint64 // Commit sequence assigned under Head.commitBarrier.
 	closed                          bool
 	storeST                         bool // Whether start-timestamp storage is enabled for this append.
 	useXOR2                         bool // Whether XOR2 encoding is used for float chunks in this append.
@@ -1520,6 +1521,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
+		series.lastAppendSeq = a.appendSeq
 		a.releasePendingCommit(series)
 		series.Unlock()
 	}
@@ -1622,6 +1624,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
+		series.lastAppendSeq = a.appendSeq
 		a.releasePendingCommit(series)
 		series.Unlock()
 	}
@@ -1724,6 +1727,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
+		series.lastAppendSeq = a.appendSeq
 		a.releasePendingCommit(series)
 		series.Unlock()
 	}
@@ -1827,6 +1831,10 @@ func (a *headAppenderBase) Commit() (err error) {
 		}
 	}()
 
+	// No commit may span the compaction watermark capture: its samples must all
+	// be applied before the capture or stamped above the watermark.
+	h.commitBarrier.RLock()
+	a.appendSeq = h.appendSeq.Add(1)
 	for _, b := range a.batches {
 		// Do not change the order of these calls. We depend on it for
 		// correct commit order of samples and for the staleness marker
@@ -1838,6 +1846,7 @@ func (a *headAppenderBase) Commit() (err error) {
 	}
 	// Release the reservations that protected newly indexed series before their first sample was queued.
 	a.releaseCreatedSeriesReservations()
+	h.commitBarrier.RUnlock()
 
 	h.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatOOORejected))
 	h.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histoOOORejected))

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1020,7 +1020,7 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 
 	// Truncate stale series: removes ref1 from the head and writes a
 	// [MinInt64, MaxInt64] tombstone record to the WAL.
-	require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, 3500, math.MaxUint64))
+	require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, 3500, math.MaxUint64, math.MaxUint64))
 
 	// Append a single sample with the same labels to create ref2.
 	// Ref2 has 0 m-mapped chunks, fewer than ref1's 3.
@@ -8360,7 +8360,7 @@ func TestHead_NumStaleSeries_MixedTypeRemoval(t *testing.T) {
 		{
 			name: "truncate_stale_series",
 			remove: func(t *testing.T, head *Head, refs []storage.SeriesRef) {
-				require.NoError(t, head.truncateStaleSeries(refs, 1000, math.MaxUint64))
+				require.NoError(t, head.truncateStaleSeries(refs, 1000, math.MaxUint64, math.MaxUint64))
 			},
 			wantSeries:        2, // Only the genuinely stale series is evicted.
 			crossTypeSurvives: true,
@@ -8807,7 +8807,7 @@ func TestHead_NumNativeHistogramSeriesAndBuckets(t *testing.T) {
 
 						series := testHead.series.getByHash(lbls.Hash(), lbls)
 						require.NotNil(t, series)
-						require.NoError(t, testHead.truncateStaleSeries([]storage.SeriesRef{storage.SeriesRef(series.ref)}, 100, math.MaxUint64))
+						require.NoError(t, testHead.truncateStaleSeries([]storage.SeriesRef{storage.SeriesRef(series.ref)}, 100, math.MaxUint64, math.MaxUint64))
 						require.Zero(t, testHead.NumSeries())
 						require.Zero(t, testHead.NumStaleSeries())
 						require.Zero(t, testHead.NumNativeHistogramSeries())
@@ -9865,7 +9865,7 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 		require.NotNil(t, ms)
 		staleRefs = append(staleRefs, storage.SeriesRef(ms.ref))
 	}
-	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64))
+	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64, math.MaxUint64))
 	require.Equal(t, uint64(0), head.NumStaleSeries())
 	require.Equal(t, uint64(0), head.NumSeries())
 
@@ -10701,7 +10701,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 
 		// Use truncateStaleSeries which calls gcStaleSeries internally.
 		require.NoError(t, h.truncateStaleSeries(
-			[]storage.SeriesRef{storage.SeriesRef(sB.ref)}, ts, math.MaxUint64,
+			[]storage.SeriesRef{storage.SeriesRef(sB.ref)}, ts, math.MaxUint64, math.MaxUint64,
 		))
 		requireCounterConsistent("after truncateStaleSeries")
 		require.Less(t, mmapReadyCounter(), readyBefore,


### PR DESCRIPTION
Observed this problem in Mimir.

Selected/stale-series compaction can lose a sample committed after its block snapshot but before head eviction. The pending-sample counter no longer protects the series once that commit finishes, and the append-ID guard is ineffective with isolation disabled. If the sample timestamp is at or below the compaction cutoff, eviction removes it; the WAL tombstone also prevents an ingester restart from restoring it.

Capture a commit-sequence watermark under a brief exclusive barrier before writing blocks. Commits hold the barrier for reading while applying samples and stamp each affected series. Eviction retains series stamped above the watermark. This reuses the existing pending-sample tracking.

Regression coverage includes selected and stale compaction, both appender APIs, float and histogram samples, concurrent commits, and WAL restart recovery. All 12 deterministic cases reproduce the loss on current main with isolation disabled.

Validation: `go test ./tsdb/...`, the full `./tsdb` suite with isolation disabled, targeted `-race` tests in both modes, and `make lint pkgs='./tsdb/...'` pass.

Sampled float append/commit benchmarks (V1/V2, 100 series, 1 or 100 samples per append, n=6 on M5 Pro) show no significant timing change and unchanged allocation counts. V1's one-sample case measured +0.45% bytes/op.

```release-notes
[BUGFIX] TSDB: Prevent selected- and stale-series compaction from losing concurrently committed samples when isolation is disabled.
```
