### PR TITLE
tsdb: apply search limits after sorting unordered index values

### DIFF
--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3039,6 +3039,57 @@ func TestHead_ReturnsSortedLabelValues(t *testing.T) {
 	require.NoError(t, q.Close())
 }
 
+func TestSearchLabelValuesLimit(t *testing.T) {
+	h, _ := newTestHead(t, 1000, compression.None, false)
+	ctx := t.Context()
+	app := h.Appender(ctx)
+	for _, name := range []string{"z_metric", "m_metric", "a_metric"} {
+		_, err := app.Append(0, labels.FromStrings("__name__", name, "job", "api"), 2100, 1)
+		require.NoError(t, err)
+	}
+	require.NoError(t, app.Commit())
+	block, err := OpenBlock(nil, createBlockFromHead(t, t.TempDir(), h), nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, block.Close()) })
+	for _, backend := range []struct {
+		name   string
+		reader BlockReader
+	}{{"Head", h}, {"Block", block}} {
+		t.Run(backend.name, func(t *testing.T) {
+			q, err := NewBlockQuerier(backend.reader, 1500, 2500)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, q.Close()) })
+
+			for _, matchers := range [][]*labels.Matcher{
+				nil,
+				{labels.MustNewMatcher(labels.MatchEqual, "job", "api")},
+			} {
+				t.Run(fmt.Sprint(matchers), func(t *testing.T) {
+					for _, limit := range []int{0, 1, 2, 3, 4} {
+						t.Run(strconv.Itoa(limit), func(t *testing.T) {
+							want := []storage.SearchResult{
+								{Value: "a_metric", Score: 1},
+								{Value: "m_metric", Score: 1},
+								{Value: "z_metric", Score: 1},
+							}
+							if limit > 0 && limit < len(want) {
+								want = want[:limit]
+							}
+							// A nil filter and an accept-all filter must return the same ranked results.
+							for _, filter := range []storage.Filter{nil, prefixFilter{prefix: ""}} {
+								rs := q.(storage.Searcher).SearchLabelValues(ctx, "__name__", &storage.SearchHints{
+									OrderBy: storage.OrderByValueAsc, Limit: limit, Filter: filter,
+								}, matchers...)
+								require.Equal(t, want, collectSearchResultSet(t, rs), "filter: %T", filter)
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
 // TestWalRepair_DecodingError ensures that a repair is run for an error
 // when decoding a record.
 func TestWalRepair_DecodingError(t *testing.T) {

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -112,12 +112,15 @@ func (q *blockBaseQuerier) SearchLabelValues(ctx context.Context, name string, h
 		hints = &storage.SearchHints{}
 	}
 
-	// Limit pushdown is only correct when natural (ascending) index order
-	// is preserved all the way to the output and no filtering discards
-	// values ahead of the limit.
+	// Preserve limit pushdown for known sorted format-v2 block indexes.
+	// Head and format-v1 indexes may limit an unordered subset before sorting.
 	labelHints := &storage.LabelHints{}
 	if hints.OrderBy == storage.OrderByValueAsc && hints.Filter == nil {
-		labelHints.Limit = hints.Limit
+		if block, ok := q.index.(blockIndexReader); ok {
+			if reader, ok := block.ir.(*index.Reader); ok && reader.Version() == index.FormatV2 {
+				labelHints.Limit = hints.Limit
+			}
+		}
 	}
 
 	var (

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -16,6 +16,7 @@ package tsdb
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 // Make entries ~50B in size, to emulate real-world high cardinality.
@@ -363,4 +365,64 @@ func BenchmarkQuerierSelectWithOutOfOrder(b *testing.B) {
 	b.Run("Head", func(b *testing.B) {
 		benchmarkSelect(b, db, numSeries, false)
 	})
+}
+
+// BenchmarkSearchLabelValues measures complete result consumption with a warm index.
+func BenchmarkSearchLabelValues(b *testing.B) {
+	for _, cardinality := range []int{1000, 100000} {
+		b.Run(fmt.Sprintf("values=%d", cardinality), func(b *testing.B) {
+			head, _ := newTestHead(b, 2000, compression.None, false)
+			ctx := b.Context()
+			app := head.Appender(ctx)
+			for _, i := range rand.New(rand.NewPCG(1, 2)).Perm(cardinality) {
+				_, err := app.Append(0, labels.FromStrings("__name__", fmt.Sprintf("metric_%06d", i), "job", "api"), 100, 1)
+				require.NoError(b, err)
+			}
+			require.NoError(b, app.Commit())
+			block, err := OpenBlock(nil, createBlockFromHead(b, b.TempDir(), head), nil, nil)
+			require.NoError(b, err)
+			b.Cleanup(func() { require.NoError(b, block.Close()) })
+			for _, backend := range []struct {
+				name   string
+				reader BlockReader
+			}{
+				{"Head", head}, {"Block", block},
+			} {
+				b.Run(backend.name, func(b *testing.B) {
+					q, err := NewBlockQuerier(backend.reader, 0, 200)
+					require.NoError(b, err)
+					b.Cleanup(func() { require.NoError(b, q.Close()) })
+					for _, tc := range []struct {
+						name     string
+						hints    *storage.SearchHints
+						matchers []*labels.Matcher
+					}{
+						{"limit=100", &storage.SearchHints{Limit: 100}, nil},
+						{"limit=100_accept_all", &storage.SearchHints{Limit: 100, Filter: prefixFilter{prefix: ""}}, nil},
+						{"limit=100_matcher", &storage.SearchHints{Limit: 100}, []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "job", "api")}},
+						{"unlimited", &storage.SearchHints{}, nil},
+					} {
+						b.Run(tc.name, func(b *testing.B) {
+							b.ReportAllocs()
+							for b.Loop() {
+								rs := q.(storage.Searcher).SearchLabelValues(ctx, "__name__", tc.hints, tc.matchers...)
+								count := 0
+								for rs.Next() {
+									_ = rs.At()
+									count++
+								}
+								require.NoError(b, rs.Err())
+								require.NoError(b, rs.Close())
+								want := cardinality
+								if tc.hints.Limit > 0 {
+									want = min(want, tc.hints.Limit)
+								}
+								require.Equal(b, want, count)
+							}
+						})
+					}
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
Related to #19673.

This is a proposed fix for review. It assumes that an ascending `SearchLabelValues` call should return the first N alphabetical values. I'd appreciate a check on that assumption.

The change applies the limit after sorting for Head. It keeps the early limit for known format-v2 block indexes, where values are already ordered. Includes a regression test and benchmark.

**Pros:** nil and accept-all filters return the same first N values; format-v2 blocks keep the early-stop optimization.

**Cons:** Head must collect and sort all candidate values. The conservative check also disables early limits for format-v3 and custom readers.

Some informal local results for 100,000 values, limit 100, with no filter or matcher:

| Index | Time before → after | Allocated bytes per call before → after |
|---|---:|---:|
| Head | 5.19 µs → 17.17 ms | 4.43 KiB → 1.53 MiB |
| Format-v2 block | 4.04 µs → 4.09 µs | 4.43 KiB → 4.43 KiB |

Six samples, 250 ms each; Go 1.26.8, Apple M5 Pro, `GOMAXPROCS=4`, warm index. Timing was noisy; block differences were not significant. The old Head path can return different values. Happy to provide the full results.

The new test fails on the original code and passes with this patch. Existing TSDB/storage tests and scoped TSDB lint pass. Full repository tests and CI checks remain outstanding.

I used AI tools to help with the investigation, code, tests, benchmarks and this draft, but I've reviewed everything.

```release-notes
[BUGFIX] TSDB: Apply label-value search limits after sorting unordered index values.
```
