### PR TITLE
model/labels: do not treat a folded character class as case insensitive

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -213,7 +213,16 @@ func findSetMatchesInternal(re *syntax.Regexp, base string) (matches []string, c
 				matches = append(matches, base+string(c))
 			}
 		}
-		return matches, isCaseSensitive(re)
+		// Unlike a literal, a character class has already had case folding
+		// expanded into its rune set by the parser, which leaves FoldCase behind
+		// as residue: [aA]|B and a|A|B both collapse to the class [ABa], but only
+		// the first still carries the flag. Reading it as "match this set case
+		// insensitively" folds the set a second time, so [aA]|B matched "b".
+		// The set may still be reported as case insensitive when it is closed
+		// under case folding, since folding it again cannot add a member; that is
+		// what lets a class compose with a case insensitive sibling, as the digits
+		// of (?i:(foo1|foo2|bar)) do.
+		return matches, isCaseSensitive(re) || !classIsCaseFoldClosed(re.Rune)
 	default:
 		return nil, false
 	}
@@ -329,6 +338,32 @@ func isCaseInsensitive(reg *syntax.Regexp) bool {
 
 // isCaseSensitive tells if a regexp is case sensitive.
 // The flag should be check at each level of the syntax tree.
+// classIsCaseFoldClosed reports whether every rune in the class is present
+// together with its whole simple-case-folding orbit, so that matching the class
+// case insensitively admits nothing the class does not already contain. The
+// caller has already capped the class at maxSetMatches runes, so this is bounded.
+func classIsCaseFoldClosed(runes []rune) bool {
+	for i := 0; i+1 < len(runes); i += 2 {
+		for r := runes[i]; r <= runes[i+1]; r++ {
+			for f := unicode.SimpleFold(r); f != r; f = unicode.SimpleFold(f) {
+				if !classContainsRune(runes, f) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func classContainsRune(runes []rune, r rune) bool {
+	for i := 0; i+1 < len(runes); i += 2 {
+		if r >= runes[i] && r <= runes[i+1] {
+			return true
+		}
+	}
+	return false
+}
+
 func isCaseSensitive(reg *syntax.Regexp) bool {
 	return !isCaseInsensitive(reg)
 }

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -58,6 +58,11 @@ var (
 		"(?s:.+)",
 		"(?s:^.*foo$)",
 		"(?i:foo)",
+		// A character class keeps FoldCase as residue once the parser has expanded
+		// folding into its rune set, so these must behave like "a|A|B".
+		"[aA]|B",
+		"(?i:a)|B",
+		"a|A|B",
 		"(?i:(foo|bar))",
 		"(?i:(foo1|foo2|bar))",
 		"^(?i:foo|oo)|(bar)$",
@@ -134,6 +139,7 @@ var (
 		"-a-a-a-",
 		"|foo|",
 		"|foo-bar|",
+		"b", "B",
 		"x-ab-y",
 		"x-abc-y",
 
@@ -267,6 +273,11 @@ func TestFindSetMatches(t *testing.T) {
 		// class starting with "-"
 		{"[-1-2][a-c]", []string{"-a", "-b", "-c", "1a", "1b", "1c", "2a", "2b", "2c"}, true},
 		{"[1^3]", []string{"1", "3", "^"}, true},
+		// A character class has already had case folding expanded into its rune
+		// set, so [aA]|B collapses to the class [ABa] and matching it case
+		// insensitively would fold a second time and admit "b".
+		{"[aA]|B", []string{"A", "B", "a"}, true},
+		{"(?i:a)|B", []string{"A", "B", "a"}, true},
 		// OpPlus with concat
 		{"(.+)/(foo|bar)", nil, false},
 		// Simple sets containing special characters without escaping.


### PR DESCRIPTION
`{l=~"[aA]|B"}` matches the series whose label value is `b`.

```
pat="[aA]|B"  op=CharClass  fold=true   str="[ABa]"   MatchString("b") = true   regexp says false
pat="a|A|B"   op=CharClass  fold=false  str="[ABa]"   MatchString("b") = false  correct
```

Two spellings, the byte-identical class `[ABa]`, different answers.

## Cause

The parser expands case folding into a character class's rune set and leaves `syntax.FoldCase` on the node behind as residue. `findSetMatchesInternal`'s `OpCharClass` branch reads that flag through `isCaseSensitive` and folds the set a second time:

```go
	return matches, isCaseSensitive(re)
```

The identical call one branch up, on `OpLiteral`, is correct — `FoldCase` on a literal really does mean "match case insensitively". On a class it means "folding was already applied here", which is not the same thing.

It is a wrong answer rather than a missed optimisation: the set becomes an `equalMultiStringSliceMatcher` with `caseSensitive: false`, and `MatchString` returns its verdict with no fallback to `m.re`. Pure ASCII, no `(?i)` required, no flag or config involved.

The doc comment on `findSetMatches` already states the invariant this breaks:

> Returns nil if we can't replace the regexp by only equality matchers or the regexp contains a mix of case sensitive and case insensitive matchers.

`[aA]|B` is exactly such a mix, and it returns a set anyway.

## Fix

```go
	return matches, isCaseSensitive(re) || !classIsCaseFoldClosed(re.Rune)
```

A class may still be reported as case insensitive when it is closed under simple case folding, because folding a closed set again cannot add a member. That matters: reporting `true` unconditionally would fix the bug but break `(?i:(foo1|foo2|bar))`, where the parser factors out `foo(1|2)` and the inner `[12]` class has to keep agreeing with its case-insensitive sibling. Digits are fold-closed, so it still does.

`classIsCaseFoldClosed` walks each rune's `unicode.SimpleFold` orbit and checks membership. The branch has already capped the class at `maxSetMatches` runes, so it is bounded.

## Scope

Only classes that collapse to single-character alternatives are affected — `(?i:debug)|ERROR` is a concat and is not. `setMatches` stays empty on this path, so the `tsdb/querier.go` postings fast path is not involved; the damage is confined to `MatchString`.

## Tests

`[aA]|B` and `(?i:a)|B` added to `regexes`, and `"b"`/`"B"` to `values`, so the existing differential test in `TestFastRegexMatcher_MatchString` — which compares the fast matcher against `regexp` for every pair — is what catches it. Two rows added to `TestFindSetMatches` pin the `caseSensitive` return directly.

Reverting only `regexp.go` fails exactly four subtests and nothing else:

```
--- FAIL: TestFastRegexMatcher_MatchString/[aA]|B_on_"b"
--- FAIL: TestFastRegexMatcher_MatchString/(?i:a)|B_on_"b"
--- FAIL: TestFindSetMatches/[aA]|B
--- FAIL: TestFindSetMatches/(?i:a)|B
```

With the fix, `go test ./model/labels/` passes and `go vet` is clean.

```release-notes
[BUGFIX] PromQL: Fix label matchers such as `{l=~"[aA]|B"}` matching case insensitively, so `{l=~"[aA]|B"}` no longer matches the value `b`.
```
