### PR TITLE
docs: fix dead links in the querying docs

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -101,7 +101,7 @@ URL query parameters:
 - `timeout=<duration>`: Evaluation timeout. Optional. Defaults to and
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Doesn't affect scalars or strings but truncates the number of series for matrices and vectors. Optional. 0 means disabled.
-- `lookback_delta=<duration | float>`: Override the [lookback period](#staleness) just for this query in `duration` format or float number of seconds. Optional.
+- `lookback_delta=<duration | float>`: Override the [lookback period](basics.md#staleness) just for this query in `duration` format or float number of seconds. Optional.
 - `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts). Any other non-empty value currently behaves like `true`, but is deprecated, adds a warning to the response, and will be rejected in the next major release. Optional. See [Query statistics](#query-statistics).
 
 The current server time is used if the `time` parameter is omitted.
@@ -175,7 +175,7 @@ URL query parameters:
 - `timeout=<duration>`: Evaluation timeout. Optional. Defaults to and
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Optional. 0 means disabled.
-- `lookback_delta=<duration | float>`: Override the [lookback period](#staleness) just for this query in `duration` format or float number of seconds. Optional.
+- `lookback_delta=<duration | float>`: Override the [lookback period](basics.md#staleness) just for this query in `duration` format or float number of seconds. Optional.
 - `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts). Any other non-empty value currently behaves like `true`, but is deprecated, adds a warning to the response, and will be rejected in the next major release. Optional. See [Query statistics](#query-statistics).
 
 You can URL-encode these parameters directly in the request body by using the `POST` method and

--- a/docs/querying/examples.md
+++ b/docs/querying/examples.md
@@ -16,7 +16,7 @@ Return all time series with the metric `http_requests_total` and the given
     http_requests_total{job="apiserver", handler="/api/comments"}
 
 Return a whole range of time (in this case 5 minutes up to the query time)
-for the same vector, making it a [range vector](../basics/#range-vector-selectors):
+for the same vector, making it a [range vector](./basics.md#range-vector-selectors):
 
     http_requests_total{job="apiserver", handler="/api/comments"}[5m]
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Trivial docs fix (no linked issue).

#### Release notes for end users (**ALL** commits must be considered).
_edit_ by @jan--f (was `[CHANGE] querying: fix dead links in examples.md and api.md.`) this is not a functionality change and does not need to be noted in the release notes.
```release-notes
NONE
```

---

Three dead links in `docs/querying/`:

- `examples.md`: `[range vector](../basics/#range-vector-selectors)` — `docs/basics/` doesn't exist; the target is `querying/basics.md` (same convention the file already uses at line 26). Anchor verified (`### Range Vector Selectors`)
- `api.md` (×2): `[lookback period](#staleness)` — no Staleness heading in api.md; the `### Staleness` section lives in `basics.md`

Trivial docs fix. Signed-off-by per the DCO requirement.