### PR TITLE
tsdb: make the append-ID watermark check durable against later cleanup

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1880,7 +1880,7 @@ func (db *DB) CompactStaleHead() (err error) {
 			return NewSelectedSeriesHead(h, mint, maxt, staleSeriesRefs)
 		},
 		func(maxt int64) error {
-			return db.head.truncateStaleSeries(staleSeriesRefs.sortedByRef, maxt, appendIDWatermark, fingerprints)
+			return db.head.truncateStaleSeries(staleSeriesRefs.sortedByRef, maxt, fingerprints)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetStaleSeries() },
 	); err != nil {
@@ -1973,7 +1973,7 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 			return NewSelectedSeriesHead(h, mint, maxt, selectedSeriesRefs)
 		},
 		func(maxt int64) error {
-			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, appendIDWatermark, fingerprints)
+			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, fingerprints)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetSelectedSeries() },
 	); err != nil {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1783,20 +1783,11 @@ type headViewFactory func(head *Head, mint, maxt int64) BlockReader
 //
 // The evictor must preserve any series that may have received samples
 // after compaction began, as those samples might not be present in the
-// generated blocks -- see fingerprintChangedForRef.
+// generated blocks -- see hasMutatedSinceSnapshot.
 //
 // maxt is the head's MaxTime at compaction start and is used to detect
 // obvious late writes via sample timestamps.
-//
-// appendIDWatermark is the head's append-ID counter at compaction
-// start. A series containing samples with appendID >
-// appendIDWatermark must not be evicted, as those samples were appended
-// after compaction began and may not be present in any block.
-//
-// When isolation is disabled, appendIDWatermark is always 0 and the
-// append-ID check becomes a no-op. In that mode, the caller must ensure
-// that no concurrent writes target the selected series.
-type headSeriesEvictor func(maxt int64, appendIDWatermark uint64) error
+type headSeriesEvictor func(maxt int64) error
 
 // compactHeadViewLocked writes a block (or sequence of blocks, one per chunk range) for the
 // restricted head view produced by viewFactory, then runs evictor to remove those series from the
@@ -1806,22 +1797,6 @@ type headSeriesEvictor func(maxt int64, appendIDWatermark uint64) error
 // The caller must hold db.cmtx.
 func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSeriesEvictor, configure func(*BlockMeta)) error {
 	mint, maxt := db.head.opts.ChunkRange*(db.head.MinTime()/db.head.opts.ChunkRange), db.head.MaxTime()
-	// Capture the highest guaranteed-committed appendID as an eviction watermark
-	// before writing any blocks.
-	//
-	// Samples with appendID <= watermark are guaranteed to be present in some
-	// generated block. Samples with higher IDs may or may not be present,
-	// depending on block-writer snapshot timing.
-	//
-	// The watermark is used during eviction: a series is removed only if it has
-	// not received any samples with appendID > watermark since compaction began.
-	//
-	// We use committedAppendID instead of lastAppendID because open appenders are
-	// excluded from all block snapshots via incompleteAppends. If one of those
-	// appenders commits between the write and evict phases, using lastAppendID
-	// could evict a series whose newest sample is present in neither the block nor
-	// the head, causing that sample to be lost on WAL replay.
-	appendIDWatermark := db.head.iso.committedAppendID()
 	// The bound is inclusive so that a sample sitting exactly on a chunk-range boundary
 	// (mint == maxt) still gets a block written before its series is evicted.
 	for ; mint <= maxt; mint += db.head.chunkRange.Load() {
@@ -1861,7 +1836,7 @@ func (db *DB) compactHeadViewLocked(viewFactory headViewFactory, evict headSerie
 		compactHeadViewBeforeEvictTestingCallback = nil
 	}
 
-	if err := evict(maxt, appendIDWatermark); err != nil {
+	if err := evict(maxt); err != nil {
 		return fmt.Errorf("head truncate: %w", err)
 	}
 	db.head.RebuildSymbolTable(db.logger)
@@ -1890,16 +1865,21 @@ func (db *DB) CompactStaleHead() (err error) {
 		return err
 	}
 
+	// Capture the append-ID watermark before anything else, so the immediate per-series check
+	// inside snapshotFingerprints below sees it before any block write -- or any unrelated
+	// commit's append-ID cleanup -- has a chance to run. See seriesFingerprint.
+	appendIDWatermark := db.head.iso.committedAppendID()
+
 	// Snapshot each stale series' in-memory shape before writing any blocks. The eviction
 	// check below compares against this snapshot to catch a sample -- stale or not -- that
 	// arrived for the series after this point, independently of whether isolation is enabled.
-	fingerprints := db.head.snapshotFingerprints(staleSeriesRefs.sortedByRef)
+	fingerprints := db.head.snapshotFingerprints(staleSeriesRefs.sortedByRef, appendIDWatermark)
 
 	if err := db.compactHeadViewLocked(
 		func(h *Head, mint, maxt int64) BlockReader {
 			return NewSelectedSeriesHead(h, mint, maxt, staleSeriesRefs)
 		},
-		func(maxt int64, appendIDWatermark uint64) error {
+		func(maxt int64) error {
 			return db.head.truncateStaleSeries(staleSeriesRefs.sortedByRef, maxt, appendIDWatermark, fingerprints)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetStaleSeries() },
@@ -1978,16 +1958,21 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 		return nil
 	}
 
+	// Capture the append-ID watermark before anything else, so the immediate per-series check
+	// inside snapshotFingerprints below sees it before any block write -- or any unrelated
+	// commit's append-ID cleanup -- has a chance to run. See seriesFingerprint.
+	appendIDWatermark := db.head.iso.committedAppendID()
+
 	// Snapshot each selected series' in-memory shape before writing any blocks. The eviction
 	// check below compares against this snapshot to catch a sample that arrived for the series
 	// after this point, independently of whether isolation is enabled.
-	fingerprints := db.head.snapshotFingerprints(selectedSeriesRefs.sortedByRef)
+	fingerprints := db.head.snapshotFingerprints(selectedSeriesRefs.sortedByRef, appendIDWatermark)
 
 	if err := db.compactHeadViewLocked(
 		func(h *Head, mint, maxt int64) BlockReader {
 			return NewSelectedSeriesHead(h, mint, maxt, selectedSeriesRefs)
 		},
-		func(maxt int64, appendIDWatermark uint64) error {
+		func(maxt int64) error {
 			return db.head.truncateSelectedSeries(selectedSeriesRefs.sortedByRef, maxt, appendIDWatermark, fingerprints)
 		},
 		func(meta *BlockMeta) { meta.Compaction.SetSelectedSeries() },

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -12054,7 +12054,8 @@ func TestCompactionSurvivesChunkRollAndMmap(t *testing.T) {
 // A multi-series Commit() writes each series in turn and only closes the whole transaction at
 // the end. This test pauses Commit() right after it writes the selected series but before it
 // can close the transaction, so the fingerprint snapshot already reflects the new sample and
-// can never see it change. Only appendIDWatermark (via hasAppendIDAbove) catches this case.
+// can never see it change. Only the durable watermarkViolatedAtSnapshot flag, captured via
+// hasAppendIDAbove at snapshot time, catches this case.
 func TestCompactSelectedSeries_SurvivesMutationFromStillOpenTransaction(t *testing.T) {
 	if defaultIsolationDisabled {
 		t.Skip("This reproduction needs isolation to exclude the incomplete appender.")
@@ -12174,4 +12175,73 @@ func TestCompactSelectedSeries_SurvivesEvidenceErasedByUnrelatedCleanup(t *testi
 	require.NoError(t, err)
 	got := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "selected"))
 	require.Len(t, got[`{name="selected"}`], 2, "The sample at 400 must survive compaction.")
+}
+
+// TestCompactionSurvivesLateAppendWithErasedWatermarkEvidence verifies that a sample appended
+// after the fingerprint snapshot survives compaction even when a later, unrelated duplicate
+// write erases the only watermark evidence that it happened.
+//
+// The append itself is real, not a duplicate, so it mutates the chunk -- the fingerprint alone
+// would already catch that. What this test adds is the duplicate that follows: it changes no
+// data, but its Commit() still runs routine append-ID cleanup, which wipes out the append-ID
+// that would have proven the earlier sample wasn't committed yet. Nothing is lost, because the
+// fingerprint never depended on that append-ID in the first place -- it's comparing chunk
+// shape, which the cleanup can't touch.
+func TestCompactionSurvivesLateAppendWithErasedWatermarkEvidence(t *testing.T) {
+	for _, stale := range []bool{false, true} {
+		name := "selected"
+		if stale {
+			name = "stale"
+		}
+		t.Run(name, func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.MinBlockDuration = 1000
+			opts.MaxBlockDuration = 1000
+			db := newTestDB(t, withOpts(opts))
+			db.DisableCompactions()
+			sel := labels.FromStrings("name", "selected")
+			v := 2.0
+			if stale {
+				v = math.Float64frombits(value.StaleNaN)
+			}
+			app := db.Appender(t.Context())
+			ref, err := app.Append(0, sel, 100, 1)
+			require.NoError(t, err)
+			_, err = app.Append(ref, sel, 200, v)
+			require.NoError(t, err)
+			_, err = app.Append(0, labels.FromStrings("name", "filler"), 700, 1)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			compactHeadViewBeforeEvictTestingCallback = func() {
+				// Both transactions start after the snapshot and block generation.
+				for range 2 {
+					app := db.Appender(t.Context())
+					_, err := app.Append(ref, sel, 400, v)
+					require.NoError(t, err)
+					require.NoError(t, app.Commit())
+				}
+			}
+			t.Cleanup(func() { compactHeadViewBeforeEvictTestingCallback = nil })
+			if stale {
+				require.NoError(t, db.CompactStaleHead())
+			} else {
+				require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{ref}))
+			}
+			q, err := db.Querier(0, 1000)
+			require.NoError(t, err)
+			got := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "selected"))
+			if len(got[sel.String()]) != 3 {
+				t.Errorf("Before restart: want 3 samples, got %v", got[sel.String()])
+			}
+			require.NoError(t, db.Close())
+			db, err = Open(db.Dir(), nil, nil, opts, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			q, err = db.Querier(0, 1000)
+			require.NoError(t, err)
+			got = query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "selected"))
+			require.Len(t, got[sel.String()], 3, "The sample at 400 must survive restart.")
+		})
+	}
 }

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -12022,7 +12022,7 @@ func TestCompactionSurvivesChunkRollAndMmap(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, app.Commit())
 			refs := []storage.SeriesRef{ref}
-			before := db.head.snapshotFingerprints(refs)
+			before := db.head.snapshotFingerprints(refs, math.MaxUint64)
 			compactHeadViewBeforeEvictTestingCallback = func() {
 				app := db.Appender(context.Background())
 				_, err := app.Append(ref, sel, 1000, v)
@@ -12031,7 +12031,7 @@ func TestCompactionSurvivesChunkRollAndMmap(t *testing.T) {
 				db.ForceHeadMMap()
 				// The chunk roll and mmap alone must not make the fingerprint look unchanged --
 				// otherwise the eviction check below would wrongly trust it.
-				require.NotEqual(t, before, db.head.snapshotFingerprints(refs), "the fingerprint must reflect the append across a chunk roll and mmap")
+				require.NotEqual(t, before, db.head.snapshotFingerprints(refs, math.MaxUint64), "the fingerprint must reflect the append across a chunk roll and mmap")
 			}
 			t.Cleanup(func() { compactHeadViewBeforeEvictTestingCallback = nil })
 			if stale {
@@ -12096,6 +12096,77 @@ func TestCompactSelectedSeries_SurvivesMutationFromStillOpenTransaction(t *testi
 	compactHeadViewBeforeEvictTestingCallback = func() {
 		unlock()
 		require.NoError(t, <-done)
+	}
+	t.Cleanup(func() { compactHeadViewBeforeEvictTestingCallback = nil })
+	require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{ref}))
+	q, err := db.Querier(0, 1000)
+	require.NoError(t, err)
+	got := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "selected"))
+	require.Len(t, got[`{name="selected"}`], 2, "The sample at 400 must survive compaction.")
+}
+
+// TestCompactSelectedSeries_SurvivesEvidenceErasedByUnrelatedCleanup verifies that a sample
+// survives compaction even when the one piece of evidence that would have proven it's missing
+// from the block gets erased before the eviction check ever looks at it.
+//
+// The sequence: a transaction writes the sample, then closes. Afterward, a totally unrelated
+// write lands on the same series -- an exact duplicate that changes no data -- but even that
+// no-op write triggers routine append-ID cleanup, which happens to wipe out the record of the
+// original write ever happening. If that record were the only evidence, eviction would see
+// nothing wrong and delete the series. It doesn't, because the violation was already recorded
+// as a durable fact the moment it was first seen (see seriesFingerprint.watermarkViolatedAtSnapshot),
+// so later cleanup can't erase it.
+func TestCompactSelectedSeries_SurvivesEvidenceErasedByUnrelatedCleanup(t *testing.T) {
+	if defaultIsolationDisabled {
+		t.Skip("This reproduction needs isolation to exclude the incomplete appender.")
+	}
+	opts := DefaultOptions()
+	opts.MinBlockDuration = 1000
+	opts.MaxBlockDuration = 1000
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+	sel := labels.FromStrings("name", "selected")
+	filler := labels.FromStrings("name", "filler")
+	app := db.Appender(context.Background())
+	ref, err := app.Append(0, sel, 100, 1)
+	require.NoError(t, err)
+	fillerRef, err := app.Append(0, filler, 700, 1)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+	app = db.Appender(context.Background())
+	_, err = app.Append(ref, sel, 400, 2)
+	require.NoError(t, err)
+	_, err = app.Append(fillerRef, filler, 700, 1)
+	require.NoError(t, err)
+
+	// Pause Commit on its second series after it mutates the selected series.
+	blocker := db.head.series.getByID(chunks.HeadSeriesRef(fillerRef))
+	blocker.Lock()
+	var unlockOnce sync.Once
+	unlock := func() { unlockOnce.Do(blocker.Unlock) }
+	defer unlock()
+	done := make(chan error, 1)
+	go func() { done <- app.Commit() }()
+	series := db.head.series.getByID(chunks.HeadSeriesRef(ref))
+	require.Eventually(t, func() bool {
+		series.Lock()
+		defer series.Unlock()
+		return series.maxTime() == 400 && !series.hasPendingCommit()
+	}, 5*time.Second, time.Millisecond)
+
+	compactHeadViewBeforeEvictTestingCallback = func() {
+		unlock()
+		require.NoError(t, <-done)
+		// A duplicate sample changes no chunks but runs append-ID cleanup.
+		cleanup := db.Appender(context.Background())
+		_, err := cleanup.Append(ref, sel, 400, 2)
+		require.NoError(t, err)
+		require.NoError(t, cleanup.Commit())
+		series.Lock()
+		if series.txs != nil {
+			require.Zero(t, series.txs.txIDCount)
+		}
+		series.Unlock()
 	}
 	t.Cleanup(func() { compactHeadViewBeforeEvictTestingCallback = nil })
 	require.NoError(t, db.CompactSelectedSeries([]storage.SeriesRef{ref}))

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1334,40 +1334,30 @@ func isStaleSeries(s *memSeries) bool {
 }
 
 // truncateStaleSeries removes the provided series as long as they're still stale and carry no
-// out-of-order data -- both checked live, not from a stale snapshot.
-//
-// Two independent guards protect a series that changed after it was selected: fingerprints
-// (see fingerprintChangedForRef) catches a new sample already visible in the chunk, including
-// a fresh stale marker that isStaleSeries alone wouldn't flag; appendIDWatermark (see
-// hasAppendIDAbove) catches one from a transaction still open when it was captured, even if
-// that transaction had already mutated the chunk before the fingerprint was ever snapshotted.
+// out-of-order data -- both checked live, not from a stale snapshot. hasMutatedSinceSnapshot
+// protects a series that changed after it was selected, including a fresh stale marker that
+// isStaleSeries alone wouldn't flag.
 func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !hasAppendIDAbove(s, appendIDWatermark) && !fingerprintChangedForRef(s, fingerprints)
+		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !hasMutatedSinceSnapshot(s, appendIDWatermark, fingerprints)
 	})
 	return err
 }
 
 // truncateSelectedSeries removes the series identified by the provided refs from the head. OOO
 // data must first be flushed by CompactOOOHead before a series can be evicted; isSeriesWithoutOOO
-// checks that live, not from a stale snapshot.
-//
-// Two independent guards protect a series that changed after its ref was collected: fingerprints
-// (see fingerprintChangedForRef) catches a new sample already visible in the chunk;
-// appendIDWatermark (see hasAppendIDAbove) catches one from a transaction still open when it was
-// captured, even if that transaction had already mutated the chunk before the fingerprint was
-// ever snapshotted.
+// checks that live, not from a stale snapshot. hasMutatedSinceSnapshot protects a series that
+// changed after its ref was collected.
 func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && !hasAppendIDAbove(s, appendIDWatermark) && !fingerprintChangedForRef(s, fingerprints)
+		return isSeriesWithoutOOO(s) && !hasMutatedSinceSnapshot(s, appendIDWatermark, fingerprints)
 	})
 	return err
 }
 
 // hasAppendIDAbove reports whether s contains any in-memory sample with an appendID greater
 // than watermark. When isolation is disabled (s.txs == nil), it always returns false: in that
-// mode there is no per-sample append-ID tracking to consult, and fingerprintChangedForRef is
-// the sole guard.
+// mode there is no per-sample append-ID tracking to consult.
 // Must be called with s.Lock held.
 func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
 	if s.txs == nil {
@@ -1402,14 +1392,16 @@ func hasAppendIDAbove(s *memSeries, watermark uint64) bool {
 // time, so a series that turns OOO after being selected is already caught there, for free.
 // Likewise, no field tracks staleness: isStaleSeries is re-evaluated live too.
 //
-// What this snapshot cannot see: a mutation that already happened by the time it's taken. A
-// multi-series Commit() applies each series' samples one at a time and only closes its
-// isolation transaction at the very end, so a sample can already be sitting in a chunk here
-// while still excluded from the block the writer is about to produce. hasAppendIDAbove, kept
-// alongside this fingerprint, is what catches that case when isolation is enabled.
+// watermarkViolatedAtSnapshot records whether, at snapshot time, this series already held a
+// sample from a transaction that hadn't closed yet -- meaning that sample wasn't guaranteed to
+// be in the block about to be written. Chunk shape alone can't see this, since the chunk looks
+// the same either way. It has to be captured now, not re-checked later: an unrelated commit
+// touching this series afterward can erase that exact evidence during its own routine cleanup,
+// even though the sample it proved missing is still missing.
 type seriesFingerprint struct {
-	currentChunkID   chunks.HeadChunkID
-	lastChunkSamples int
+	currentChunkID              chunks.HeadChunkID
+	lastChunkSamples            int
+	watermarkViolatedAtSnapshot bool
 }
 
 // currentChunkID returns the HeadChunkID of s's active (most recently created) chunk -- the
@@ -1423,10 +1415,12 @@ func currentChunkID(s *memSeries) chunks.HeadChunkID {
 	return s.headChunkID(total - 1)
 }
 
-// snapshotFingerprint captures s's current fingerprint. Must be called with s.Lock held.
-func snapshotFingerprint(s *memSeries) seriesFingerprint {
+// snapshotFingerprint captures s's current fingerprint against appendIDWatermark. Must be
+// called with s.Lock held.
+func snapshotFingerprint(s *memSeries, appendIDWatermark uint64) seriesFingerprint {
 	fp := seriesFingerprint{
-		currentChunkID: currentChunkID(s),
+		currentChunkID:              currentChunkID(s),
+		watermarkViolatedAtSnapshot: hasAppendIDAbove(s, appendIDWatermark),
 	}
 	if s.headChunks != nil {
 		fp.lastChunkSamples = s.headChunks.chunk.NumSamples()
@@ -1447,23 +1441,37 @@ func fingerprintChanged(s *memSeries, fp seriesFingerprint) bool {
 	return lastChunkSamples != fp.lastChunkSamples
 }
 
-// fingerprintChangedForRef looks up s's snapshot in fingerprints and reports whether it has
-// since changed. A missing entry is treated as changed -- retain rather than risk evicting --
+// hasMutatedSinceSnapshot reports whether s has been appended to since appendIDWatermark and
+// fingerprints were captured.
+//
+// fp.watermarkViolatedAtSnapshot is checked first: it's a durable fact recorded the moment the
+// snapshot was taken, immune to s.txs being pruned by an unrelated commit's append-ID cleanup
+// afterward -- see seriesFingerprint. Only if that's clear do we fall back to a live check:
+// hasAppendIDAbove, for a transaction that started after the snapshot, while isolation is
+// enabled; fingerprintChanged otherwise.
+//
+// A missing fingerprint entry is treated as mutated -- retain rather than risk evicting --
 // though every ref CompactSelectedSeries or CompactStaleHead passes through should have one.
 // Must be called with s.Lock held.
-func fingerprintChangedForRef(s *memSeries, fingerprints map[storage.SeriesRef]seriesFingerprint) bool {
+func hasMutatedSinceSnapshot(s *memSeries, appendIDWatermark uint64, fingerprints map[storage.SeriesRef]seriesFingerprint) bool {
 	fp, ok := fingerprints[storage.SeriesRef(s.ref)]
 	if !ok {
 		return true
 	}
+	if fp.watermarkViolatedAtSnapshot {
+		return true
+	}
+	if s.txs != nil {
+		return hasAppendIDAbove(s, appendIDWatermark)
+	}
 	return fingerprintChanged(s, fp)
 }
 
-// snapshotFingerprints captures a seriesFingerprint per ref, before the caller
-// (CompactSelectedSeries or CompactStaleHead) writes any blocks, so the later eviction check
-// can detect -- independently of isolation -- a sample received since this point. Refs that no
-// longer resolve to a live series are omitted.
-func (h *Head) snapshotFingerprints(seriesRefs []storage.SeriesRef) map[storage.SeriesRef]seriesFingerprint {
+// snapshotFingerprints captures a seriesFingerprint per ref against appendIDWatermark, before
+// the caller (CompactSelectedSeries or CompactStaleHead) writes any blocks or lets any other
+// commit run -- see seriesFingerprint. Refs that no longer resolve to a live series are
+// omitted.
+func (h *Head) snapshotFingerprints(seriesRefs []storage.SeriesRef, appendIDWatermark uint64) map[storage.SeriesRef]seriesFingerprint {
 	fingerprints := make(map[storage.SeriesRef]seriesFingerprint, len(seriesRefs))
 	for _, ref := range seriesRefs {
 		s := h.series.getByID(chunks.HeadSeriesRef(ref))
@@ -1471,7 +1479,7 @@ func (h *Head) snapshotFingerprints(seriesRefs []storage.SeriesRef) map[storage.
 			continue
 		}
 		s.Lock()
-		fingerprints[ref] = snapshotFingerprint(s)
+		fingerprints[ref] = snapshotFingerprint(s, appendIDWatermark)
 		s.Unlock()
 	}
 	return fingerprints

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1337,9 +1337,9 @@ func isStaleSeries(s *memSeries) bool {
 // out-of-order data -- both checked live, not from a stale snapshot. hasMutatedSinceSnapshot
 // protects a series that changed after it was selected, including a fresh stale marker that
 // isStaleSeries alone wouldn't flag.
-func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
+func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !hasMutatedSinceSnapshot(s, appendIDWatermark, fingerprints)
+		return isSeriesWithoutOOO(s) && isStaleSeries(s) && !hasMutatedSinceSnapshot(s, fingerprints)
 	})
 	return err
 }
@@ -1348,9 +1348,9 @@ func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64, a
 // data must first be flushed by CompactOOOHead before a series can be evicted; isSeriesWithoutOOO
 // checks that live, not from a stale snapshot. hasMutatedSinceSnapshot protects a series that
 // changed after its ref was collected.
-func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, appendIDWatermark uint64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
+func (h *Head) truncateSelectedSeries(seriesRefs []storage.SeriesRef, maxt int64, fingerprints map[storage.SeriesRef]seriesFingerprint) error {
 	_, err := h.truncateSeries(seriesRefs, maxt, func(s *memSeries) bool {
-		return isSeriesWithoutOOO(s) && !hasMutatedSinceSnapshot(s, appendIDWatermark, fingerprints)
+		return isSeriesWithoutOOO(s) && !hasMutatedSinceSnapshot(s, fingerprints)
 	})
 	return err
 }
@@ -1441,28 +1441,28 @@ func fingerprintChanged(s *memSeries, fp seriesFingerprint) bool {
 	return lastChunkSamples != fp.lastChunkSamples
 }
 
-// hasMutatedSinceSnapshot reports whether s has been appended to since appendIDWatermark and
-// fingerprints were captured.
+// hasMutatedSinceSnapshot reports whether s has been appended to since fingerprints were
+// captured.
 //
 // fp.watermarkViolatedAtSnapshot is checked first: it's a durable fact recorded the moment the
 // snapshot was taken, immune to s.txs being pruned by an unrelated commit's append-ID cleanup
-// afterward -- see seriesFingerprint. Only if that's clear do we fall back to a live check:
-// hasAppendIDAbove, for a transaction that started after the snapshot, while isolation is
-// enabled; fingerprintChanged otherwise.
+// afterward -- see seriesFingerprint. It only catches a transaction that was already open at
+// snapshot time, though, so any append arriving after the snapshot still needs a live check:
+// fingerprintChanged. That's also what any such append would show up as -- a real append always
+// changes the chunk in the same step it would add to s.txs, so there's nothing hasAppendIDAbove
+// could still catch here that fingerprintChanged wouldn't, and unlike s.txs, chunk shape isn't
+// something a later, unrelated commit can prune away.
 //
 // A missing fingerprint entry is treated as mutated -- retain rather than risk evicting --
 // though every ref CompactSelectedSeries or CompactStaleHead passes through should have one.
 // Must be called with s.Lock held.
-func hasMutatedSinceSnapshot(s *memSeries, appendIDWatermark uint64, fingerprints map[storage.SeriesRef]seriesFingerprint) bool {
+func hasMutatedSinceSnapshot(s *memSeries, fingerprints map[storage.SeriesRef]seriesFingerprint) bool {
 	fp, ok := fingerprints[storage.SeriesRef(s.ref)]
 	if !ok {
 		return true
 	}
 	if fp.watermarkViolatedAtSnapshot {
 		return true
-	}
-	if s.txs != nil {
-		return hasAppendIDAbove(s, appendIDWatermark)
 	}
 	return fingerprintChanged(s, fp)
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1021,7 +1021,7 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 	// Truncate stale series: removes ref1 from the head and writes a
 	// [MinInt64, MaxInt64] tombstone record to the WAL.
 	staleRefs := []storage.SeriesRef{ref1}
-	require.NoError(t, head.truncateStaleSeries(staleRefs, 3500, math.MaxUint64, head.snapshotFingerprints(staleRefs, math.MaxUint64)))
+	require.NoError(t, head.truncateStaleSeries(staleRefs, 3500, head.snapshotFingerprints(staleRefs, math.MaxUint64)))
 
 	// Append a single sample with the same labels to create ref2.
 	// Ref2 has 0 m-mapped chunks, fewer than ref1's 3.
@@ -8361,7 +8361,7 @@ func TestHead_NumStaleSeries_MixedTypeRemoval(t *testing.T) {
 		{
 			name: "truncate_stale_series",
 			remove: func(t *testing.T, head *Head, refs []storage.SeriesRef) {
-				require.NoError(t, head.truncateStaleSeries(refs, 1000, math.MaxUint64, head.snapshotFingerprints(refs, math.MaxUint64)))
+				require.NoError(t, head.truncateStaleSeries(refs, 1000, head.snapshotFingerprints(refs, math.MaxUint64)))
 			},
 			wantSeries:        2, // Only the genuinely stale series is evicted.
 			crossTypeSurvives: true,
@@ -8809,7 +8809,7 @@ func TestHead_NumNativeHistogramSeriesAndBuckets(t *testing.T) {
 						series := testHead.series.getByHash(lbls.Hash(), lbls)
 						require.NotNil(t, series)
 						staleRefs := []storage.SeriesRef{storage.SeriesRef(series.ref)}
-						require.NoError(t, testHead.truncateStaleSeries(staleRefs, 100, math.MaxUint64, testHead.snapshotFingerprints(staleRefs, math.MaxUint64)))
+						require.NoError(t, testHead.truncateStaleSeries(staleRefs, 100, testHead.snapshotFingerprints(staleRefs, math.MaxUint64)))
 						require.Zero(t, testHead.NumSeries())
 						require.Zero(t, testHead.NumStaleSeries())
 						require.Zero(t, testHead.NumNativeHistogramSeries())
@@ -9867,7 +9867,7 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 		require.NotNil(t, ms)
 		staleRefs = append(staleRefs, storage.SeriesRef(ms.ref))
 	}
-	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64, head.snapshotFingerprints(staleRefs, math.MaxUint64)))
+	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, head.snapshotFingerprints(staleRefs, math.MaxUint64)))
 	require.Equal(t, uint64(0), head.NumStaleSeries())
 	require.Equal(t, uint64(0), head.NumSeries())
 
@@ -10881,7 +10881,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		// Use truncateStaleSeries which calls gcStaleSeries internally.
 		staleRefs := []storage.SeriesRef{storage.SeriesRef(sB.ref)}
 		require.NoError(t, h.truncateStaleSeries(
-			staleRefs, ts, math.MaxUint64, h.snapshotFingerprints(staleRefs, math.MaxUint64),
+			staleRefs, ts, h.snapshotFingerprints(staleRefs, math.MaxUint64),
 		))
 		requireCounterConsistent("after truncateStaleSeries")
 		require.Less(t, mmapReadyCounter(), readyBefore,

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1021,7 +1021,7 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 	// Truncate stale series: removes ref1 from the head and writes a
 	// [MinInt64, MaxInt64] tombstone record to the WAL.
 	staleRefs := []storage.SeriesRef{ref1}
-	require.NoError(t, head.truncateStaleSeries(staleRefs, 3500, math.MaxUint64, head.snapshotFingerprints(staleRefs)))
+	require.NoError(t, head.truncateStaleSeries(staleRefs, 3500, math.MaxUint64, head.snapshotFingerprints(staleRefs, math.MaxUint64)))
 
 	// Append a single sample with the same labels to create ref2.
 	// Ref2 has 0 m-mapped chunks, fewer than ref1's 3.
@@ -8361,7 +8361,7 @@ func TestHead_NumStaleSeries_MixedTypeRemoval(t *testing.T) {
 		{
 			name: "truncate_stale_series",
 			remove: func(t *testing.T, head *Head, refs []storage.SeriesRef) {
-				require.NoError(t, head.truncateStaleSeries(refs, 1000, math.MaxUint64, head.snapshotFingerprints(refs)))
+				require.NoError(t, head.truncateStaleSeries(refs, 1000, math.MaxUint64, head.snapshotFingerprints(refs, math.MaxUint64)))
 			},
 			wantSeries:        2, // Only the genuinely stale series is evicted.
 			crossTypeSurvives: true,
@@ -8809,7 +8809,7 @@ func TestHead_NumNativeHistogramSeriesAndBuckets(t *testing.T) {
 						series := testHead.series.getByHash(lbls.Hash(), lbls)
 						require.NotNil(t, series)
 						staleRefs := []storage.SeriesRef{storage.SeriesRef(series.ref)}
-						require.NoError(t, testHead.truncateStaleSeries(staleRefs, 100, math.MaxUint64, testHead.snapshotFingerprints(staleRefs)))
+						require.NoError(t, testHead.truncateStaleSeries(staleRefs, 100, math.MaxUint64, testHead.snapshotFingerprints(staleRefs, math.MaxUint64)))
 						require.Zero(t, testHead.NumSeries())
 						require.Zero(t, testHead.NumStaleSeries())
 						require.Zero(t, testHead.NumNativeHistogramSeries())
@@ -9867,7 +9867,7 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 		require.NotNil(t, ms)
 		staleRefs = append(staleRefs, storage.SeriesRef(ms.ref))
 	}
-	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64, head.snapshotFingerprints(staleRefs)))
+	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64, head.snapshotFingerprints(staleRefs, math.MaxUint64)))
 	require.Equal(t, uint64(0), head.NumStaleSeries())
 	require.Equal(t, uint64(0), head.NumSeries())
 
@@ -10881,7 +10881,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		// Use truncateStaleSeries which calls gcStaleSeries internally.
 		staleRefs := []storage.SeriesRef{storage.SeriesRef(sB.ref)}
 		require.NoError(t, h.truncateStaleSeries(
-			staleRefs, ts, math.MaxUint64, h.snapshotFingerprints(staleRefs),
+			staleRefs, ts, math.MaxUint64, h.snapshotFingerprints(staleRefs, math.MaxUint64),
 		))
 		requireCounterConsistent("after truncateStaleSeries")
 		require.Less(t, mmapReadyCounter(), readyBefore,


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
#### Description

This PR is a follow-up of #19666. It fixes a race in `CompactSelectedSeries` and `CompactStaleHead` that could cause a series to be evicted even though it had received a sample that compaction should have retained.

Both methods guard against this using two pieces of evidence: a fingerprint of the series' chunk shape and an append-ID watermark covering transactions that were still open when compaction started.

The watermark check had a gap: instead of preserving its result, it re-scanned the series' current append-ID history every time it was needed. That history is not durable. A later commit touching the same series, including a no-op duplicate write, can run routine cleanup and prune the entry that the check relies on. The check then finds no evidence of the earlier write and incorrectly allows the series to be evicted, leaving the sample out of the generated block.

This PR fixes the issue by evaluating the watermark once, when the chunk fingerprint is snapshotted, before compaction can modify the underlying evidence, and recording the result. Eviction treats that recorded result as the source of truth for anything that had already happened by snapshot time. For anything that happens afterward, eviction relies on the chunk fingerprint instead of re-scanning the append-ID history -- the fingerprint is a direct comparison of chunk shape, so it isn't exposed to the same cleanup-driven erasure the watermark was.

Test coverage: three regression tests reproduce the failure modes this closes. One covers a write whose transaction was still open when the snapshot was taken. Another covers that same write's evidence being erased by an unrelated duplicate's cleanup before eviction runs. The third covers a write that lands after the snapshot, followed by an unrelated duplicate whose cleanup erases its append-ID evidence -- verifying the chunk fingerprint alone still catches it.

#### Which issue(s) does the PR fix:
Follow-up to #19666.
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] TSDB: Fix a rare case where a sample could be lost during selected-series or stale-series compaction if an unrelated write to the same series ran cleanup that erased the evidence needed to protect it.
```
