### PR TITLE
scrape: fix 'there'a' typo in reload comment

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -340,7 +340,7 @@ func (m *Manager) Stop() {
 	defer m.mtxScrape.Unlock()
 
 	// Stop pools in parallel as each stop() blocks until all its scrape
-	// loops have exited, which can take a long time if there'a a lot of
+	// loops have exited, which can take a long time if there's a lot of
 	// pools with high number of targets.
 	// Limit the number of pools stopping at once to avoid unbounded goroutines.
 	g := new(errgroup.Group)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Trivial comment fix (no linked issue).

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```

---

`scrape/manager.go`: "which can take a long time if **there'a** a lot of" → "there's a lot of". Comment-only.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>