### PR TITLE
httputil: clear handler-set content length before compression

### DIFF
--- a/util/httputil/compression.go
+++ b/util/httputil/compression.go
@@ -38,11 +38,25 @@ type compressedResponseWriter struct {
 
 // Writes HTTP response content data.
 func (c *compressedResponseWriter) Write(p []byte) (int, error) {
+	c.removeContentLength()
 	return c.writer.Write(p)
+}
+
+func (c *compressedResponseWriter) WriteHeader(statusCode int) {
+	c.removeContentLength()
+	c.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (c *compressedResponseWriter) removeContentLength() {
+	switch c.writer.(type) {
+	case *zlib.Writer, *gzip.Writer:
+		c.Header().Del("Content-Length")
+	}
 }
 
 // Closes the compressedResponseWriter and ensures to flush all data before.
 func (c *compressedResponseWriter) Close() {
+	c.removeContentLength()
 	if zlibWriter, ok := c.writer.(*zlib.Writer); ok {
 		zlibWriter.Flush()
 	}
@@ -67,7 +81,6 @@ func newCompressedResponseWriter(writer http.ResponseWriter, req *http.Request) 
 		switch strings.TrimSpace(encoding) {
 		case gzipEncoding:
 			h := writer.Header()
-			h.Del("Content-Length") // avoid stale length after compression
 			h.Set(contentEncodingHeader, gzipEncoding)
 			return &compressedResponseWriter{
 				ResponseWriter: writer,
@@ -75,7 +88,6 @@ func newCompressedResponseWriter(writer http.ResponseWriter, req *http.Request) 
 			}
 		case deflateEncoding:
 			h := writer.Header()
-			h.Del("Content-Length")
 			h.Set(contentEncodingHeader, deflateEncoding)
 			return &compressedResponseWriter{
 				ResponseWriter: writer,

--- a/util/httputil/compression_test.go
+++ b/util/httputil/compression_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -152,4 +153,64 @@ func TestCompressionHandler_Deflate(t *testing.T) {
 	actual := buf.String()
 	expected := "Hello World!"
 	require.Equal(t, expected, actual, "expected response with content")
+}
+
+func TestCompressionHandler_ContentLength(t *testing.T) {
+	for _, encoding := range []string{"", gzipEncoding, deflateEncoding} {
+		for _, tc := range []struct {
+			name   string
+			body   string
+			status int
+		}{
+			{name: "implicit status", body: "Hello World!"},
+			{name: "explicit status", body: "Hello World!", status: http.StatusOK},
+			{name: "empty body"},
+			{name: "no content", status: http.StatusNoContent},
+		} {
+			t.Run(encoding+"/"+tc.name, func(t *testing.T) {
+				srv := httptest.NewServer(CompressionHandler{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Length", strconv.Itoa(len(tc.body)))
+					if tc.status != 0 {
+						w.WriteHeader(tc.status)
+					}
+					if tc.body != "" {
+						w.Write([]byte(tc.body))
+					}
+				})})
+				defer srv.Close()
+
+				req, err := http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+				require.NoError(t, err)
+				req.Header.Set(acceptEncodingHeader, encoding)
+				transport := &http.Transport{DisableCompression: true}
+				defer transport.CloseIdleConnections()
+				client := &http.Client{Transport: transport}
+				resp, err := client.Do(req)
+				require.NoError(t, err)
+				defer resp.Body.Close()
+				if tc.status == http.StatusNoContent {
+					require.Equal(t, http.StatusNoContent, resp.StatusCode)
+					body, err := io.ReadAll(resp.Body)
+					require.NoError(t, err)
+					require.Empty(t, body)
+					return
+				}
+
+				reader := resp.Body
+				switch encoding {
+				case gzipEncoding:
+					reader, err = gzip.NewReader(resp.Body)
+				case deflateEncoding:
+					reader, err = zlib.NewReader(resp.Body)
+				default:
+					require.Equal(t, int64(len(tc.body)), resp.ContentLength)
+				}
+				require.NoError(t, err)
+				defer reader.Close()
+				body, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				require.Equal(t, tc.body, string(body))
+			})
+		}
+	}
 }


### PR DESCRIPTION
CompressionHandler clears `Content-Length` before the wrapped handler runs. If that handler sets the uncompressed length, gzip and deflate responses can still be truncated. Clear the header before committing headers or compressed bytes, including when closing an empty compressed response. Uncompressed responses retain their content length.

Validation: `go test -race ./util/httputil -count=1` and scoped `make lint` passed. Real HTTP-server tests reproduce six failures before the fix and cover explicit and implicit status codes, empty content, uncompressed responses, and HTTP 204.


#### Which issue(s) does the PR fix:

Follow-up to #17466. @aknuds1

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] HTTP: Avoid truncating compressed responses when handlers set Content-Length.
```
