### PR TITLE
WIP, POC: metadata-wal-records alternative implementation

### DIFF
--- a/cmd/prometheus/features_test.go
+++ b/cmd/prometheus/features_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/util/testutil"
@@ -113,4 +114,19 @@ func TestFeaturesAPI(t *testing.T) {
 
 	// Compare the features data with the golden file.
 	require.Equal(t, expectedFeatures, apiResponse.Data, "Features mismatch. Run 'make update-features-testdata' to update the golden file.")
+}
+
+// TestSetFeatureListOptions_MetadataWALRecords is a regression test: enabling
+// metadata-wal-records used to only flip the scrape and web AppendMetadata
+// options, never tsdb.EnableMetadataWALRecords. AppenderV2, which the scrape
+// manager prefers whenever the storage implements it, gates on that TSDB
+// option, so metadata was silently never recorded via the default scrape
+// path regardless of the flag.
+func TestSetFeatureListOptions_MetadataWALRecords(t *testing.T) {
+	c := &flagConfig{featureList: []string{"metadata-wal-records"}}
+	require.NoError(t, c.setFeatureListOptions(promslog.NewNopLogger()))
+
+	require.True(t, c.scrape.AppendMetadata)
+	require.True(t, c.web.AppendMetadata)
+	require.True(t, c.tsdb.EnableMetadataWALRecords)
 }

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -247,6 +247,7 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 			case "metadata-wal-records":
 				c.scrape.AppendMetadata = true
 				c.web.AppendMetadata = true
+				c.tsdb.EnableMetadataWALRecords = true
 				features.Enable(features.TSDB, "metadata_wal_records")
 				logger.Info("Experimental metadata records in WAL enabled")
 			case "promql-per-step-stats":
@@ -2145,6 +2146,7 @@ type tsdbOptions struct {
 	StaleSeriesCompactionThreshold float64
 	EnableFastStartup              bool
 	FloatChunkEncoding             chunkenc.Encoding
+	EnableMetadataWALRecords       bool
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -2178,6 +2180,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		StaleSeriesCompactionThreshold: opts.StaleSeriesCompactionThreshold,
 		EnableFastStartup:              opts.EnableFastStartup,
 		FloatChunkEncoding:             opts.FloatChunkEncoding,
+		EnableMetadataWALRecords:       opts.EnableMetadataWALRecords,
 	}
 }
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -952,7 +952,7 @@ func main() {
 	var (
 		localStorage  = &readyStorage{stats: tsdb.NewDBStats()}
 		scraper       = &readyScrapeManager{}
-		remoteStorage = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, cfg.scrape.EnableTypeAndUnitLabels)
+		remoteStorage = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, cfg.scrape.EnableTypeAndUnitLabels, cfg.scrape.AppendMetadata)
 		fanoutStorage = storage.NewFanout(logger, localStorage, remoteStorage)
 	)
 

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -442,11 +442,12 @@ type QueueManager struct {
 	protoMsg    remoteapi.WriteMessageType
 	compr       compression.Type
 
-	seriesMtx      sync.Mutex // Covers seriesLabels, seriesMetadata, droppedSeries and builder.
-	seriesLabels   map[chunks.HeadSeriesRef]labels.Labels
-	seriesMetadata map[chunks.HeadSeriesRef]*metadata.Metadata
-	droppedSeries  map[chunks.HeadSeriesRef]struct{}
-	builder        *labels.Builder
+	seriesMtx         sync.Mutex // Covers seriesLabels, seriesMetadataRef, metadataDefs, droppedSeries and builder.
+	seriesLabels      map[chunks.HeadSeriesRef]labels.Labels
+	seriesMetadataRef map[chunks.HeadSeriesRef]record.MetadataRef
+	metadataDefs      map[record.MetadataRef]*metadata.Metadata
+	droppedSeries     map[chunks.HeadSeriesRef]struct{}
+	builder           *labels.Builder
 
 	seriesSegmentMtx     sync.Mutex // Covers seriesSegmentIndexes - if you also lock seriesMtx, take seriesMtx first.
 	seriesSegmentIndexes map[chunks.HeadSeriesRef]int
@@ -517,7 +518,8 @@ func NewQueueManager(
 		failedRequestLogging:    failedRequestLogging,
 
 		seriesLabels:         make(map[chunks.HeadSeriesRef]labels.Labels),
-		seriesMetadata:       make(map[chunks.HeadSeriesRef]*metadata.Metadata),
+		seriesMetadataRef:    make(map[chunks.HeadSeriesRef]record.MetadataRef),
+		metadataDefs:         make(map[record.MetadataRef]*metadata.Metadata),
 		seriesSegmentIndexes: make(map[chunks.HeadSeriesRef]int),
 		droppedSeries:        make(map[chunks.HeadSeriesRef]struct{}),
 		builder:              labels.NewBuilder(labels.EmptyLabels()),
@@ -750,7 +752,7 @@ outer:
 		}
 		// TODO(cstyan): Handle or at least log an error if no metadata is found.
 		// See https://github.com/prometheus/prometheus/issues/14405
-		meta := t.seriesMetadata[s.Ref]
+		meta := t.metadataDefs[t.seriesMetadataRef[s.Ref]]
 		t.seriesMtx.Unlock()
 		// Start with a very small backoff. This should not be t.cfg.MinBackoff
 		// as it can happen without errors, and we want to pickup work after
@@ -812,7 +814,7 @@ outer:
 			t.seriesMtx.Unlock()
 			continue
 		}
-		meta := t.seriesMetadata[e.Ref]
+		meta := t.metadataDefs[t.seriesMetadataRef[e.Ref]]
 		t.seriesMtx.Unlock()
 		// This will only loop if the queues are being resharded.
 		backoff := t.cfg.MinBackoff
@@ -874,7 +876,7 @@ outer:
 			t.seriesMtx.Unlock()
 			continue
 		}
-		meta := t.seriesMetadata[h.Ref]
+		meta := t.metadataDefs[t.seriesMetadataRef[h.Ref]]
 		t.seriesMtx.Unlock()
 
 		backoff := model.Duration(5 * time.Millisecond)
@@ -936,7 +938,7 @@ outer:
 			t.seriesMtx.Unlock()
 			continue
 		}
-		meta := t.seriesMetadata[h.Ref]
+		meta := t.metadataDefs[t.seriesMetadataRef[h.Ref]]
 		t.seriesMtx.Unlock()
 
 		backoff := model.Duration(5 * time.Millisecond)
@@ -1040,11 +1042,48 @@ func (t *QueueManager) StoreMetadata(meta []record.RefMetadata) {
 	t.seriesMtx.Lock()
 	defer t.seriesMtx.Unlock()
 	for _, m := range meta {
-		t.seriesMetadata[m.Ref] = &metadata.Metadata{
+		// Pre-MetadataDefinition/SeriesMetadataRef format: give each series its
+		// own MetadataRef (its series ref, offset to avoid clashing with refs
+		// allocated from the new format) pointing at its own definition, so
+		// both formats resolve through the same metadataDefs/seriesMetadataRef
+		// maps at the send path.
+		ref := record.MetadataRef(m.Ref) + math.MaxUint32
+		t.metadataDefs[ref] = &metadata.Metadata{
 			Type: record.ToMetricType(m.Type),
 			Unit: m.Unit,
 			Help: m.Help,
 		}
+		t.seriesMetadataRef[m.Ref] = ref
+	}
+}
+
+// StoreMetadataDefinitions records the content for each newly-seen MetadataRef.
+func (t *QueueManager) StoreMetadataDefinitions(defs []record.RefMetadataDefinition) {
+	if t.protoMsg == remoteapi.WriteV1MessageType {
+		return
+	}
+
+	t.seriesMtx.Lock()
+	defer t.seriesMtx.Unlock()
+	for _, def := range defs {
+		t.metadataDefs[def.Ref] = &metadata.Metadata{
+			Type: record.ToMetricType(def.Type),
+			Unit: def.Unit,
+			Help: def.Help,
+		}
+	}
+}
+
+// StoreSeriesMetadataRef associates each series with its (possibly new) MetadataRef.
+func (t *QueueManager) StoreSeriesMetadataRef(refs []record.RefSeriesMetadataRef) {
+	if t.protoMsg == remoteapi.WriteV1MessageType {
+		return
+	}
+
+	t.seriesMtx.Lock()
+	defer t.seriesMtx.Unlock()
+	for _, r := range refs {
+		t.seriesMetadataRef[r.Ref] = r.MetadataRef
 	}
 }
 
@@ -1072,8 +1111,18 @@ func (t *QueueManager) SeriesReset(index int) {
 		if v < index {
 			delete(t.seriesSegmentIndexes, k)
 			delete(t.seriesLabels, k)
-			delete(t.seriesMetadata, k)
+			delete(t.seriesMetadataRef, k)
 			delete(t.droppedSeries, k)
+		}
+	}
+	// Drop metadata definitions no longer referenced by any series.
+	liveMetadataRefs := make(map[record.MetadataRef]struct{}, len(t.seriesMetadataRef))
+	for _, ref := range t.seriesMetadataRef {
+		liveMetadataRefs[ref] = struct{}{}
+	}
+	for ref := range t.metadataDefs {
+		if _, ok := liveMetadataRefs[ref]; !ok {
+			delete(t.metadataDefs, ref)
 		}
 	}
 }

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -66,6 +66,143 @@ const (
 	reasonNHCBNotSupported           = "nhcb_in_rw1_not_supported"
 )
 
+// seriesEntry holds the labels and MetadataRef for a single active (non-dropped) series.
+type seriesEntry struct {
+	labels      labels.Labels
+	metadataRef record.MetadataRef
+}
+
+// seriesStorage holds per-series label and metadata state, selecting its internal
+// layout at construction time based on whether metadata WAL records are in use:
+//
+//   - withMeta=false (RWv1, or RWv2 without metadata-wal-records): only labels is
+//     populated. Each Append lookup requires a single map access.
+//   - withMeta=true (RWv2 with metadata-wal-records enabled): only entries and
+//     metadataDefs are populated. Each Append lookup retrieves the labels and
+//     MetadataRef in a single map access, then resolves the ref against the much
+//     smaller, deduplicated metadataDefs map.
+//
+// The hot-path method lookup acquires and releases mu internally.
+// Callers that must hold both series.mu and seriesSegmentMtx must take series.mu first.
+type seriesStorage struct {
+	mu sync.Mutex
+	// withMeta is set once in NewQueueManager and never modified; it is safe to
+	// read without holding mu.
+	withMeta bool
+
+	// withMeta=false: labels is used; entries and metadataDefs are nil.
+	labels map[chunks.HeadSeriesRef]labels.Labels
+	// withMeta=true: entries and metadataDefs are used; labels is nil.
+	entries map[chunks.HeadSeriesRef]seriesEntry
+	// metadataDefs holds metadata content once per distinct MetadataRef, shared
+	// across every series entry pointing at it.
+	metadataDefs map[record.MetadataRef]*metadata.Metadata
+
+	dropped map[chunks.HeadSeriesRef]struct{}
+}
+
+func (s *seriesStorage) lock()   { s.mu.Lock() }
+func (s *seriesStorage) unlock() { s.mu.Unlock() }
+
+// lookup returns the labels and metadata for ref, taking and releasing mu internally.
+// active is true when the series is known and not dropped.
+// dropped is only meaningful when active=false: true means the series was explicitly
+// filtered by relabelling, false means it was never seen.
+func (s *seriesStorage) lookup(ref chunks.HeadSeriesRef) (lbls labels.Labels, meta *metadata.Metadata, active, dropped bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.withMeta {
+		e, ok := s.entries[ref]
+		if !ok {
+			_, d := s.dropped[ref]
+			return labels.EmptyLabels(), nil, false, d
+		}
+		return e.labels, s.metadataDefs[e.metadataRef], true, false
+	}
+	l, ok := s.labels[ref]
+	if !ok {
+		_, d := s.dropped[ref]
+		return labels.EmptyLabels(), nil, false, d
+	}
+	return l, nil, true, false
+}
+
+// storeLocked records ref as an active series with the given labels, preserving any
+// existing MetadataRef. Must be called with mu held.
+func (s *seriesStorage) storeLocked(ref chunks.HeadSeriesRef, lbls labels.Labels) {
+	delete(s.dropped, ref)
+	if s.withMeta {
+		existing := s.entries[ref]
+		s.entries[ref] = seriesEntry{labels: lbls, metadataRef: existing.metadataRef}
+	} else {
+		s.labels[ref] = lbls
+	}
+}
+
+// dropLocked marks ref as an explicitly-dropped series and removes it from the active
+// maps. Must be called with mu held.
+func (s *seriesStorage) dropLocked(ref chunks.HeadSeriesRef) {
+	if s.withMeta {
+		delete(s.entries, ref)
+	} else {
+		delete(s.labels, ref)
+	}
+	s.dropped[ref] = struct{}{}
+}
+
+// deleteLocked removes ref from all maps. Must be called with mu held.
+func (s *seriesStorage) deleteLocked(ref chunks.HeadSeriesRef) {
+	if s.withMeta {
+		delete(s.entries, ref)
+	} else {
+		delete(s.labels, ref)
+	}
+	delete(s.dropped, ref)
+}
+
+// storeMetadataDefinitionLocked records the content for a MetadataRef. Content is
+// immutable per ref, so this only ever adds an entry, never changes one. Must be
+// called with mu held. No-op when withMeta is false.
+func (s *seriesStorage) storeMetadataDefinitionLocked(ref record.MetadataRef, m metadata.Metadata) {
+	if !s.withMeta {
+		return
+	}
+	s.metadataDefs[ref] = &m
+}
+
+// storeSeriesMetadataRefLocked points ref at metadataRef, if ref is an active
+// series. A series not yet known via StoreSeries is silently skipped: Append
+// already discards dropped/unknown series before reading metadata, so this has
+// no effect on what gets sent. Must be called with mu held. No-op when withMeta
+// is false.
+func (s *seriesStorage) storeSeriesMetadataRefLocked(ref chunks.HeadSeriesRef, metadataRef record.MetadataRef) {
+	if !s.withMeta {
+		return
+	}
+	if e, ok := s.entries[ref]; ok {
+		e.metadataRef = metadataRef
+		s.entries[ref] = e
+	}
+}
+
+// pruneUnreferencedMetadataDefsLocked drops metadataDefs entries no longer
+// referenced by any entries value. Must be called with mu held. No-op when
+// withMeta is false.
+func (s *seriesStorage) pruneUnreferencedMetadataDefsLocked() {
+	if !s.withMeta {
+		return
+	}
+	liveMetadataRefs := make(map[record.MetadataRef]struct{}, len(s.entries))
+	for _, e := range s.entries {
+		liveMetadataRefs[e.metadataRef] = struct{}{}
+	}
+	for ref := range s.metadataDefs {
+		if _, ok := liveMetadataRefs[ref]; !ok {
+			delete(s.metadataDefs, ref)
+		}
+	}
+}
+
 type queueManagerMetrics struct {
 	reg prometheus.Registerer
 
@@ -442,14 +579,10 @@ type QueueManager struct {
 	protoMsg    remoteapi.WriteMessageType
 	compr       compression.Type
 
-	seriesMtx         sync.Mutex // Covers seriesLabels, seriesMetadataRef, metadataDefs, droppedSeries and builder.
-	seriesLabels      map[chunks.HeadSeriesRef]labels.Labels
-	seriesMetadataRef map[chunks.HeadSeriesRef]record.MetadataRef
-	metadataDefs      map[record.MetadataRef]*metadata.Metadata
-	droppedSeries     map[chunks.HeadSeriesRef]struct{}
-	builder           *labels.Builder
+	series  seriesStorage
+	builder *labels.Builder // Accessed under series.mu during StoreSeries.
 
-	seriesSegmentMtx     sync.Mutex // Covers seriesSegmentIndexes - if you also lock seriesMtx, take seriesMtx first.
+	seriesSegmentMtx     sync.Mutex // Covers seriesSegmentIndexes - if you also lock series.mu, take series.mu first.
 	seriesSegmentIndexes map[chunks.HeadSeriesRef]int
 
 	shards      *shards
@@ -489,6 +622,7 @@ func NewQueueManager(
 	enableExemplarRemoteWrite bool,
 	enableNativeHistogramRemoteWrite bool,
 	enableTypeAndUnitLabels bool,
+	enableMetadataWALRecords bool,
 	protoMsg remoteapi.WriteMessageType,
 	recordBuf *record.BuffersPool,
 	failedRequestLogging bool,
@@ -517,11 +651,7 @@ func NewQueueManager(
 		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
 		failedRequestLogging:    failedRequestLogging,
 
-		seriesLabels:         make(map[chunks.HeadSeriesRef]labels.Labels),
-		seriesMetadataRef:    make(map[chunks.HeadSeriesRef]record.MetadataRef),
-		metadataDefs:         make(map[record.MetadataRef]*metadata.Metadata),
 		seriesSegmentIndexes: make(map[chunks.HeadSeriesRef]int),
-		droppedSeries:        make(map[chunks.HeadSeriesRef]struct{}),
 		builder:              labels.NewBuilder(labels.EmptyLabels()),
 
 		numShards:   cfg.MinShards,
@@ -541,7 +671,16 @@ func NewQueueManager(
 		compr:    compression.Snappy, // Hardcoded for now, but scaffolding exists for likely future use.
 	}
 
-	walMetadata := t.protoMsg != remoteapi.WriteV1MessageType
+	walMetadata := protoMsg != remoteapi.WriteV1MessageType && enableMetadataWALRecords
+
+	t.series.withMeta = walMetadata
+	t.series.dropped = make(map[chunks.HeadSeriesRef]struct{})
+	if walMetadata {
+		t.series.entries = make(map[chunks.HeadSeriesRef]seriesEntry)
+		t.series.metadataDefs = make(map[record.MetadataRef]*metadata.Metadata)
+	} else {
+		t.series.labels = make(map[chunks.HeadSeriesRef]labels.Labels)
+	}
 
 	t.watcher = wlog.NewWatcher(watcherMetrics, readerMetrics, logger, client.Name(), t, dir, enableExemplarRemoteWrite, enableNativeHistogramRemoteWrite, walMetadata, recordBuf)
 
@@ -737,23 +876,19 @@ outer:
 			t.metrics.droppedSamplesTotal.WithLabelValues(reasonTooOld).Inc()
 			continue
 		}
-		t.seriesMtx.Lock()
-		lbls, ok := t.seriesLabels[s.Ref]
+		lbls, meta, ok, dropped := t.series.lookup(s.Ref)
 		if !ok {
 			t.dataDropped.incr(1)
-			if _, ok := t.droppedSeries[s.Ref]; !ok {
+			if dropped {
+				t.metrics.droppedSamplesTotal.WithLabelValues(reasonDroppedSeries).Inc()
+			} else {
 				t.logger.Info("Dropped sample for series that was not explicitly dropped via relabelling", "ref", s.Ref)
 				t.metrics.droppedSamplesTotal.WithLabelValues(reasonUnintentionalDroppedSeries).Inc()
-			} else {
-				t.metrics.droppedSamplesTotal.WithLabelValues(reasonDroppedSeries).Inc()
 			}
-			t.seriesMtx.Unlock()
 			continue
 		}
 		// TODO(cstyan): Handle or at least log an error if no metadata is found.
 		// See https://github.com/prometheus/prometheus/issues/14405
-		meta := t.metadataDefs[t.seriesMetadataRef[s.Ref]]
-		t.seriesMtx.Unlock()
 		// Start with a very small backoff. This should not be t.cfg.MinBackoff
 		// as it can happen without errors, and we want to pickup work after
 		// filling a queue/resharding as quickly as possible.
@@ -800,22 +935,18 @@ outer:
 			t.metrics.droppedExemplarsTotal.WithLabelValues(reasonTooOld).Inc()
 			continue
 		}
-		t.seriesMtx.Lock()
-		lbls, ok := t.seriesLabels[e.Ref]
+		lbls, meta, ok, dropped := t.series.lookup(e.Ref)
 		if !ok {
 			// Track dropped exemplars in the same EWMA for sharding calc.
 			t.dataDropped.incr(1)
-			if _, ok := t.droppedSeries[e.Ref]; !ok {
+			if dropped {
+				t.metrics.droppedExemplarsTotal.WithLabelValues(reasonDroppedSeries).Inc()
+			} else {
 				t.logger.Info("Dropped exemplar for series that was not explicitly dropped via relabelling", "ref", e.Ref)
 				t.metrics.droppedExemplarsTotal.WithLabelValues(reasonUnintentionalDroppedSeries).Inc()
-			} else {
-				t.metrics.droppedExemplarsTotal.WithLabelValues(reasonDroppedSeries).Inc()
 			}
-			t.seriesMtx.Unlock()
 			continue
 		}
-		meta := t.metadataDefs[t.seriesMetadataRef[e.Ref]]
-		t.seriesMtx.Unlock()
 		// This will only loop if the queues are being resharded.
 		backoff := t.cfg.MinBackoff
 		for {
@@ -863,21 +994,17 @@ outer:
 			t.logger.Warn("Dropped native histogram with custom buckets (NHCB) as remote write v1 does not support itB", "ref", h.Ref)
 			continue
 		}
-		t.seriesMtx.Lock()
-		lbls, ok := t.seriesLabels[h.Ref]
+		lbls, meta, ok, dropped := t.series.lookup(h.Ref)
 		if !ok {
 			t.dataDropped.incr(1)
-			if _, ok := t.droppedSeries[h.Ref]; !ok {
+			if dropped {
+				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonDroppedSeries).Inc()
+			} else {
 				t.logger.Info("Dropped histogram for series that was not explicitly dropped via relabelling", "ref", h.Ref)
 				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonUnintentionalDroppedSeries).Inc()
-			} else {
-				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonDroppedSeries).Inc()
 			}
-			t.seriesMtx.Unlock()
 			continue
 		}
-		meta := t.metadataDefs[t.seriesMetadataRef[h.Ref]]
-		t.seriesMtx.Unlock()
 
 		backoff := model.Duration(5 * time.Millisecond)
 		for {
@@ -925,21 +1052,17 @@ outer:
 			t.logger.Warn("Dropped float native histogram with custom buckets (NHCB) as remote write v1 does not support itB", "ref", h.Ref)
 			continue
 		}
-		t.seriesMtx.Lock()
-		lbls, ok := t.seriesLabels[h.Ref]
+		lbls, meta, ok, dropped := t.series.lookup(h.Ref)
 		if !ok {
 			t.dataDropped.incr(1)
-			if _, ok := t.droppedSeries[h.Ref]; !ok {
+			if dropped {
+				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonDroppedSeries).Inc()
+			} else {
 				t.logger.Info("Dropped histogram for series that was not explicitly dropped via relabelling", "ref", h.Ref)
 				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonUnintentionalDroppedSeries).Inc()
-			} else {
-				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonDroppedSeries).Inc()
 			}
-			t.seriesMtx.Unlock()
 			continue
 		}
-		meta := t.metadataDefs[t.seriesMetadataRef[h.Ref]]
-		t.seriesMtx.Unlock()
 
 		backoff := model.Duration(5 * time.Millisecond)
 		for {
@@ -1013,8 +1136,8 @@ func (t *QueueManager) Stop() {
 
 // StoreSeries keeps track of which series we know about for lookups when sending samples to remote.
 func (t *QueueManager) StoreSeries(series []record.RefSeries, index int) {
-	t.seriesMtx.Lock()
-	defer t.seriesMtx.Unlock()
+	t.series.lock()
+	defer t.series.unlock()
 	t.seriesSegmentMtx.Lock()
 	defer t.seriesSegmentMtx.Unlock()
 	for _, s := range series {
@@ -1025,65 +1148,65 @@ func (t *QueueManager) StoreSeries(series []record.RefSeries, index int) {
 		processExternalLabels(t.builder, t.externalLabels)
 		keep := relabel.ProcessBuilder(t.builder, t.relabelConfigs...)
 		if !keep {
-			t.droppedSeries[s.Ref] = struct{}{}
+			t.series.dropLocked(s.Ref)
 			continue
 		}
-		lbls := t.builder.Labels()
-		t.seriesLabels[s.Ref] = lbls
+		t.series.storeLocked(s.Ref, t.builder.Labels())
 	}
 }
 
 // StoreMetadata keeps track of known series' metadata for lookups when sending samples to remote.
+// This is the pre-MetadataDefinition/SeriesMetadataRef format, kept for WAL segments written
+// before that format existed.
 func (t *QueueManager) StoreMetadata(meta []record.RefMetadata) {
-	if t.protoMsg == remoteapi.WriteV1MessageType {
+	if !t.series.withMeta {
 		return
 	}
 
-	t.seriesMtx.Lock()
-	defer t.seriesMtx.Unlock()
+	t.series.lock()
+	defer t.series.unlock()
 	for _, m := range meta {
-		// Pre-MetadataDefinition/SeriesMetadataRef format: give each series its
-		// own MetadataRef (its series ref, offset to avoid clashing with refs
-		// allocated from the new format) pointing at its own definition, so
-		// both formats resolve through the same metadataDefs/seriesMetadataRef
-		// maps at the send path.
+		// Give each series its own MetadataRef (its series ref, offset to avoid
+		// clashing with refs allocated from the new format) pointing at its own
+		// definition, so both formats resolve through the same seriesStorage
+		// state at the send path.
 		ref := record.MetadataRef(m.Ref) + math.MaxUint32
-		t.metadataDefs[ref] = &metadata.Metadata{
+		t.series.storeMetadataDefinitionLocked(ref, metadata.Metadata{
 			Type: record.ToMetricType(m.Type),
 			Unit: m.Unit,
 			Help: m.Help,
-		}
-		t.seriesMetadataRef[m.Ref] = ref
+		})
+		t.series.storeSeriesMetadataRefLocked(m.Ref, ref)
 	}
 }
 
 // StoreMetadataDefinitions records the content for each newly-seen MetadataRef.
 func (t *QueueManager) StoreMetadataDefinitions(defs []record.RefMetadataDefinition) {
-	if t.protoMsg == remoteapi.WriteV1MessageType {
+	if !t.series.withMeta {
 		return
 	}
 
-	t.seriesMtx.Lock()
-	defer t.seriesMtx.Unlock()
+	t.series.lock()
+	defer t.series.unlock()
 	for _, def := range defs {
-		t.metadataDefs[def.Ref] = &metadata.Metadata{
+		t.series.storeMetadataDefinitionLocked(def.Ref, metadata.Metadata{
 			Type: record.ToMetricType(def.Type),
 			Unit: def.Unit,
 			Help: def.Help,
-		}
+		})
 	}
 }
 
 // StoreSeriesMetadataRef associates each series with its (possibly new) MetadataRef.
 func (t *QueueManager) StoreSeriesMetadataRef(refs []record.RefSeriesMetadataRef) {
-	if t.protoMsg == remoteapi.WriteV1MessageType {
+	if !t.series.withMeta {
 		return
 	}
 
-	t.seriesMtx.Lock()
-	defer t.seriesMtx.Unlock()
+	t.series.lock()
+	defer t.series.unlock()
 	for _, r := range refs {
-		t.seriesMetadataRef[r.Ref] = r.MetadataRef
+		t.series.storeSeriesMetadataRefLocked(r.Ref, r.MetadataRef)
 	}
 }
 
@@ -1101,8 +1224,8 @@ func (t *QueueManager) UpdateSeriesSegment(series []record.RefSeries, index int)
 // stored series records with the checkpoints index number, so we can now
 // delete any ref ID's lower than that # from the two maps.
 func (t *QueueManager) SeriesReset(index int) {
-	t.seriesMtx.Lock()
-	defer t.seriesMtx.Unlock()
+	t.series.lock()
+	defer t.series.unlock()
 	t.seriesSegmentMtx.Lock()
 	defer t.seriesSegmentMtx.Unlock()
 	// Check for series that are in segments older than the checkpoint
@@ -1110,21 +1233,11 @@ func (t *QueueManager) SeriesReset(index int) {
 	for k, v := range t.seriesSegmentIndexes {
 		if v < index {
 			delete(t.seriesSegmentIndexes, k)
-			delete(t.seriesLabels, k)
-			delete(t.seriesMetadataRef, k)
-			delete(t.droppedSeries, k)
+			t.series.deleteLocked(k)
 		}
 	}
 	// Drop metadata definitions no longer referenced by any series.
-	liveMetadataRefs := make(map[record.MetadataRef]struct{}, len(t.seriesMetadataRef))
-	for _, ref := range t.seriesMetadataRef {
-		liveMetadataRefs[ref] = struct{}{}
-	}
-	for ref := range t.metadataDefs {
-		if _, ok := liveMetadataRefs[ref]; !ok {
-			delete(t.metadataDefs, ref)
-		}
-	}
+	t.series.pruneUnreferencedMetadataDefsLocked()
 }
 
 // SetClient updates the client used by a queue. Used when only client specific

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -140,7 +140,7 @@ func TestBasicContentNegotiation(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 			defer s.Close()
 
 			recs := testwal.GenerateRecords(recCase{
@@ -225,7 +225,7 @@ func TestSampleDelivery(t *testing.T) {
 		} {
 			t.Run(fmt.Sprintf("proto=%s/case=%s", protoMsg, rc.Name), func(t *testing.T) {
 				dir := t.TempDir()
-				s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+				s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, true)
 				defer s.Close()
 
 				rc.NoST = protoMsg == remoteapi.WriteV1MessageType // RW1 does not support ST.
@@ -300,13 +300,13 @@ func newTestClientAndQueueManager(t testing.TB, flushDeadline time.Duration, pro
 	c := NewTestWriteClient(protoMsg)
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
-	return c, newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg)
+	return c, newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 }
 
-func newTestQueueManager(t testing.TB, cfg config.QueueConfig, mcfg config.MetadataConfig, deadline time.Duration, c WriteClient, protoMsg remoteapi.WriteMessageType) *QueueManager {
+func newTestQueueManager(t testing.TB, cfg config.QueueConfig, mcfg config.MetadataConfig, deadline time.Duration, c WriteClient, protoMsg remoteapi.WriteMessageType, enableMetadataWALRecords bool) *QueueManager {
 	dir := t.TempDir()
 	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, protoMsg, record.NewBuffersPool(), false)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, enableMetadataWALRecords, protoMsg, record.NewBuffersPool(), false)
 
 	return m
 }
@@ -367,7 +367,7 @@ func TestWALMetadataDelivery(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
-			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, true)
 			defer s.Close()
 
 			cfg := config.DefaultQueueConfig
@@ -399,8 +399,7 @@ func TestWALMetadataDelivery(t *testing.T) {
 			qm.StoreSeries(recs.Series, 0)
 			storeMetadata(qm, recs)
 
-			require.Len(t, qm.seriesLabels, n)
-			require.Len(t, qm.seriesMetadataRef, n)
+			require.Len(t, qm.series.entries, n)
 
 			c.expectSamples(recs.Samples, recs.Series)
 			c.expectMetadataForBatch(recs.Metadata, recs.Series, recs.Samples, nil, nil, nil)
@@ -426,7 +425,7 @@ func TestSampleDeliveryTimeout(t *testing.T) {
 			cfg.MaxShards = 1
 
 			c := NewTestWriteClient(protoMsg)
-			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			m.StoreSeries(recs.Series, 0)
 			m.Start()
 			defer m.Stop()
@@ -478,7 +477,7 @@ func TestShutdown(t *testing.T) {
 				cfg := config.DefaultQueueConfig
 				mcfg := config.DefaultMetadataConfig
 
-				m := newTestQueueManager(t, cfg, mcfg, deadline, c, protoMsg)
+				m := newTestQueueManager(t, cfg, mcfg, deadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 				// Send 2x batch size, so we know it will need at least two sends.
 				n := 2 * config.DefaultQueueConfig.MaxSamplesPerSend
 				recs := testwal.GenerateRecords(recCase{
@@ -506,6 +505,122 @@ func TestShutdown(t *testing.T) {
 	}
 }
 
+func TestSeriesStorage(t *testing.T) {
+	ref1 := chunks.HeadSeriesRef(1)
+	lbls1 := labels.FromStrings("a", "b")
+
+	t.Run("withMeta=false", func(t *testing.T) {
+		s := &seriesStorage{
+			labels:  make(map[chunks.HeadSeriesRef]labels.Labels),
+			dropped: make(map[chunks.HeadSeriesRef]struct{}),
+		}
+
+		// Never-seen ref: not active, not dropped.
+		lbls, meta, active, dropped := s.lookup(ref1)
+		require.False(t, active)
+		require.False(t, dropped)
+		require.Nil(t, meta)
+
+		s.storeLocked(ref1, lbls1)
+		lbls, meta, active, dropped = s.lookup(ref1)
+		require.True(t, active)
+		require.False(t, dropped)
+		testutil.RequireEqual(t, lbls1, lbls)
+		require.Nil(t, meta) // withMeta=false never resolves metadata, even after StoreMetadata-style calls would be no-ops.
+
+		// storeMetadataDefinitionLocked/storeSeriesMetadataRefLocked are no-ops.
+		s.storeMetadataDefinitionLocked(1, metadata.Metadata{Help: "should be ignored"})
+		s.storeSeriesMetadataRefLocked(ref1, 1)
+		_, meta, _, _ = s.lookup(ref1)
+		require.Nil(t, meta)
+
+		s.dropLocked(ref1)
+		_, _, active, dropped = s.lookup(ref1)
+		require.False(t, active)
+		require.True(t, dropped)
+
+		s.deleteLocked(ref1)
+		_, _, active, dropped = s.lookup(ref1)
+		require.False(t, active)
+		require.False(t, dropped)
+	})
+
+	t.Run("withMeta=true", func(t *testing.T) {
+		s := &seriesStorage{
+			withMeta:     true,
+			entries:      make(map[chunks.HeadSeriesRef]seriesEntry),
+			metadataDefs: make(map[record.MetadataRef]*metadata.Metadata),
+			dropped:      make(map[chunks.HeadSeriesRef]struct{}),
+		}
+		m1 := metadata.Metadata{Type: model.MetricTypeCounter, Help: "first"}
+		m2 := metadata.Metadata{Type: model.MetricTypeCounter, Help: "second"}
+
+		// A series can get its MetadataRef before StoreSeries ever sees it (a
+		// SeriesMetadataRef record can't outrun StoreSeries in practice, since
+		// Head only ever produces one after the series already exists, but the
+		// method must still degrade safely if it somehow did): storeSeriesMetadataRefLocked
+		// is then a no-op, matching storeMetadataLocked's documented behavior of
+		// not storing metadata for series it doesn't know about yet.
+		s.storeMetadataDefinitionLocked(1, m1)
+		s.storeSeriesMetadataRefLocked(ref1, 1)
+		_, meta, active, _ := s.lookup(ref1)
+		require.False(t, active)
+		require.Nil(t, meta)
+
+		s.storeLocked(ref1, lbls1)
+		lbls, meta, active, dropped := s.lookup(ref1)
+		require.True(t, active)
+		require.False(t, dropped)
+		testutil.RequireEqual(t, lbls1, lbls)
+		require.Nil(t, meta) // storeLocked doesn't touch metadataRef; none was set while active.
+
+		// Now that the series is active, storeSeriesMetadataRefLocked takes effect.
+		s.storeSeriesMetadataRefLocked(ref1, 1)
+		_, meta, _, _ = s.lookup(ref1)
+		require.Equal(t, &m1, meta)
+
+		// storeLocked preserves the existing metadataRef.
+		s.storeLocked(ref1, lbls1)
+		_, meta, _, _ = s.lookup(ref1)
+		require.Equal(t, &m1, meta)
+
+		// Content is immutable per ref; a changed definition gets a new ref.
+		s.storeMetadataDefinitionLocked(2, m2)
+		s.storeSeriesMetadataRefLocked(ref1, 2)
+		_, meta, _, _ = s.lookup(ref1)
+		require.Equal(t, &m2, meta)
+
+		// pruneUnreferencedMetadataDefsLocked drops the now-unreferenced ref 1,
+		// keeps the still-referenced ref 2.
+		s.pruneUnreferencedMetadataDefsLocked()
+		require.NotContains(t, s.metadataDefs, record.MetadataRef(1))
+		require.Contains(t, s.metadataDefs, record.MetadataRef(2))
+
+		s.dropLocked(ref1)
+		_, _, active, dropped = s.lookup(ref1)
+		require.False(t, active)
+		require.True(t, dropped)
+
+		// dropLocked removes the entry, so its metadataRef is no longer referenced.
+		s.pruneUnreferencedMetadataDefsLocked()
+		require.Empty(t, s.metadataDefs)
+
+		// storeLocked on a previously-dropped ref restores it as active, with no metadataRef.
+		s.storeLocked(ref1, lbls1)
+		_, meta, active, dropped = s.lookup(ref1)
+		require.True(t, active)
+		require.False(t, dropped)
+		require.Nil(t, meta)
+
+		// deleteLocked removes both the active entry and the dropped flag.
+		s.dropLocked(ref1) // move ref1 back to dropped before deleting.
+		s.deleteLocked(ref1)
+		_, _, active, dropped = s.lookup(ref1)
+		require.False(t, active)
+		require.False(t, dropped)
+	})
+}
+
 func TestSeriesReset(t *testing.T) {
 	for _, protoMsg := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
 		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
@@ -516,7 +631,7 @@ func TestSeriesReset(t *testing.T) {
 
 			cfg := config.DefaultQueueConfig
 			mcfg := config.DefaultMetadataConfig
-			m := newTestQueueManager(t, cfg, mcfg, deadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, deadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			for i := range numSegments {
 				series := []record.RefSeries{}
 				metadata := []record.RefMetadata{}
@@ -528,20 +643,23 @@ func TestSeriesReset(t *testing.T) {
 				m.StoreSeries(series, i)
 				m.StoreMetadata(metadata)
 			}
-			require.Len(t, m.seriesLabels, numSegments*numSeries)
-			// V2 stores metadata in seriesMetadataRef/metadataDefs maps for inline sending.
-			// V1 sends metadata separately via MetadataWatcher, so they are not populated.
+			// V2 stores active series in the combined entries+metadataDefs maps for
+			// inline sending. V1 sends metadata separately via MetadataWatcher, so
+			// active series live in the plain labels map instead.
 			if protoMsg == remoteapi.WriteV2MessageType {
-				require.Len(t, m.seriesMetadataRef, numSegments*numSeries)
-				require.Len(t, m.metadataDefs, numSegments*numSeries)
+				require.Len(t, m.series.entries, numSegments*numSeries)
+				require.Len(t, m.series.metadataDefs, numSegments*numSeries)
+			} else {
+				require.Len(t, m.series.labels, numSegments*numSeries)
 			}
 
 			m.SeriesReset(2)
-			require.Len(t, m.seriesLabels, numSegments*numSeries/2)
-			// Verify metadata is also reset for V2
+			// Verify series (and, for V2, metadata) are also reset.
 			if protoMsg == remoteapi.WriteV2MessageType {
-				require.Len(t, m.seriesMetadataRef, numSegments*numSeries/2)
-				require.Len(t, m.metadataDefs, numSegments*numSeries/2)
+				require.Len(t, m.series.entries, numSegments*numSeries/2)
+				require.Len(t, m.series.metadataDefs, numSegments*numSeries/2)
+			} else {
+				require.Len(t, m.series.labels, numSegments*numSeries/2)
 			}
 		})
 	}
@@ -565,7 +683,7 @@ func TestReshard(t *testing.T) {
 			cfg.MaxShards = 1
 
 			c := NewTestWriteClient(protoMsg)
-			m := newTestQueueManager(t, cfg, config.DefaultMetadataConfig, defaultFlushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, config.DefaultMetadataConfig, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			c.expectSamples(recs.Samples, recs.Series)
 			m.StoreSeries(recs.Series, 0)
 
@@ -605,7 +723,7 @@ func TestReshardRaceWithStop(t *testing.T) {
 			exitCh := make(chan struct{})
 			go func() {
 				for {
-					m = newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg)
+					m = newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 
 					m.Start()
 					h.Unlock()
@@ -647,7 +765,7 @@ func TestReshardPartialBatch(t *testing.T) {
 			flushDeadline := 10 * time.Millisecond
 			cfg.BatchSendDeadline = model.Duration(batchSendDeadline)
 
-			m := newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			m.StoreSeries(recs.Series, 0)
 
 			m.Start()
@@ -697,7 +815,7 @@ func TestQueueFilledDeadlock(t *testing.T) {
 			batchSendDeadline := time.Millisecond
 			cfg.BatchSendDeadline = model.Duration(batchSendDeadline)
 
-			m := newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			m.StoreSeries(recs.Series, 0)
 			m.Start()
 			defer m.Stop()
@@ -818,7 +936,7 @@ func TestDisableReshardOnRetry(t *testing.T) {
 		}
 	)
 
-	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, nil, false)
+	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, false, false, remoteapi.WriteV1MessageType, nil, false)
 	m.StoreSeries(recs.Series, 0)
 
 	// Attempt to samples while the manager is running. We immediately stop the
@@ -1363,7 +1481,7 @@ func BenchmarkSampleSend(b *testing.B) {
 	// todo: test with new proto type(s)
 	for _, format := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
 		b.Run(string(format), func(b *testing.B) {
-			m := newTestQueueManager(b, cfg, mcfg, defaultFlushDeadline, c, format)
+			m := newTestQueueManager(b, cfg, mcfg, defaultFlushDeadline, c, format, format != remoteapi.WriteV1MessageType)
 			m.StoreSeries(recs.Series, 0)
 
 			// These should be received by the client.
@@ -1426,7 +1544,7 @@ func BenchmarkStoreSeries(b *testing.B) {
 				mcfg := config.DefaultMetadataConfig
 				metrics := newQueueManagerMetrics(nil, "", "")
 
-				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, record.NewBuffersPool(), false)
+				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, false, remoteapi.WriteV1MessageType, record.NewBuffersPool(), false)
 				m.externalLabels = tc.externalLabels
 				m.relabelConfigs = tc.relabelConfigs
 
@@ -1985,7 +2103,7 @@ func TestDropOldTimeSeries(t *testing.T) {
 			mcfg := config.DefaultMetadataConfig
 			cfg.MaxShards = 1
 			cfg.SampleAgeLimit = model.Duration(60 * time.Second)
-			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			m.StoreSeries(series, 0)
 
 			m.Start()
@@ -2029,7 +2147,7 @@ func TestSendSamplesWithBackoffWithSampleAgeLimit(t *testing.T) {
 			metadataCfg.SendInterval = model.Duration(time.Second * 60)
 			metadataCfg.MaxSamplesPerSend = maxSamplesPerSend
 			c := NewTestWriteClient(protoMsg)
-			m := newTestQueueManager(t, cfg, metadataCfg, time.Second, c, protoMsg)
+			m := newTestQueueManager(t, cfg, metadataCfg, time.Second, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 
 			m.Start()
 
@@ -2622,7 +2740,7 @@ func TestAppendHistogramSchemaValidation(t *testing.T) {
 			mcfg := config.DefaultMetadataConfig
 			cfg.MaxShards = 1
 
-			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			m.sendNativeHistograms = true
 
 			// Create series for the histograms
@@ -2776,7 +2894,7 @@ func TestAppendHistogramsWithStartTimestamp(t *testing.T) {
 	mcfg := config.DefaultMetadataConfig
 	cfg.MaxShards = 1
 
-	m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg)
+	m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 	m.sendNativeHistograms = true
 
 	series := []record.RefSeries{

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -346,49 +346,71 @@ func TestMetadataDelivery(t *testing.T) {
 }
 
 func TestWALMetadataDelivery(t *testing.T) {
-	dir := t.TempDir()
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
-	defer s.Close()
-
-	cfg := config.DefaultQueueConfig
-	cfg.BatchSendDeadline = model.Duration(100 * time.Millisecond)
-	cfg.MaxShards = 1
-
-	writeConfig := baseRemoteWriteConfig("http://test-storage.com")
-	writeConfig.QueueConfig = cfg
-	writeConfig.ProtobufMessage = remoteapi.WriteV2MessageType
-
-	conf := &config.Config{
-		GlobalConfig: config.DefaultGlobalConfig,
-		RemoteWriteConfigs: []*config.RemoteWriteConfig{
-			writeConfig,
+	// storeMetadata pushes recs.Metadata into qm using either the pre-MetadataRef
+	// format (StoreMetadata) or the MetadataDefinition/SeriesMetadataRef format
+	// that superseded it; both must resolve to the same metadata at send time.
+	for name, storeMetadata := range map[string]func(qm *QueueManager, recs testwal.Records){
+		"RefMetadata": func(qm *QueueManager, recs testwal.Records) {
+			qm.StoreMetadata(recs.Metadata)
 		},
+		"MetadataDefinition+SeriesMetadataRef": func(qm *QueueManager, recs testwal.Records) {
+			defs := make([]record.RefMetadataDefinition, len(recs.Metadata))
+			refs := make([]record.RefSeriesMetadataRef, len(recs.Metadata))
+			for i, m := range recs.Metadata {
+				ref := record.MetadataRef(i + 1)
+				defs[i] = record.RefMetadataDefinition{Ref: ref, Type: m.Type, Unit: m.Unit, Help: m.Help}
+				refs[i] = record.RefSeriesMetadataRef{Ref: m.Ref, MetadataRef: ref}
+			}
+			qm.StoreMetadataDefinitions(defs)
+			qm.StoreSeriesMetadataRef(refs)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+			defer s.Close()
+
+			cfg := config.DefaultQueueConfig
+			cfg.BatchSendDeadline = model.Duration(100 * time.Millisecond)
+			cfg.MaxShards = 1
+
+			writeConfig := baseRemoteWriteConfig("http://test-storage.com")
+			writeConfig.QueueConfig = cfg
+			writeConfig.ProtobufMessage = remoteapi.WriteV2MessageType
+
+			conf := &config.Config{
+				GlobalConfig: config.DefaultGlobalConfig,
+				RemoteWriteConfigs: []*config.RemoteWriteConfig{
+					writeConfig,
+				},
+			}
+
+			n := 3
+			recs := testwal.GenerateRecords(recCase{Series: n, SamplesPerSeries: n})
+
+			require.NoError(t, s.ApplyConfig(conf))
+			hash, err := toHash(writeConfig)
+			require.NoError(t, err)
+			qm := s.rws.queues[hash]
+
+			c := NewTestWriteClient(remoteapi.WriteV2MessageType)
+			qm.SetClient(c)
+
+			qm.StoreSeries(recs.Series, 0)
+			storeMetadata(qm, recs)
+
+			require.Len(t, qm.seriesLabels, n)
+			require.Len(t, qm.seriesMetadataRef, n)
+
+			c.expectSamples(recs.Samples, recs.Series)
+			c.expectMetadataForBatch(recs.Metadata, recs.Series, recs.Samples, nil, nil, nil)
+			qm.Append(recs.Samples)
+			c.waitForExpectedData(t, 30*time.Second)
+
+			// Metadata is cached state, not a queue item used for shard scaling.
+			require.Equal(t, int64(len(recs.Samples)), qm.dataOut.newEvents.Load())
+		})
 	}
-
-	n := 3
-	recs := testwal.GenerateRecords(recCase{Series: n, SamplesPerSeries: n})
-
-	require.NoError(t, s.ApplyConfig(conf))
-	hash, err := toHash(writeConfig)
-	require.NoError(t, err)
-	qm := s.rws.queues[hash]
-
-	c := NewTestWriteClient(remoteapi.WriteV2MessageType)
-	qm.SetClient(c)
-
-	qm.StoreSeries(recs.Series, 0)
-	qm.StoreMetadata(recs.Metadata)
-
-	require.Len(t, qm.seriesLabels, n)
-	require.Len(t, qm.seriesMetadata, n)
-
-	c.expectSamples(recs.Samples, recs.Series)
-	c.expectMetadataForBatch(recs.Metadata, recs.Series, recs.Samples, nil, nil, nil)
-	qm.Append(recs.Samples)
-	c.waitForExpectedData(t, 30*time.Second)
-
-	// Metadata is cached state, not a queue item used for shard scaling.
-	require.Equal(t, int64(len(recs.Samples)), qm.dataOut.newEvents.Load())
 }
 
 func TestSampleDeliveryTimeout(t *testing.T) {
@@ -507,17 +529,19 @@ func TestSeriesReset(t *testing.T) {
 				m.StoreMetadata(metadata)
 			}
 			require.Len(t, m.seriesLabels, numSegments*numSeries)
-			// V2 stores metadata in seriesMetadata map for inline sending.
-			// V1 sends metadata separately via MetadataWatcher, so seriesMetadata is not populated.
+			// V2 stores metadata in seriesMetadataRef/metadataDefs maps for inline sending.
+			// V1 sends metadata separately via MetadataWatcher, so they are not populated.
 			if protoMsg == remoteapi.WriteV2MessageType {
-				require.Len(t, m.seriesMetadata, numSegments*numSeries)
+				require.Len(t, m.seriesMetadataRef, numSegments*numSeries)
+				require.Len(t, m.metadataDefs, numSegments*numSeries)
 			}
 
 			m.SeriesReset(2)
 			require.Len(t, m.seriesLabels, numSegments*numSeries/2)
 			// Verify metadata is also reset for V2
 			if protoMsg == remoteapi.WriteV2MessageType {
-				require.Len(t, m.seriesMetadata, numSegments*numSeries/2)
+				require.Len(t, m.seriesMetadataRef, numSegments*numSeries/2)
+				require.Len(t, m.metadataDefs, numSegments*numSeries/2)
 			}
 		})
 	}

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -93,7 +93,7 @@ func TestNoDuplicateReadConfigs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
-			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 			conf := &config.Config{
 				GlobalConfig:      config.DefaultGlobalConfig,
 				RemoteReadConfigs: tc.cfgs,

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -66,7 +66,7 @@ type Storage struct {
 var _ storage.Storage = &Storage{}
 
 // NewStorage returns a remote.Storage.
-func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeCallback, walDir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels bool) *Storage {
+func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeCallback, walDir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels, enableMetadataWALRecords bool) *Storage {
 	if l == nil {
 		l = promslog.NewNopLogger()
 	}
@@ -78,7 +78,7 @@ func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeC
 		deduper:                deduper,
 		localStartTimeCallback: stCallback,
 	}
-	s.rws = NewWriteStorage(s.logger, reg, walDir, flushDeadline, sm, enableTypeAndUnitLabels)
+	s.rws = NewWriteStorage(s.logger, reg, walDir, flushDeadline, sm, enableTypeAndUnitLabels, enableMetadataWALRecords)
 	return s
 }
 

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -29,7 +29,7 @@ import (
 func TestStorageLifecycle(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -56,7 +56,7 @@ func TestStorageLifecycle(t *testing.T) {
 func TestUpdateRemoteReadConfigs(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
@@ -77,7 +77,7 @@ func TestUpdateRemoteReadConfigs(t *testing.T) {
 func TestFilterExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{
@@ -102,7 +102,7 @@ func TestFilterExternalLabels(t *testing.T) {
 func TestIgnoreExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{
@@ -159,7 +159,7 @@ func baseRemoteReadConfig(host string) *config.RemoteReadConfig {
 // ApplyConfig runs concurrently with Notify
 // See https://github.com/prometheus/prometheus/issues/12747
 func TestWriteStorageApplyConfigsDuringCommit(t *testing.T) {
-	s := NewStorage(nil, nil, nil, t.TempDir(), defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, t.TempDir(), defaultFlushDeadline, nil, false, false)
 
 	var wg sync.WaitGroup
 	wg.Add(2000)

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -76,12 +76,13 @@ type WriteStorage struct {
 	recordBuf *record.BuffersPool
 
 	// For timestampTracker.
-	highestTimestamp        *maxTimestamp
-	enableTypeAndUnitLabels bool
+	highestTimestamp         *maxTimestamp
+	enableTypeAndUnitLabels  bool
+	enableMetadataWALRecords bool
 }
 
 // NewWriteStorage creates and runs a WriteStorage.
-func NewWriteStorage(logger *slog.Logger, reg prometheus.Registerer, dir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels bool) *WriteStorage {
+func NewWriteStorage(logger *slog.Logger, reg prometheus.Registerer, dir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels, enableMetadataWALRecords bool) *WriteStorage {
 	if logger == nil {
 		logger = promslog.NewNopLogger()
 	}
@@ -105,8 +106,9 @@ func NewWriteStorage(logger *slog.Logger, reg prometheus.Registerer, dir string,
 				Help:      "Highest timestamp that has come into the remote storage via the Appender interface, in seconds since epoch. Initialized to 0 when no data has been received yet. Deprecated, check prometheus_remote_storage_queue_highest_timestamp_seconds which is more accurate.",
 			}),
 		},
-		recordBuf:               record.NewBuffersPool(),
-		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
+		recordBuf:                record.NewBuffersPool(),
+		enableTypeAndUnitLabels:  enableTypeAndUnitLabels,
+		enableMetadataWALRecords: enableMetadataWALRecords,
 	}
 	if reg != nil {
 		reg.MustRegister(rws.highestTimestamp)
@@ -218,6 +220,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rwConf.SendExemplars,
 			rwConf.SendNativeHistograms,
 			rws.enableTypeAndUnitLabels,
+			rws.enableMetadataWALRecords,
 			rwConf.ProtobufMessage,
 			rws.recordBuf,
 			rwConf.FailedRequestLogging,

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -100,7 +100,7 @@ func TestWriteStorageApplyConfig_NoDuplicateWriteConfigs(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false)
+			s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false, false)
 			conf := &config.Config{
 				GlobalConfig:       config.DefaultGlobalConfig,
 				RemoteWriteConfigs: tc.cfgs,
@@ -126,7 +126,7 @@ func TestWriteStorageApplyConfig_RestartOnNameChange(t *testing.T) {
 	hash, err := toHash(cfg)
 	require.NoError(t, err)
 
-	s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false)
+	s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false, false)
 
 	conf := &config.Config{
 		GlobalConfig:       config.DefaultGlobalConfig,
@@ -148,7 +148,7 @@ func TestWriteStorageApplyConfig_RestartOnNameChange(t *testing.T) {
 func TestWriteStorageApplyConfig_UpdateWithRegisterer(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Millisecond, nil, false)
+	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Millisecond, nil, false, false)
 	c1 := &config.RemoteWriteConfig{
 		Name: "named",
 		URL: &common_config.URL{
@@ -189,7 +189,7 @@ func TestWriteStorageApplyConfig_UpdateWithRegisterer(t *testing.T) {
 func TestWriteStorageApplyConfig_Lifecycle(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false, false)
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -205,7 +205,7 @@ func TestWriteStorageApplyConfig_Lifecycle(t *testing.T) {
 func TestWriteStorageApplyConfig_UpdateExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Second, nil, false)
+	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Second, nil, false, false)
 
 	externalLabels := labels.FromStrings("external", "true")
 	conf := &config.Config{
@@ -233,7 +233,7 @@ func TestWriteStorageApplyConfig_UpdateExternalLabels(t *testing.T) {
 func TestWriteStorageApplyConfig_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false, false)
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -257,7 +257,7 @@ func TestWriteStorageApplyConfig_Idempotent(t *testing.T) {
 func TestWriteStorageApplyConfig_PartialUpdate(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false, false)
 
 	c0 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(10 * time.Second),
@@ -369,7 +369,7 @@ func TestWriteStorage_CanRegisterMetricsAfterClosing(t *testing.T) {
 	dir := t.TempDir()
 	reg := prometheus.NewPedanticRegistry()
 
-	s := NewWriteStorage(nil, reg, dir, time.Millisecond, nil, false)
+	s := NewWriteStorage(nil, reg, dir, time.Millisecond, nil, false, false)
 	require.NoError(t, s.Close())
-	require.NotPanics(t, func() { NewWriteStorage(nil, reg, dir, time.Millisecond, nil, false) })
+	require.NotPanics(t, func() { NewWriteStorage(nil, reg, dir, time.Millisecond, nil, false, false) })
 }

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -51,7 +51,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 		rs := remote.NewStorage(
 			promslog.NewNopLogger(), nil,
 			startTime, storageDir,
-			30*time.Second, nil, false,
+			30*time.Second, nil, false, false,
 		)
 		defer rs.Close()
 
@@ -309,7 +309,7 @@ func benchCheckpoint(b *testing.B, p benchCheckpointParams) {
 	rs := remote.NewStorage(
 		promslog.NewNopLogger(), nil,
 		startTime, p.storageDir,
-		30*time.Second, nil, false,
+		30*time.Second, nil, false, false,
 	)
 	defer rs.Close()
 

--- a/tsdb/agent/db_append_v2_test.go
+++ b/tsdb/agent/db_append_v2_test.go
@@ -789,7 +789,7 @@ func TestWALReplay_AppendV2(t *testing.T) {
 
 func Test_ExistingWAL_NextRef_AppendV2(t *testing.T) {
 	dbDir := t.TempDir()
-	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false)
+	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false, false)
 	defer func() {
 		require.NoError(t, rs.Close())
 	}()

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -94,7 +94,7 @@ func createTestAgentDB(t testing.TB, reg prometheus.Registerer, opts *Options) *
 
 	dbDir := t.TempDir()
 
-	rs := remote.NewStorage(promslog.NewNopLogger(), reg, startTime, dbDir, time.Second*30, nil, false)
+	rs := remote.NewStorage(promslog.NewNopLogger(), reg, startTime, dbDir, time.Second*30, nil, false, false)
 	t.Cleanup(func() {
 		require.NoError(t, rs.Close())
 	})
@@ -798,7 +798,7 @@ func TestLockfile(t *testing.T) {
 	tsdbutil.TestDirLockerUsage(t, func(t *testing.T, data string, createLock bool) (*tsdbutil.DirLocker, testutil.Closer) {
 		logger := promslog.NewNopLogger()
 		reg := prometheus.NewRegistry()
-		rs := remote.NewStorage(logger, reg, startTime, data, time.Second*30, nil, false)
+		rs := remote.NewStorage(logger, reg, startTime, data, time.Second*30, nil, false, false)
 		t.Cleanup(func() {
 			require.NoError(t, rs.Close())
 		})
@@ -818,7 +818,7 @@ func TestLockfile(t *testing.T) {
 
 func Test_ExistingWAL_NextRef(t *testing.T) {
 	dbDir := t.TempDir()
-	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false)
+	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false, false)
 	defer func() {
 		require.NoError(t, rs.Close())
 	}()
@@ -1379,7 +1379,7 @@ func TestDBStartTimestampSamplesIngestion(t *testing.T) {
 func TestDuplicateSeriesRefsByHash(t *testing.T) {
 	dbDir := t.TempDir()
 	opts := DefaultOptions()
-	rs1 := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false)
+	rs1 := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false, false)
 	db, err := Open(promslog.NewNopLogger(), nil, rs1, dbDir, opts)
 	require.NoError(t, err)
 
@@ -1437,7 +1437,7 @@ func TestDuplicateSeriesRefsByHash(t *testing.T) {
 	require.NoError(t, db.Close())
 	require.NoError(t, rs1.Close())
 
-	rs2 := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false)
+	rs2 := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false, false)
 	t.Cleanup(func() { require.NoError(t, rs2.Close()) })
 	db, err = Open(promslog.NewNopLogger(), nil, rs2, dbDir, opts)
 	require.NoError(t, err)

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -3444,25 +3444,45 @@ func TestMetadataInWAL_AppenderV2(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, app.Commit())
 
-	// Read the WAL to see if the disk storage format is correct.
+	// Read the WAL to see if the disk storage format is correct: metadata content
+	// is deduplicated behind MetadataDefinition records, and series point at that
+	// content via SeriesMetadataRef records.
 	recs := readTestWAL(t, path.Join(db.Dir(), "wal"))
-	var gotMetadataBlocks [][]record.RefMetadata
+	var gotMetadataDefBlocks [][]record.RefMetadataDefinition
+	var gotSeriesMetadataRefBlocks [][]record.RefSeriesMetadataRef
 	for _, rec := range recs {
-		if mr, ok := rec.([]record.RefMetadata); ok {
-			gotMetadataBlocks = append(gotMetadataBlocks, mr)
+		switch r := rec.(type) {
+		case []record.RefMetadataDefinition:
+			gotMetadataDefBlocks = append(gotMetadataDefBlocks, r)
+		case []record.RefSeriesMetadataRef:
+			gotSeriesMetadataRefBlocks = append(gotSeriesMetadataRefBlocks, r)
 		}
 	}
 
-	expectedMetadata := []record.RefMetadata{
+	// m1, m2, m3 are new content the first time they're seen (refs 1-3). The
+	// second batch repeats m1 for s1 (no-op, same ref already assigned), sees
+	// m4 for the first time (ref 4), and sees m5 for the first time (ref 5).
+	expectedMetadataDefs := []record.RefMetadataDefinition{
 		{Ref: 1, Type: record.GetMetricType(m1.Type), Unit: m1.Unit, Help: m1.Help},
 		{Ref: 2, Type: record.GetMetricType(m2.Type), Unit: m2.Unit, Help: m2.Help},
 		{Ref: 3, Type: record.GetMetricType(m3.Type), Unit: m3.Unit, Help: m3.Help},
 		{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
-		{Ref: 2, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
+		{Ref: 5, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
 	}
-	require.Len(t, gotMetadataBlocks, 2)
-	require.Equal(t, expectedMetadata[:3], gotMetadataBlocks[0])
-	require.Equal(t, expectedMetadata[3:], gotMetadataBlocks[1])
+	require.Len(t, gotMetadataDefBlocks, 2)
+	require.Equal(t, expectedMetadataDefs[:3], gotMetadataDefBlocks[0])
+	require.Equal(t, expectedMetadataDefs[3:], gotMetadataDefBlocks[1])
+
+	expectedSeriesMetadataRefs := []record.RefSeriesMetadataRef{
+		{Ref: 1, MetadataRef: 1}, // s1
+		{Ref: 2, MetadataRef: 2}, // s2
+		{Ref: 3, MetadataRef: 3}, // s3
+		{Ref: 4, MetadataRef: 4}, // s4
+		{Ref: 2, MetadataRef: 5}, // s2, changed to m5
+	}
+	require.Len(t, gotSeriesMetadataRefBlocks, 2)
+	require.Equal(t, expectedSeriesMetadataRefs[:3], gotSeriesMetadataRefBlocks[0])
+	require.Equal(t, expectedSeriesMetadataRefs[3:], gotSeriesMetadataRefBlocks[1])
 }
 
 func TestMetadataCheckpointingOnlyKeepsLatestEntry_AppendV2(t *testing.T) {
@@ -3553,26 +3573,39 @@ func TestMetadataCheckpointingOnlyKeepsLatestEntry_AppendV2(t *testing.T) {
 
 			// Read in checkpoint and WAL.
 			recs := readTestWAL(t, cdir)
-			var gotMetadataBlocks [][]record.RefMetadata
+			var gotSeriesMetadataRefBlocks [][]record.RefSeriesMetadataRef
+			var gotMetadataDefBlocks [][]record.RefMetadataDefinition
 			for _, rec := range recs {
-				if mr, ok := rec.([]record.RefMetadata); ok {
-					gotMetadataBlocks = append(gotMetadataBlocks, mr)
+				switch r := rec.(type) {
+				case []record.RefSeriesMetadataRef:
+					gotSeriesMetadataRefBlocks = append(gotSeriesMetadataRefBlocks, r)
+				case []record.RefMetadataDefinition:
+					gotMetadataDefBlocks = append(gotMetadataDefBlocks, r)
 				}
 			}
 
-			// There should only be 1 metadata block present, with only the latest
-			// metadata kept around.
-			wantMetadata := []record.RefMetadata{
-				{Ref: 1, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
-				{Ref: 2, Type: record.GetMetricType(m6.Type), Unit: m6.Unit, Help: m6.Help},
-				{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
+			// There should only be 1 block of each present, with only the latest
+			// metadata ref kept per series (s3 dropped entirely per keep()), and
+			// only the MetadataDefinitions still referenced by a kept series.
+			wantSeriesMetadataRefs := []record.RefSeriesMetadataRef{
+				{Ref: 1, MetadataRef: 5}, // s1, ends on m5
+				{Ref: 2, MetadataRef: 6}, // s2, ends on m6
+				{Ref: 4, MetadataRef: 4}, // s4, ends on m4
 			}
-			require.Len(t, gotMetadataBlocks, 1)
-			require.Len(t, gotMetadataBlocks[0], 3)
-			gotMetadataBlock := gotMetadataBlocks[0]
+			require.Len(t, gotSeriesMetadataRefBlocks, 1)
+			gotSeriesMetadataRefBlock := gotSeriesMetadataRefBlocks[0]
+			sort.Slice(gotSeriesMetadataRefBlock, func(i, j int) bool { return gotSeriesMetadataRefBlock[i].Ref < gotSeriesMetadataRefBlock[j].Ref })
+			require.Equal(t, wantSeriesMetadataRefs, gotSeriesMetadataRefBlock)
 
-			sort.Slice(gotMetadataBlock, func(i, j int) bool { return gotMetadataBlock[i].Ref < gotMetadataBlock[j].Ref })
-			require.Equal(t, wantMetadata, gotMetadataBlock)
+			wantMetadataDefs := []record.RefMetadataDefinition{
+				{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
+				{Ref: 5, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
+				{Ref: 6, Type: record.GetMetricType(m6.Type), Unit: m6.Unit, Help: m6.Help},
+			}
+			require.Len(t, gotMetadataDefBlocks, 1)
+			gotMetadataDefBlock := gotMetadataDefBlocks[0]
+			sort.Slice(gotMetadataDefBlock, func(i, j int) bool { return gotMetadataDefBlock[i].Ref < gotMetadataDefBlock[j].Ref })
+			require.Equal(t, wantMetadataDefs, gotMetadataDefBlock)
 			require.NoError(t, hb.Close())
 		})
 	}
@@ -3612,10 +3645,10 @@ func TestMetadataAssertInMemoryData_AppendV2(t *testing.T) {
 	series2 := db.head.series.getByHash(s2.Hash(), s2)
 	series3 := db.head.series.getByHash(s3.Hash(), s3)
 	series4 := db.head.series.getByHash(s4.Hash(), s4)
-	require.Equal(t, *series1.meta, m1)
-	require.Equal(t, *series2.meta, m2)
-	require.Equal(t, *series3.meta, m3)
-	require.Nil(t, series4.meta)
+	requireSeriesMetadataEqual(t, db.head, series1, m1)
+	requireSeriesMetadataEqual(t, db.head, series2, m2)
+	requireSeriesMetadataEqual(t, db.head, series3, m3)
+	requireNoSeriesMetadata(t, db.head, series4)
 
 	// Add a replicated metadata entry to the first series,
 	// a changed metadata entry to the second series,
@@ -3637,10 +3670,10 @@ func TestMetadataAssertInMemoryData_AppendV2(t *testing.T) {
 	series2 = db.head.series.getByHash(s2.Hash(), s2)
 	series3 = db.head.series.getByHash(s3.Hash(), s3)
 	series4 = db.head.series.getByHash(s4.Hash(), s4)
-	require.Equal(t, *series1.meta, m1)
-	require.Equal(t, *series2.meta, m5)
-	require.Equal(t, *series3.meta, m3)
-	require.Equal(t, *series4.meta, m4)
+	requireSeriesMetadataEqual(t, db.head, series1, m1)
+	requireSeriesMetadataEqual(t, db.head, series2, m5)
+	requireSeriesMetadataEqual(t, db.head, series3, m3)
+	requireSeriesMetadataEqual(t, db.head, series4, m4)
 
 	require.NoError(t, db.Close())
 
@@ -3655,10 +3688,10 @@ func TestMetadataAssertInMemoryData_AppendV2(t *testing.T) {
 	_, err = reopenDB.head.wal.Size()
 	require.NoError(t, err)
 
-	require.Equal(t, *reopenDB.head.series.getByHash(s1.Hash(), s1).meta, m1)
-	require.Equal(t, *reopenDB.head.series.getByHash(s2.Hash(), s2).meta, m5)
-	require.Equal(t, *reopenDB.head.series.getByHash(s3.Hash(), s3).meta, m3)
-	require.Equal(t, *reopenDB.head.series.getByHash(s4.Hash(), s4).meta, m4)
+	requireSeriesMetadataEqual(t, reopenDB.head, reopenDB.head.series.getByHash(s1.Hash(), s1), m1)
+	requireSeriesMetadataEqual(t, reopenDB.head, reopenDB.head.series.getByHash(s2.Hash(), s2), m5)
+	requireSeriesMetadataEqual(t, reopenDB.head, reopenDB.head.series.getByHash(s3.Hash(), s3), m3)
+	requireSeriesMetadataEqual(t, reopenDB.head, reopenDB.head.series.getByHash(s4.Hash(), s4), m4)
 }
 
 // TestMultipleEncodingsCommitOrder mainly serves to demonstrate when happens when committing a batch of samples for the

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -5028,25 +5028,45 @@ func TestMetadataInWAL(t *testing.T) {
 	updateMetadata(t, app, s2, m5)
 	require.NoError(t, app.Commit())
 
-	// Read the WAL to see if the disk storage format is correct.
+	// Read the WAL to see if the disk storage format is correct: metadata content
+	// is deduplicated behind MetadataDefinition records, and series point at that
+	// content via SeriesMetadataRef records.
 	recs := readTestWAL(t, path.Join(db.Dir(), "wal"))
-	var gotMetadataBlocks [][]record.RefMetadata
+	var gotMetadataDefBlocks [][]record.RefMetadataDefinition
+	var gotSeriesMetadataRefBlocks [][]record.RefSeriesMetadataRef
 	for _, rec := range recs {
-		if mr, ok := rec.([]record.RefMetadata); ok {
-			gotMetadataBlocks = append(gotMetadataBlocks, mr)
+		switch r := rec.(type) {
+		case []record.RefMetadataDefinition:
+			gotMetadataDefBlocks = append(gotMetadataDefBlocks, r)
+		case []record.RefSeriesMetadataRef:
+			gotSeriesMetadataRefBlocks = append(gotSeriesMetadataRefBlocks, r)
 		}
 	}
 
-	expectedMetadata := []record.RefMetadata{
+	// m1, m2, m3 are new content the first time they're seen (refs 1-3). The
+	// second batch repeats m1 for s1 (no-op, same ref already assigned), sees
+	// m4 for the first time (ref 4), and sees m5 for the first time (ref 5).
+	expectedMetadataDefs := []record.RefMetadataDefinition{
 		{Ref: 1, Type: record.GetMetricType(m1.Type), Unit: m1.Unit, Help: m1.Help},
 		{Ref: 2, Type: record.GetMetricType(m2.Type), Unit: m2.Unit, Help: m2.Help},
 		{Ref: 3, Type: record.GetMetricType(m3.Type), Unit: m3.Unit, Help: m3.Help},
 		{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
-		{Ref: 2, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
+		{Ref: 5, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
 	}
-	require.Len(t, gotMetadataBlocks, 2)
-	require.Equal(t, expectedMetadata[:3], gotMetadataBlocks[0])
-	require.Equal(t, expectedMetadata[3:], gotMetadataBlocks[1])
+	require.Len(t, gotMetadataDefBlocks, 2)
+	require.Equal(t, expectedMetadataDefs[:3], gotMetadataDefBlocks[0])
+	require.Equal(t, expectedMetadataDefs[3:], gotMetadataDefBlocks[1])
+
+	expectedSeriesMetadataRefs := []record.RefSeriesMetadataRef{
+		{Ref: 1, MetadataRef: 1}, // s1
+		{Ref: 2, MetadataRef: 2}, // s2
+		{Ref: 3, MetadataRef: 3}, // s3
+		{Ref: 4, MetadataRef: 4}, // s4
+		{Ref: 2, MetadataRef: 5}, // s2, changed to m5
+	}
+	require.Len(t, gotSeriesMetadataRefBlocks, 2)
+	require.Equal(t, expectedSeriesMetadataRefs[:3], gotSeriesMetadataRefBlocks[0])
+	require.Equal(t, expectedSeriesMetadataRefs[3:], gotSeriesMetadataRefBlocks[1])
 }
 
 func TestMetadataCheckpointingOnlyKeepsLatestEntry(t *testing.T) {
@@ -5132,26 +5152,39 @@ func TestMetadataCheckpointingOnlyKeepsLatestEntry(t *testing.T) {
 
 			// Read in checkpoint and WAL.
 			recs := readTestWAL(t, cdir)
-			var gotMetadataBlocks [][]record.RefMetadata
+			var gotSeriesMetadataRefBlocks [][]record.RefSeriesMetadataRef
+			var gotMetadataDefBlocks [][]record.RefMetadataDefinition
 			for _, rec := range recs {
-				if mr, ok := rec.([]record.RefMetadata); ok {
-					gotMetadataBlocks = append(gotMetadataBlocks, mr)
+				switch r := rec.(type) {
+				case []record.RefSeriesMetadataRef:
+					gotSeriesMetadataRefBlocks = append(gotSeriesMetadataRefBlocks, r)
+				case []record.RefMetadataDefinition:
+					gotMetadataDefBlocks = append(gotMetadataDefBlocks, r)
 				}
 			}
 
-			// There should only be 1 metadata block present, with only the latest
-			// metadata kept around.
-			wantMetadata := []record.RefMetadata{
-				{Ref: 1, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
-				{Ref: 2, Type: record.GetMetricType(m6.Type), Unit: m6.Unit, Help: m6.Help},
-				{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
+			// There should only be 1 block of each present, with only the latest
+			// metadata ref kept per series (s3 dropped entirely per keep()), and
+			// only the MetadataDefinitions still referenced by a kept series.
+			wantSeriesMetadataRefs := []record.RefSeriesMetadataRef{
+				{Ref: 1, MetadataRef: 5}, // s1, ends on m5
+				{Ref: 2, MetadataRef: 6}, // s2, ends on m6
+				{Ref: 4, MetadataRef: 4}, // s4, ends on m4
 			}
-			require.Len(t, gotMetadataBlocks, 1)
-			require.Len(t, gotMetadataBlocks[0], 3)
-			gotMetadataBlock := gotMetadataBlocks[0]
+			require.Len(t, gotSeriesMetadataRefBlocks, 1)
+			gotSeriesMetadataRefBlock := gotSeriesMetadataRefBlocks[0]
+			sort.Slice(gotSeriesMetadataRefBlock, func(i, j int) bool { return gotSeriesMetadataRefBlock[i].Ref < gotSeriesMetadataRefBlock[j].Ref })
+			require.Equal(t, wantSeriesMetadataRefs, gotSeriesMetadataRefBlock)
 
-			sort.Slice(gotMetadataBlock, func(i, j int) bool { return gotMetadataBlock[i].Ref < gotMetadataBlock[j].Ref })
-			require.Equal(t, wantMetadata, gotMetadataBlock)
+			wantMetadataDefs := []record.RefMetadataDefinition{
+				{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
+				{Ref: 5, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
+				{Ref: 6, Type: record.GetMetricType(m6.Type), Unit: m6.Unit, Help: m6.Help},
+			}
+			require.Len(t, gotMetadataDefBlocks, 1)
+			gotMetadataDefBlock := gotMetadataDefBlocks[0]
+			sort.Slice(gotMetadataDefBlock, func(i, j int) bool { return gotMetadataDefBlock[i].Ref < gotMetadataDefBlock[j].Ref })
+			require.Equal(t, wantMetadataDefs, gotMetadataDefBlock)
 			require.NoError(t, hb.Close())
 		})
 	}
@@ -5194,10 +5227,10 @@ func TestMetadataAssertInMemoryData(t *testing.T) {
 	series2 := db.head.series.getByHash(s2.Hash(), s2)
 	series3 := db.head.series.getByHash(s3.Hash(), s3)
 	series4 := db.head.series.getByHash(s4.Hash(), s4)
-	require.Equal(t, *series1.meta, m1)
-	require.Equal(t, *series2.meta, m2)
-	require.Equal(t, *series3.meta, m3)
-	require.Nil(t, series4.meta)
+	requireSeriesMetadataEqual(t, db.head, series1, m1)
+	requireSeriesMetadataEqual(t, db.head, series2, m2)
+	requireSeriesMetadataEqual(t, db.head, series3, m3)
+	requireNoSeriesMetadata(t, db.head, series4)
 
 	// Add a replicated metadata entry to the first series,
 	// a changed metadata entry to the second series,
@@ -5215,10 +5248,10 @@ func TestMetadataAssertInMemoryData(t *testing.T) {
 	series2 = db.head.series.getByHash(s2.Hash(), s2)
 	series3 = db.head.series.getByHash(s3.Hash(), s3)
 	series4 = db.head.series.getByHash(s4.Hash(), s4)
-	require.Equal(t, *series1.meta, m1)
-	require.Equal(t, *series2.meta, m5)
-	require.Equal(t, *series3.meta, m3)
-	require.Equal(t, *series4.meta, m4)
+	requireSeriesMetadataEqual(t, db.head, series1, m1)
+	requireSeriesMetadataEqual(t, db.head, series2, m5)
+	requireSeriesMetadataEqual(t, db.head, series3, m3)
+	requireSeriesMetadataEqual(t, db.head, series4, m4)
 
 	require.NoError(t, db.Close())
 
@@ -5228,10 +5261,10 @@ func TestMetadataAssertInMemoryData(t *testing.T) {
 	_, err := db.head.wal.Size()
 	require.NoError(t, err)
 
-	require.Equal(t, *db.head.series.getByHash(s1.Hash(), s1).meta, m1)
-	require.Equal(t, *db.head.series.getByHash(s2.Hash(), s2).meta, m5)
-	require.Equal(t, *db.head.series.getByHash(s3.Hash(), s3).meta, m3)
-	require.Equal(t, *db.head.series.getByHash(s4.Hash(), s4).meta, m4)
+	requireSeriesMetadataEqual(t, db.head, db.head.series.getByHash(s1.Hash(), s1), m1)
+	requireSeriesMetadataEqual(t, db.head, db.head.series.getByHash(s2.Hash(), s2), m5)
+	requireSeriesMetadataEqual(t, db.head, db.head.series.getByHash(s3.Hash(), s3), m3)
+	requireSeriesMetadataEqual(t, db.head, db.head.series.getByHash(s4.Hash(), s4), m4)
 }
 
 // TestMultipleEncodingsCommitOrder mainly serves to demonstrate when happens when committing a batch of samples for the

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"go.uber.org/atomic"
 
@@ -84,6 +85,7 @@ type Head struct {
 	lastWALTruncationTime    atomic.Int64
 	lastMemoryTruncationTime atomic.Int64
 	lastSeriesID             atomic.Uint64
+	lastMetadataID           atomic.Uint64
 	// All the ooo m-map chunks should be after this. This is used to truncate old ooo m-map chunks.
 	// This should be typecasted to chunks.ChunkDiskMapperRef after loading.
 	minOOOMmapRef atomic.Uint64
@@ -95,33 +97,48 @@ type Head struct {
 	exemplars       ExemplarStorage
 	logger          *slog.Logger
 	// TODO(bwplotka): Consider using record.Pools that's reused with WAL watchers.
-	refSeriesPool       zeropool.Pool[[]record.RefSeries]
-	floatsPool          zeropool.Pool[[]record.RefSample]
-	exemplarsPool       zeropool.Pool[[]exemplarWithSeriesRef]
-	histogramsPool      zeropool.Pool[[]record.RefHistogramSample]
-	floatHistogramsPool zeropool.Pool[[]record.RefFloatHistogramSample]
-	metadataPool        zeropool.Pool[[]record.RefMetadata]
-	seriesPool          zeropool.Pool[[]*memSeries]
-	typeMapPool         zeropool.Pool[map[chunks.HeadSeriesRef]sampleType]
-	bytesPool           zeropool.Pool[[]byte]
-	memChunkPool        sync.Pool
+	refSeriesPool          zeropool.Pool[[]record.RefSeries]
+	floatsPool             zeropool.Pool[[]record.RefSample]
+	exemplarsPool          zeropool.Pool[[]exemplarWithSeriesRef]
+	histogramsPool         zeropool.Pool[[]record.RefHistogramSample]
+	floatHistogramsPool    zeropool.Pool[[]record.RefFloatHistogramSample]
+	metadataDefsPool       zeropool.Pool[[]record.RefMetadataDefinition]
+	seriesMetadataRefsPool zeropool.Pool[[]record.RefSeriesMetadataRef]
+	seriesPool             zeropool.Pool[[]*memSeries]
+	typeMapPool            zeropool.Pool[map[chunks.HeadSeriesRef]sampleType]
+	bytesPool              zeropool.Pool[[]byte]
+	memChunkPool           sync.Pool
 
 	// These pools are only used during WAL/WBL replay and are reset at the end.
 	// NOTE: Adjust resetWLReplayResources() upon changes to the pools.
-	wlReplaySeriesPool          zeropool.Pool[[]record.RefSeries]
-	wlReplaySamplesPool         zeropool.Pool[[]record.RefSample]
-	wlReplaytStonesPool         zeropool.Pool[[]tombstones.Stone]
-	wlReplayExemplarsPool       zeropool.Pool[[]record.RefExemplar]
-	wlReplayHistogramsPool      zeropool.Pool[[]record.RefHistogramSample]
-	wlReplayFloatHistogramsPool zeropool.Pool[[]record.RefFloatHistogramSample]
-	wlReplayMetadataPool        zeropool.Pool[[]record.RefMetadata]
-	wlReplayMmapMarkersPool     zeropool.Pool[[]record.RefMmapMarker]
+	wlReplaySeriesPool             zeropool.Pool[[]record.RefSeries]
+	wlReplaySamplesPool            zeropool.Pool[[]record.RefSample]
+	wlReplaytStonesPool            zeropool.Pool[[]tombstones.Stone]
+	wlReplayExemplarsPool          zeropool.Pool[[]record.RefExemplar]
+	wlReplayHistogramsPool         zeropool.Pool[[]record.RefHistogramSample]
+	wlReplayFloatHistogramsPool    zeropool.Pool[[]record.RefFloatHistogramSample]
+	wlReplayMetadataPool           zeropool.Pool[[]record.RefMetadata] // Decode buffer for the pre-MetadataRef record.Metadata format, kept for replaying WAL segments written before the upgrade.
+	wlReplayMetadataDefsPool       zeropool.Pool[[]record.RefMetadataDefinition]
+	wlReplaySeriesMetadataRefsPool zeropool.Pool[[]record.RefSeriesMetadataRef]
+	wlReplayMmapMarkersPool        zeropool.Pool[[]record.RefMmapMarker]
 
 	// All series addressable by their ID or hash.
 	series *stripeSeries
 
 	walExpiriesMtx sync.Mutex
 	walExpiries    map[chunks.HeadSeriesRef]int64 // Series no longer in the head, and what time they must be kept until.
+
+	// metadataMtx guards the two maps below, which together intern metadata
+	// content (type, unit, help) behind a MetadataRef so that series sharing
+	// identical metadata (e.g. all series of the same metric family) share a
+	// single copy instead of each holding their own. Entries are never
+	// removed while the Head is alive: the map is bounded by the number of
+	// distinct metadata contents ever observed, not by the number of series,
+	// which is the entire point of interning it. Checkpoint GC of refs no
+	// longer used by any live series happens independently in wlog.Checkpoint.
+	metadataMtx          sync.Mutex
+	metadataByRef        map[record.MetadataRef]metadata.Metadata
+	metadataRefByContent map[metadata.Metadata]record.MetadataRef
 
 	// TODO(codesome): Extend MemPostings to return only OOOPostings, Set OOOStatus, ... Like an additional map of ooo postings.
 	postings *index.MemPostings // Postings lists for terms.
@@ -395,6 +412,8 @@ func (h *Head) resetInMemoryState() error {
 	h.postings = index.NewUnorderedMemPostings()
 	h.tombstones = tombstones.NewMemTombstones()
 	h.walExpiries = map[chunks.HeadSeriesRef]int64{}
+	h.metadataByRef = map[record.MetadataRef]metadata.Metadata{}
+	h.metadataRefByContent = map[metadata.Metadata]record.MetadataRef{}
 	h.chunkRange.Store(h.opts.ChunkRange)
 	h.minTime.Store(math.MaxInt64)
 	h.maxTime.Store(math.MinInt64)
@@ -413,6 +432,8 @@ func (h *Head) resetWLReplayResources() {
 	h.wlReplayHistogramsPool = zeropool.Pool[[]record.RefHistogramSample]{}
 	h.wlReplayFloatHistogramsPool = zeropool.Pool[[]record.RefFloatHistogramSample]{}
 	h.wlReplayMetadataPool = zeropool.Pool[[]record.RefMetadata]{}
+	h.wlReplayMetadataDefsPool = zeropool.Pool[[]record.RefMetadataDefinition]{}
+	h.wlReplaySeriesMetadataRefsPool = zeropool.Pool[[]record.RefSeriesMetadataRef]{}
 	h.wlReplayMmapMarkersPool = zeropool.Pool[[]record.RefMmapMarker]{}
 }
 
@@ -1613,6 +1634,50 @@ func (h *Head) updateWALExpiry(id chunks.HeadSeriesRef, keepUntil int64) {
 	defer h.walExpiriesMtx.Unlock()
 
 	h.walExpiries[id] = max(keepUntil, h.walExpiries[id])
+}
+
+// getOrCreateMetadataRef interns m behind a MetadataRef, allocating a new,
+// never-reused ref the first time this exact content is seen. isNew reports
+// whether a ref was just allocated, i.e. whether the caller must log a
+// MetadataDefinition record for it.
+func (h *Head) getOrCreateMetadataRef(m metadata.Metadata) (ref record.MetadataRef, isNew bool) {
+	if m.Type == "" {
+		// Canonicalize so content that's semantically the same, per
+		// metadata.Metadata.Equals, maps to the same ref.
+		m.Type = model.MetricTypeUnknown
+	}
+
+	h.metadataMtx.Lock()
+	defer h.metadataMtx.Unlock()
+
+	if ref, ok := h.metadataRefByContent[m]; ok {
+		return ref, false
+	}
+
+	ref = record.MetadataRef(h.lastMetadataID.Inc())
+	h.metadataByRef[ref] = m
+	h.metadataRefByContent[m] = ref
+	return ref, true
+}
+
+// setMetadataRefDefinition installs a (ref, content) pair read back from the
+// WAL or checkpoint, e.g. during replay, where the ref value is already
+// determined rather than allocated fresh.
+func (h *Head) setMetadataRefDefinition(ref record.MetadataRef, m metadata.Metadata) {
+	h.metadataMtx.Lock()
+	defer h.metadataMtx.Unlock()
+
+	h.metadataByRef[ref] = m
+	h.metadataRefByContent[m] = ref
+}
+
+// getMetadata returns the metadata content associated with ref.
+func (h *Head) getMetadata(ref record.MetadataRef) (metadata.Metadata, bool) {
+	h.metadataMtx.Lock()
+	defer h.metadataMtx.Unlock()
+
+	m, ok := h.metadataByRef[ref]
+	return m, ok
 }
 
 // keepSeriesInWALCheckpointFn returns a function that is used to determine whether a series record should be kept in the checkpoint.
@@ -2877,8 +2942,8 @@ func (s sample) Copy() chunks.Sample {
 // are goroutine safe and it is the caller's responsibility to lock it.
 type memSeries struct {
 	// Members up to the Mutex are not changed after construction, so can be accessed without a lock.
-	ref  chunks.HeadSeriesRef
-	meta *metadata.Metadata
+	ref         chunks.HeadSeriesRef
+	metadataRef record.MetadataRef // MetadataRef of the metadata currently associated with this series, or 0 if none.
 
 	// Series labels hash to use for sharding purposes. The value is always 0 when sharding has not
 	// been explicitly enabled in TSDB.

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -194,6 +194,7 @@ func (h *Head) appender() *headAppender {
 			oooTimeWindow:         h.opts.OutOfOrderTimeWindow.Load(),
 			seriesRefs:            h.getRefSeriesBuffer(),
 			series:                h.getSeriesBuffer(),
+			metadataDefs:          h.getMetadataDefsBuffer(),
 			typesInBatch:          h.getTypeMap(),
 			appendID:              appendID,
 			cleanupAppendIDsBelow: cleanupAppendIDsBelow,
@@ -300,17 +301,29 @@ func (h *Head) putFloatHistogramBuffer(b []record.RefFloatHistogramSample) {
 	h.floatHistogramsPool.Put(b[:0])
 }
 
-func (h *Head) getMetadataBuffer() []record.RefMetadata {
-	b := h.metadataPool.Get()
+func (h *Head) getMetadataDefsBuffer() []record.RefMetadataDefinition {
+	b := h.metadataDefsPool.Get()
 	if b == nil {
-		return make([]record.RefMetadata, 0, 512)
+		return make([]record.RefMetadataDefinition, 0, 8)
 	}
 	return b
 }
 
-func (h *Head) putMetadataBuffer(b []record.RefMetadata) {
+func (h *Head) putMetadataDefsBuffer(b []record.RefMetadataDefinition) {
 	clear(b)
-	h.metadataPool.Put(b[:0])
+	h.metadataDefsPool.Put(b[:0])
+}
+
+func (h *Head) getSeriesMetadataRefsBuffer() []record.RefSeriesMetadataRef {
+	b := h.seriesMetadataRefsPool.Get()
+	if b == nil {
+		return make([]record.RefSeriesMetadataRef, 0, 512)
+	}
+	return b
+}
+
+func (h *Head) putSeriesMetadataRefsBuffer(b []record.RefSeriesMetadataRef) {
+	h.seriesMetadataRefsPool.Put(b[:0])
 }
 
 func (h *Head) getSeriesBuffer() []*memSeries {
@@ -386,8 +399,8 @@ type appendBatch struct {
 	histogramSeries      []*memSeries                     // HistogramSamples series corresponding to the samples held by this appender (using corresponding slice indices - same series may appear more than once).
 	floatHistograms      []record.RefFloatHistogramSample // New float histogram samples held by this appender.
 	floatHistogramSeries []*memSeries                     // FloatHistogramSamples series corresponding to the samples held by this appender (using corresponding slice indices - same series may appear more than once).
-	metadata             []record.RefMetadata             // New metadata held by this appender.
-	metadataSeries       []*memSeries                     // Series corresponding to the metadata held by this appender.
+	seriesMetadataRefs   []record.RefSeriesMetadataRef    // New series-to-MetadataRef associations held by this appender.
+	metadataSeries       []*memSeries                     // Series corresponding to the seriesMetadataRefs held by this appender (using corresponding slice indices).
 	exemplars            []exemplarWithSeriesRef          // New exemplars held by this appender.
 }
 
@@ -405,8 +418,8 @@ func (b *appendBatch) close(h *Head) {
 	b.floatHistograms = nil
 	h.putSeriesBuffer(b.floatHistogramSeries)
 	b.floatHistogramSeries = nil
-	h.putMetadataBuffer(b.metadata)
-	b.metadata = nil
+	h.putSeriesMetadataRefsBuffer(b.seriesMetadataRefs)
+	b.seriesMetadataRefs = nil
 	h.putSeriesBuffer(b.metadataSeries)
 	b.metadataSeries = nil
 	h.putExemplarBuffer(b.exemplars)
@@ -422,6 +435,13 @@ type headAppenderBase struct {
 	seriesRefs []record.RefSeries // New series records held by this appender.
 	series     []*memSeries       // New series held by this appender (using corresponding slices indexes from seriesRefs)
 	batches    []*appendBatch     // Holds all the other data to append. (In regular cases, there should be only one of these.)
+
+	// metadataDefs holds newly-allocated MetadataRef definitions. Like
+	// seriesRefs, this lives outside batches and is always logged, even on
+	// Rollback: getOrCreateMetadataRef interns the ref into the Head
+	// immediately and irreversibly (mirroring series creation), so the WAL
+	// must record it regardless of whether the rest of this append commits.
+	metadataDefs []record.RefMetadataDefinition
 
 	typesInBatch map[chunks.HeadSeriesRef]sampleType // Which (one) sample type each series holds in the most recent batch.
 
@@ -620,7 +640,7 @@ func (a *headAppenderBase) getCurrentBatch(st sampleType, s chunks.HeadSeriesRef
 			histogramSeries:      h.getSeriesBuffer(),
 			floatHistograms:      h.getFloatHistogramBuffer(),
 			floatHistogramSeries: h.getSeriesBuffer(),
-			metadata:             h.getMetadataBuffer(),
+			seriesMetadataRefs:   h.getSeriesMetadataRefsBuffer(),
 			metadataSeries:       h.getSeriesBuffer(),
 		}
 
@@ -1083,22 +1103,41 @@ func (a *headAppender) UpdateMetadata(ref storage.SeriesRef, lset labels.Labels,
 		return 0, fmt.Errorf("unknown series when trying to add metadata with HeadSeriesRef: %d and labels: %s", ref, lset)
 	}
 
-	s.Lock()
-	hasNewMetadata := s.meta == nil || *s.meta != meta
-	s.Unlock()
+	a.updateSeriesMetadata(s, meta)
 
-	if hasNewMetadata {
-		b := a.getCurrentBatch(stNone, s.ref)
-		b.metadata = append(b.metadata, record.RefMetadata{
-			Ref:  s.ref,
+	return ref, nil
+}
+
+// updateSeriesMetadata interns meta behind a MetadataRef and, unless s
+// already points at that ref, buffers the WAL records needed to point it
+// there: a MetadataDefinition the first time this exact content is seen
+// (buffered in a.metadataDefs, see its doc comment for why that must live
+// outside batches), and a SeriesMetadataRef associating s with the ref,
+// applied to s at commit time by commitMetadata.
+func (a *headAppenderBase) updateSeriesMetadata(s *memSeries, meta metadata.Metadata) {
+	ref, isNew := a.head.getOrCreateMetadataRef(meta)
+	if isNew {
+		a.metadataDefs = append(a.metadataDefs, record.RefMetadataDefinition{
+			Ref:  ref,
 			Type: record.GetMetricType(meta.Type),
 			Unit: meta.Unit,
 			Help: meta.Help,
 		})
-		b.metadataSeries = append(b.metadataSeries, s)
 	}
 
-	return ref, nil
+	s.Lock()
+	changed := s.metadataRef != ref
+	s.Unlock()
+	if !changed {
+		return
+	}
+
+	b := a.getCurrentBatch(stNone, s.ref)
+	b.seriesMetadataRefs = append(b.seriesMetadataRefs, record.RefSeriesMetadataRef{
+		Ref:         s.ref,
+		MetadataRef: ref,
+	})
+	b.metadataSeries = append(b.metadataSeries, s)
 }
 
 var _ storage.GetRef = &headAppender{}
@@ -1132,13 +1171,22 @@ func (a *headAppenderBase) log() error {
 			return fmt.Errorf("log series: %w", err)
 		}
 	}
+	if len(a.metadataDefs) > 0 {
+		// Must be logged before any SeriesMetadataRef record can reference these refs.
+		rec = enc.MetadataDefinition(a.metadataDefs, buf)
+		buf = rec[:0]
+
+		if err := a.head.wal.Log(rec); err != nil {
+			return fmt.Errorf("log metadata definitions: %w", err)
+		}
+	}
 	for _, b := range a.batches {
-		if len(b.metadata) > 0 {
-			rec = enc.Metadata(b.metadata, buf)
+		if len(b.seriesMetadataRefs) > 0 {
+			rec = enc.SeriesMetadataRef(b.seriesMetadataRefs, buf)
 			buf = rec[:0]
 
 			if err := a.head.wal.Log(rec); err != nil {
-				return fmt.Errorf("log metadata: %w", err)
+				return fmt.Errorf("log series metadata refs: %w", err)
 			}
 		}
 		// It's important to do (float) Samples before histogram samples
@@ -1729,16 +1777,16 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 	}
 }
 
-// commitMetadata commits the metadata for each series in the provided batch.
-// It iterates over the metadata slice and updates the corresponding series
-// with the new metadata information. The series is locked during the update
-// to ensure thread safety.
+// commitMetadata commits the metadata ref for each series in the provided
+// batch. It iterates over the seriesMetadataRefs slice and points the
+// corresponding series at its (already WAL-logged) MetadataRef. The series is
+// locked during the update to ensure thread safety.
 func commitMetadata(b *appendBatch) {
 	var series *memSeries
-	for i, m := range b.metadata {
+	for i, m := range b.seriesMetadataRefs {
 		series = b.metadataSeries[i]
 		series.Lock()
-		series.meta = &metadata.Metadata{Type: record.ToMetricType(m.Type), Unit: m.Unit, Help: m.Help}
+		series.metadataRef = m.MetadataRef
 		series.Unlock()
 	}
 }
@@ -1780,6 +1828,7 @@ func (a *headAppenderBase) Commit() (err error) {
 		}
 		h.putRefSeriesBuffer(a.seriesRefs)
 		h.putSeriesBuffer(a.series)
+		h.putMetadataDefsBuffer(a.metadataDefs)
 		h.putTypeMap(a.typesInBatch)
 		a.closed = true
 	}()
@@ -2315,6 +2364,7 @@ func (a *headAppenderBase) Rollback() (err error) {
 		a.closed = true
 		h.putRefSeriesBuffer(a.seriesRefs)
 		h.putSeriesBuffer(a.series)
+		h.putMetadataDefsBuffer(a.metadataDefs)
 		h.putTypeMap(a.typesInBatch)
 	}()
 

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -93,6 +93,7 @@ func (h *Head) appenderV2() *headAppenderV2 {
 			oooTimeWindow:         h.opts.OutOfOrderTimeWindow.Load(),
 			seriesRefs:            h.getRefSeriesBuffer(),
 			series:                h.getSeriesBuffer(),
+			metadataDefs:          h.getMetadataDefsBuffer(),
 			typesInBatch:          h.getTypeMap(),
 			appendID:              appendID,
 			cleanupAppendIDsBelow: cleanupAppendIDsBelow,
@@ -209,19 +210,7 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 		partialErr = a.appendExemplars(s, opts.Exemplars)
 	}
 	if a.head.opts.EnableMetadataWALRecords && !opts.Metadata.IsEmpty() {
-		s.Lock()
-		metaChanged := s.meta == nil || !s.meta.Equals(opts.Metadata)
-		s.Unlock()
-		if metaChanged {
-			b := a.getCurrentBatch(stNone, s.ref)
-			b.metadata = append(b.metadata, record.RefMetadata{
-				Ref:  s.ref,
-				Type: record.GetMetricType(opts.Metadata.Type),
-				Unit: opts.Metadata.Unit,
-				Help: opts.Metadata.Help,
-			})
-			b.metadataSeries = append(b.metadataSeries, s)
-		}
+		a.updateSeriesMetadata(s, opts.Metadata)
 	}
 	return storage.SeriesRef(s.ref), partialErr
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
@@ -61,6 +62,26 @@ import (
 	"github.com/prometheus/prometheus/util/compression"
 	"github.com/prometheus/prometheus/util/testutil"
 )
+
+// seriesMetadata returns the metadata content currently associated with s, if any.
+func seriesMetadata(h *Head, s *memSeries) (metadata.Metadata, bool) {
+	return h.getMetadata(s.metadataRef)
+}
+
+// requireSeriesMetadataEqual asserts that s currently points at metadata content equal to want.
+func requireSeriesMetadataEqual(t testing.TB, h *Head, s *memSeries, want metadata.Metadata) {
+	t.Helper()
+	got, ok := seriesMetadata(h, s)
+	require.True(t, ok, "expected series to have metadata")
+	require.Equal(t, want, got)
+}
+
+// requireNoSeriesMetadata asserts that s currently has no metadata associated with it.
+func requireNoSeriesMetadata(t testing.TB, h *Head, s *memSeries) {
+	t.Helper()
+	_, ok := seriesMetadata(h, s)
+	require.False(t, ok, "expected series to have no metadata")
+}
 
 // newTestHeadDefaultOptions returns the HeadOptions that should be used by default in unit tests.
 func newTestHeadDefaultOptions(chunkRange int64, oooEnabled bool) *HeadOptions {
@@ -181,6 +202,14 @@ func readTestWAL(t testing.TB, dir string) (recs []any) {
 			meta, err := dec.Metadata(rec, nil)
 			require.NoError(t, err)
 			recs = append(recs, meta)
+		case record.MetadataDefinition:
+			defs, err := dec.MetadataDefinition(rec, nil)
+			require.NoError(t, err)
+			recs = append(recs, defs)
+		case record.SeriesMetadataRef:
+			refs, err := dec.SeriesMetadataRef(rec, nil)
+			require.NoError(t, err)
+			recs = append(recs, refs)
 		case record.Exemplars:
 			exemplars, err := dec.Exemplars(rec, nil)
 			require.NoError(t, err)
@@ -908,9 +937,10 @@ func TestHead_ReadWAL(t *testing.T) {
 				require.NotEmpty(t, e[0].Exemplars)
 				require.True(t, exemplar.Exemplar{Ts: 101, Value: 7, Labels: labels.FromStrings("trace_id", "zxcv")}.Equals(e[0].Exemplars[0]))
 
-				require.NotNil(t, s100.meta)
-				require.Equal(t, "foo", s100.meta.Unit)
-				require.Equal(t, "total foo", s100.meta.Help)
+				s100Meta, ok := seriesMetadata(head, s100)
+				require.True(t, ok)
+				require.Equal(t, "foo", s100Meta.Unit)
+				require.Equal(t, "total foo", s100Meta.Help)
 
 				intervals, err := head.tombstones.Get(storage.SeriesRef(s100.ref))
 				require.NoError(t, err)

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -233,6 +233,8 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				}
 				decoded <- hists
 			case record.Metadata:
+				// Kept for replaying WAL segments written before the introduction of
+				// MetadataDefinition/SeriesMetadataRef, which superseded this per-series format.
 				meta := h.wlReplayMetadataPool.Get()[:0]
 				meta, err := dec.Metadata(r.Record(), meta)
 				if err != nil {
@@ -244,6 +246,30 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 					return
 				}
 				decoded <- meta
+			case record.MetadataDefinition:
+				defs := h.wlReplayMetadataDefsPool.Get()[:0]
+				defs, err = dec.MetadataDefinition(r.Record(), defs)
+				if err != nil {
+					decodeErr = &wlog.CorruptionErr{
+						Err:     fmt.Errorf("decode metadata definitions: %w", err),
+						Segment: r.Segment(),
+						Offset:  r.Offset(),
+					}
+					return
+				}
+				decoded <- defs
+			case record.SeriesMetadataRef:
+				refs := h.wlReplaySeriesMetadataRefsPool.Get()[:0]
+				refs, err = dec.SeriesMetadataRef(r.Record(), refs)
+				if err != nil {
+					decodeErr = &wlog.CorruptionErr{
+						Err:     fmt.Errorf("decode series metadata refs: %w", err),
+						Segment: r.Segment(),
+						Offset:  r.Offset(),
+					}
+					return
+				}
+				decoded <- refs
 			default:
 				// Noop.
 			}
@@ -455,6 +481,9 @@ Outer:
 			clear(v) // Zero out to avoid retaining histogram data.
 			h.wlReplayFloatHistogramsPool.Put(v[:0])
 		case []record.RefMetadata:
+			// Pre-MetadataDefinition/SeriesMetadataRef format; intern the content
+			// the same way the new format does, so replay ends up in the same
+			// in-memory state regardless of which format wrote the WAL.
 			for _, m := range v {
 				if r, ok := multiRef[m.Ref]; ok {
 					m.Ref = r
@@ -465,14 +494,42 @@ Outer:
 					missingSeries[m.Ref] = struct{}{}
 					continue
 				}
-				s.meta = &metadata.Metadata{
+				ref, _ := h.getOrCreateMetadataRef(metadata.Metadata{
 					Type: record.ToMetricType(m.Type),
 					Unit: m.Unit,
 					Help: m.Help,
-				}
+				})
+				s.metadataRef = ref
 			}
 			clear(v) // Zero out to avoid retaining metadata strings.
 			h.wlReplayMetadataPool.Put(v[:0])
+		case []record.RefMetadataDefinition:
+			for _, def := range v {
+				h.setMetadataRefDefinition(def.Ref, metadata.Metadata{
+					Type: record.ToMetricType(def.Type),
+					Unit: def.Unit,
+					Help: def.Help,
+				})
+				if record.MetadataRef(h.lastMetadataID.Load()) < def.Ref {
+					h.lastMetadataID.Store(uint64(def.Ref))
+				}
+			}
+			clear(v) // Zero out to avoid retaining metadata strings.
+			h.wlReplayMetadataDefsPool.Put(v[:0])
+		case []record.RefSeriesMetadataRef:
+			for _, m := range v {
+				if r, ok := multiRef[m.Ref]; ok {
+					m.Ref = r
+				}
+				s := h.series.getByID(m.Ref)
+				if s == nil {
+					unknownMetadataRefs.Inc()
+					missingSeries[m.Ref] = struct{}{}
+					continue
+				}
+				s.metadataRef = m.MetadataRef
+			}
+			h.wlReplaySeriesMetadataRefsPool.Put(v[:0])
 		default:
 			panic(fmt.Errorf("unexpected decoded type: %T", d))
 		}

--- a/tsdb/record/buffers.go
+++ b/tsdb/record/buffers.go
@@ -20,12 +20,14 @@ import (
 
 // BuffersPool offers pool of zero-ed record buffers.
 type BuffersPool struct {
-	series          zeropool.Pool[[]RefSeries]
-	samples         zeropool.Pool[[]RefSample]
-	exemplars       zeropool.Pool[[]RefExemplar]
-	histograms      zeropool.Pool[[]RefHistogramSample]
-	floatHistograms zeropool.Pool[[]RefFloatHistogramSample]
-	metadata        zeropool.Pool[[]RefMetadata]
+	series             zeropool.Pool[[]RefSeries]
+	samples            zeropool.Pool[[]RefSample]
+	exemplars          zeropool.Pool[[]RefExemplar]
+	histograms         zeropool.Pool[[]RefHistogramSample]
+	floatHistograms    zeropool.Pool[[]RefFloatHistogramSample]
+	metadata           zeropool.Pool[[]RefMetadata]
+	metadataDefs       zeropool.Pool[[]RefMetadataDefinition]
+	seriesMetadataRefs zeropool.Pool[[]RefSeriesMetadataRef]
 }
 
 // NewBuffersPool returns a new BuffersPool object.
@@ -112,4 +114,29 @@ func (p *BuffersPool) GetMetadata(capacity int) []RefMetadata {
 func (p *BuffersPool) PutMetadata(b []RefMetadata) {
 	clear(b)
 	p.metadata.Put(b[:0])
+}
+
+func (p *BuffersPool) GetMetadataDefinitions(capacity int) []RefMetadataDefinition {
+	b := p.metadataDefs.Get()
+	if b == nil {
+		return make([]RefMetadataDefinition, 0, capacity)
+	}
+	return b
+}
+
+func (p *BuffersPool) PutMetadataDefinitions(b []RefMetadataDefinition) {
+	clear(b)
+	p.metadataDefs.Put(b[:0])
+}
+
+func (p *BuffersPool) GetSeriesMetadataRefs(capacity int) []RefSeriesMetadataRef {
+	b := p.seriesMetadataRefs.Get()
+	if b == nil {
+		return make([]RefSeriesMetadataRef, 0, capacity)
+	}
+	return b
+}
+
+func (p *BuffersPool) PutSeriesMetadataRefs(b []RefSeriesMetadataRef) {
+	p.seriesMetadataRefs.Put(b[:0])
 }

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -64,6 +64,10 @@ const (
 	HistogramSamplesV2 Type = 12
 	// FloatHistogramSamplesV2 is an enhanced float histogram record that supports start time per sample.
 	FloatHistogramSamplesV2 Type = 13
+	// MetadataDefinition is used to match WAL records that define the content for a MetadataRef.
+	MetadataDefinition Type = 14
+	// SeriesMetadataRef is used to match WAL records that associate a series with a MetadataRef.
+	SeriesMetadataRef Type = 15
 )
 
 func (rt Type) String() string {
@@ -94,6 +98,10 @@ func (rt Type) String() string {
 		return "mmapmarkers"
 	case Metadata:
 		return "metadata"
+	case MetadataDefinition:
+		return "metadata_definition"
+	case SeriesMetadataRef:
+		return "series_metadata_ref"
 	default:
 		return "unknown"
 	}
@@ -185,6 +193,30 @@ type RefMetadata struct {
 	Help string
 }
 
+// MetadataRef is a unique identifier for a metadata entry's content
+// (type, unit and help). Unlike a series ID, it is not tied to a single
+// series: every series sharing the same metadata content shares the same
+// MetadataRef. Like chunks.HeadSeriesRef, a MetadataRef is never reused; if
+// the content changes, a new MetadataRef is allocated.
+type MetadataRef uint64
+
+// RefMetadataDefinition defines the content for a MetadataRef. It is written
+// exactly once per MetadataRef, the first time that content is seen.
+type RefMetadataDefinition struct {
+	Ref  MetadataRef
+	Type uint8
+	Unit string
+	Help string
+}
+
+// RefSeriesMetadataRef associates a series with the MetadataRef that
+// describes its current metadata. It is written whenever a series starts
+// pointing at a (possibly new) MetadataRef.
+type RefSeriesMetadataRef struct {
+	Ref         chunks.HeadSeriesRef
+	MetadataRef MetadataRef
+}
+
 // RefExemplar is an exemplar with the labels, timestamp, value the exemplar was collected/observed with, and a reference to a series.
 type RefExemplar struct {
 	Ref    chunks.HeadSeriesRef
@@ -234,7 +266,7 @@ func (*Decoder) Type(rec []byte) Type {
 	switch t := Type(rec[0]); t {
 	case Series, Samples, SamplesV2, Tombstones, Exemplars, MmapMarkers, Metadata,
 		HistogramSamples, FloatHistogramSamples, CustomBucketsHistogramSamples, CustomBucketsFloatHistogramSamples,
-		HistogramSamplesV2, FloatHistogramSamplesV2:
+		HistogramSamplesV2, FloatHistogramSamplesV2, MetadataDefinition, SeriesMetadataRef:
 		return t
 	}
 	return Unknown
@@ -306,6 +338,60 @@ func (*Decoder) Metadata(rec []byte, metadata []RefMetadata) ([]RefMetadata, err
 		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return metadata, nil
+}
+
+// MetadataDefinition appends metadata definitions in rec to the given slice.
+func (*Decoder) MetadataDefinition(rec []byte, defs []RefMetadataDefinition) ([]RefMetadataDefinition, error) {
+	dec := encoding.Decbuf{B: rec}
+
+	if Type(dec.Byte()) != MetadataDefinition {
+		return nil, errors.New("invalid record type")
+	}
+	for len(dec.B) > 0 && dec.Err() == nil {
+		ref := dec.Uvarint64()
+		typ := dec.Byte()
+		unit := dec.UvarintStr()
+		help := dec.UvarintStr()
+
+		defs = append(defs, RefMetadataDefinition{
+			Ref:  MetadataRef(ref),
+			Type: typ,
+			Unit: unit,
+			Help: help,
+		})
+	}
+	if dec.Err() != nil {
+		return nil, dec.Err()
+	}
+	if len(dec.B) > 0 {
+		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
+	}
+	return defs, nil
+}
+
+// SeriesMetadataRef appends series-to-metadata-ref associations in rec to the given slice.
+func (*Decoder) SeriesMetadataRef(rec []byte, refs []RefSeriesMetadataRef) ([]RefSeriesMetadataRef, error) {
+	dec := encoding.Decbuf{B: rec}
+
+	if Type(dec.Byte()) != SeriesMetadataRef {
+		return nil, errors.New("invalid record type")
+	}
+	for len(dec.B) > 0 && dec.Err() == nil {
+		ref := dec.Uvarint64()
+		metadataRef := dec.Uvarint64()
+
+		refs = append(refs, RefSeriesMetadataRef{
+			Ref:         chunks.HeadSeriesRef(ref),
+			MetadataRef: MetadataRef(metadataRef),
+		})
+	}
+	if dec.Err() != nil {
+		return nil, dec.Err()
+	}
+	if len(dec.B) > 0 {
+		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
+	}
+	return refs, nil
 }
 
 func yoloString(b []byte) string {
@@ -907,6 +993,34 @@ func (*Encoder) Metadata(metadata []RefMetadata, b []byte) []byte {
 		buf.PutUvarintStr(m.Unit)
 		buf.PutUvarintStr(helpMetaName)
 		buf.PutUvarintStr(m.Help)
+	}
+
+	return buf.Get()
+}
+
+// MetadataDefinition appends the encoded metadata definitions to b and returns the resulting slice.
+func (*Encoder) MetadataDefinition(defs []RefMetadataDefinition, b []byte) []byte {
+	buf := encoding.Encbuf{B: b}
+	buf.PutByte(byte(MetadataDefinition))
+
+	for _, m := range defs {
+		buf.PutUvarint64(uint64(m.Ref))
+		buf.PutByte(m.Type)
+		buf.PutUvarintStr(m.Unit)
+		buf.PutUvarintStr(m.Help)
+	}
+
+	return buf.Get()
+}
+
+// SeriesMetadataRef appends the encoded series-to-metadata-ref associations to b and returns the resulting slice.
+func (*Encoder) SeriesMetadataRef(refs []RefSeriesMetadataRef, b []byte) []byte {
+	buf := encoding.Encbuf{B: b}
+	buf.PutByte(byte(SeriesMetadataRef))
+
+	for _, r := range refs {
+		buf.PutUvarint64(uint64(r.Ref))
+		buf.PutUvarint64(uint64(r.MetadataRef))
 	}
 
 	return buf.Get()

--- a/tsdb/record/record_test.go
+++ b/tsdb/record/record_test.go
@@ -76,6 +76,39 @@ func TestRecord_EncodeDecode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, metadata, decMetadata)
 
+	metadataDefs := []RefMetadataDefinition{
+		{
+			Ref:  100,
+			Type: uint8(Counter),
+			Unit: "",
+			Help: "some magic counter",
+		},
+		{
+			Ref:  1,
+			Type: uint8(Counter),
+			Unit: "seconds",
+			Help: "CPU time counter",
+		},
+		{
+			Ref:  147741,
+			Type: uint8(Gauge),
+			Unit: "percentage",
+			Help: "current memory usage",
+		},
+	}
+	decMetadataDefs, err := dec.MetadataDefinition(enc.MetadataDefinition(metadataDefs, nil), nil)
+	require.NoError(t, err)
+	require.Equal(t, metadataDefs, decMetadataDefs)
+
+	seriesMetadataRefs := []RefSeriesMetadataRef{
+		{Ref: 100, MetadataRef: 1},
+		{Ref: 1, MetadataRef: 1},
+		{Ref: 435245, MetadataRef: 147741},
+	}
+	decSeriesMetadataRefs, err := dec.SeriesMetadataRef(enc.SeriesMetadataRef(seriesMetadataRefs, nil), nil)
+	require.NoError(t, err)
+	require.Equal(t, seriesMetadataRefs, decSeriesMetadataRefs)
+
 	// Without ST.
 	samples := []RefSample{
 		{Ref: 0, T: 12423423, V: 1.2345},
@@ -1053,6 +1086,14 @@ func TestRecord_Type(t *testing.T) {
 	metadata := []RefMetadata{{Ref: 147, Type: uint8(Counter), Unit: "unit", Help: "help"}}
 	recordType = dec.Type(enc.Metadata(metadata, nil))
 	require.Equal(t, Metadata, recordType)
+
+	metadataDefs := []RefMetadataDefinition{{Ref: 1, Type: uint8(Counter), Unit: "unit", Help: "help"}}
+	recordType = dec.Type(enc.MetadataDefinition(metadataDefs, nil))
+	require.Equal(t, MetadataDefinition, recordType)
+
+	seriesMetadataRefs := []RefSeriesMetadataRef{{Ref: 147, MetadataRef: 1}}
+	recordType = dec.Type(enc.SeriesMetadataRef(seriesMetadataRefs, nil))
+	require.Equal(t, SeriesMetadataRef, recordType)
 
 	histograms := []RefHistogramSample{
 		{

--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -171,6 +171,8 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 		tstones               []tombstones.Stone
 		exemplars             []record.RefExemplar
 		metadata              []record.RefMetadata
+		metadataDefs          []record.RefMetadataDefinition
+		seriesMetadataRefs    []record.RefSeriesMetadataRef
 		st                    = labels.NewSymbolTable() // Needed for decoding; labels do not outlive this function.
 		dec                   = record.NewDecoder(st, logger)
 		enc                   = record.Encoder{EnableSTStorage: enableSTStorage}
@@ -178,9 +180,17 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 		recs                  [][]byte
 
 		latestMetadataMap = make(map[chunks.HeadSeriesRef]record.RefMetadata)
+
+		// MetadataDefinition content is immutable per ref, so every definition
+		// ever seen is buffered here; which ones are still reachable is only
+		// known once latestSeriesMetadataRefMap is final, so the actual
+		// filtering happens in a final pass after the main loop below.
+		metadataDefsSeen           = make(map[record.MetadataRef]record.RefMetadataDefinition)
+		latestSeriesMetadataRefMap = make(map[chunks.HeadSeriesRef]record.RefSeriesMetadataRef)
 	)
 	for r.Next() {
-		series, samples, histogramSamples, floatHistogramSamples, tstones, exemplars, metadata = series[:0], samples[:0], histogramSamples[:0], floatHistogramSamples[:0], tstones[:0], exemplars[:0], metadata[:0]
+		series, samples, histogramSamples, floatHistogramSamples, tstones, exemplars, metadata, metadataDefs, seriesMetadataRefs =
+			series[:0], samples[:0], histogramSamples[:0], floatHistogramSamples[:0], tstones[:0], exemplars[:0], metadata[:0], metadataDefs[:0], seriesMetadataRefs[:0]
 
 		// We don't reset the buffer since we batch up multiple records
 		// before writing them to the checkpoint.
@@ -374,6 +384,35 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 			}
 			stats.TotalMetadata += len(metadata)
 			stats.DroppedMetadata += len(metadata) - repl
+		case record.MetadataDefinition:
+			metadataDefs, err = dec.MetadataDefinition(rec, metadataDefs)
+			if err != nil {
+				return nil, fmt.Errorf("decode metadata definitions: %w", err)
+			}
+			// Content is immutable per ref, so just remember every definition seen;
+			// which ones are still reachable is decided once the final
+			// latestSeriesMetadataRefMap is known, after the main loop.
+			for _, def := range metadataDefs {
+				metadataDefsSeen[def.Ref] = def
+			}
+			stats.TotalMetadata += len(metadataDefs)
+		case record.SeriesMetadataRef:
+			seriesMetadataRefs, err = dec.SeriesMetadataRef(rec, seriesMetadataRefs)
+			if err != nil {
+				return nil, fmt.Errorf("decode series metadata refs: %w", err)
+			}
+			// Only keep reference to the latest found MetadataRef for each series ref.
+			repl := 0
+			for _, sm := range seriesMetadataRefs {
+				if keep(sm.Ref) {
+					if _, ok := latestSeriesMetadataRefMap[sm.Ref]; !ok {
+						repl++
+					}
+					latestSeriesMetadataRefMap[sm.Ref] = sm
+				}
+			}
+			stats.TotalMetadata += len(seriesMetadataRefs)
+			stats.DroppedMetadata += len(seriesMetadataRefs) - repl
 		default:
 			// Unknown record type, probably from a future Prometheus version.
 			continue
@@ -410,6 +449,34 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 		}
 		if err := cp.Log(enc.Metadata(latestMetadata, buf[:0])); err != nil {
 			return nil, fmt.Errorf("flush metadata records: %w", err)
+		}
+	}
+
+	// Flush the latest series-to-MetadataRef association for each kept series,
+	// and only the MetadataDefinitions still reachable from one of those
+	// associations. Definitions must be logged before the associations that
+	// reference them.
+	if len(latestSeriesMetadataRefMap) > 0 {
+		liveMetadataRefs := make(map[record.MetadataRef]struct{}, len(latestSeriesMetadataRefMap))
+		latestSeriesMetadataRefs := make([]record.RefSeriesMetadataRef, 0, len(latestSeriesMetadataRefMap))
+		for _, sm := range latestSeriesMetadataRefMap {
+			latestSeriesMetadataRefs = append(latestSeriesMetadataRefs, sm)
+			liveMetadataRefs[sm.MetadataRef] = struct{}{}
+		}
+
+		liveMetadataDefs := make([]record.RefMetadataDefinition, 0, len(liveMetadataRefs))
+		for ref := range liveMetadataRefs {
+			if def, ok := metadataDefsSeen[ref]; ok {
+				liveMetadataDefs = append(liveMetadataDefs, def)
+			}
+		}
+		if len(liveMetadataDefs) > 0 {
+			if err := cp.Log(enc.MetadataDefinition(liveMetadataDefs, buf[:0])); err != nil {
+				return nil, fmt.Errorf("flush metadata definition records: %w", err)
+			}
+		}
+		if err := cp.Log(enc.SeriesMetadataRef(latestSeriesMetadataRefs, buf[:0])); err != nil {
+			return nil, fmt.Errorf("flush series metadata ref records: %w", err)
 		}
 	}
 

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -61,6 +61,11 @@ type WriteTo interface {
 	AppendFloatHistograms([]record.RefFloatHistogramSample) bool
 	StoreSeries([]record.RefSeries, int)
 	StoreMetadata([]record.RefMetadata)
+	// StoreMetadataDefinitions and StoreSeriesMetadataRef supersede StoreMetadata:
+	// StoreMetadataDefinitions stores the content for a record.MetadataRef, and
+	// StoreSeriesMetadataRef associates a series with a (possibly new) ref.
+	StoreMetadataDefinitions([]record.RefMetadataDefinition)
+	StoreSeriesMetadataRef([]record.RefSeriesMetadataRef)
 
 	// UpdateSeriesSegment and SeriesReset are intended for
 	// garbage-collection:
@@ -518,6 +523,8 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, onlySeries bool) er
 	histograms := w.recordBuf.GetHistograms(512)
 	floatHistograms := w.recordBuf.GetFloatHistograms(512)
 	metadata := w.recordBuf.GetMetadata(512)
+	metadataDefs := w.recordBuf.GetMetadataDefinitions(8)
+	seriesMetadataRefs := w.recordBuf.GetSeriesMetadataRefs(512)
 	defer func() {
 		w.recordBuf.PutRefSeries(series)
 		w.recordBuf.PutSamples(samples)
@@ -525,6 +532,8 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, onlySeries bool) er
 		w.recordBuf.PutHistograms(histograms)
 		w.recordBuf.PutFloatHistograms(floatHistograms)
 		w.recordBuf.PutMetadata(metadata)
+		w.recordBuf.PutMetadataDefinitions(metadataDefs)
+		w.recordBuf.PutSeriesMetadataRefs(seriesMetadataRefs)
 	}()
 
 	dec := record.NewDecoder(labels.NewSymbolTable(), w.logger) // One table per WAL segment means it won't grow indefinitely.
@@ -657,6 +666,28 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, onlySeries bool) er
 				return err
 			}
 			w.writer.StoreMetadata(metadata)
+
+		case record.MetadataDefinition:
+			if !w.sendMetadata {
+				break
+			}
+			metadataDefs, err = dec.MetadataDefinition(rec, metadataDefs[:0])
+			if err != nil {
+				w.recordDecodeFailsMetric.Inc()
+				return err
+			}
+			w.writer.StoreMetadataDefinitions(metadataDefs)
+
+		case record.SeriesMetadataRef:
+			if !w.sendMetadata {
+				break
+			}
+			seriesMetadataRefs, err = dec.SeriesMetadataRef(rec, seriesMetadataRefs[:0])
+			if err != nil {
+				w.recordDecodeFailsMetric.Inc()
+				return err
+			}
+			w.writer.StoreSeriesMetadataRef(seriesMetadataRefs)
 
 		case record.Unknown:
 			// Could be corruption, or reading from a WAL from a newer Prometheus.

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -69,19 +69,23 @@ func overwriteReadTimeout(t *testing.T, val time.Duration) {
 type writeToMock struct {
 	mu sync.Mutex
 
-	seriesStored            []record.RefSeries
-	metadataStored          []record.RefMetadata
-	samplesAppended         []record.RefSample
-	exemplarsAppended       []record.RefExemplar
-	histogramsAppended      []record.RefHistogramSample
-	floatHistogramsAppended []record.RefFloatHistogramSample
+	seriesStored             []record.RefSeries
+	metadataStored           []record.RefMetadata
+	metadataDefsStored       []record.RefMetadataDefinition
+	seriesMetadataRefsStored []record.RefSeriesMetadataRef
+	samplesAppended          []record.RefSample
+	exemplarsAppended        []record.RefExemplar
+	histogramsAppended       []record.RefHistogramSample
+	floatHistogramsAppended  []record.RefFloatHistogramSample
 
-	seriesStores           int
-	metadataStores         int
-	sampleAppends          int
-	exemplarAppends        int
-	histogramAppends       int
-	floatHistogramsAppends int
+	seriesStores             int
+	metadataStores           int
+	metadataDefsStores       int
+	seriesMetadataRefsStores int
+	sampleAppends            int
+	exemplarAppends          int
+	histogramAppends         int
+	floatHistogramsAppends   int
 
 	seriesSegmentIndexes map[chunks.HeadSeriesRef]int
 
@@ -147,6 +151,24 @@ func (wtm *writeToMock) StoreMetadata(meta []record.RefMetadata) {
 
 	wtm.metadataStores++
 	wtm.metadataStored = append(wtm.metadataStored, meta...)
+	time.Sleep(wtm.delay)
+}
+
+func (wtm *writeToMock) StoreMetadataDefinitions(defs []record.RefMetadataDefinition) {
+	wtm.mu.Lock()
+	defer wtm.mu.Unlock()
+
+	wtm.metadataDefsStores++
+	wtm.metadataDefsStored = append(wtm.metadataDefsStored, defs...)
+	time.Sleep(wtm.delay)
+}
+
+func (wtm *writeToMock) StoreSeriesMetadataRef(refs []record.RefSeriesMetadataRef) {
+	wtm.mu.Lock()
+	defer wtm.mu.Unlock()
+
+	wtm.seriesMetadataRefsStores++
+	wtm.seriesMetadataRefsStored = append(wtm.seriesMetadataRefsStored, refs...)
 	time.Sleep(wtm.delay)
 }
 
@@ -272,11 +294,28 @@ func TestWatcher_Tail(t *testing.T) {
 					{Ref: 2, T: timestamp.FromTime(now), V: 123.1},
 				}, nil)))
 
+				// metadataDefs/seriesMetadataRefs derived from records[i].Metadata: one
+				// MetadataRef per series, reusing the series ref as the MetadataRef value
+				// since RefPadding already keeps them from colliding across batches.
+				metadataDefs := make([][]record.RefMetadataDefinition, batches)
+				seriesMetadataRefs := make([][]record.RefSeriesMetadataRef, batches)
+				for i := range records {
+					metadataDefs[i] = make([]record.RefMetadataDefinition, len(records[i].Metadata))
+					seriesMetadataRefs[i] = make([]record.RefSeriesMetadataRef, len(records[i].Metadata))
+					for j, m := range records[i].Metadata {
+						ref := record.MetadataRef(m.Ref)
+						metadataDefs[i][j] = record.RefMetadataDefinition{Ref: ref, Type: m.Type, Unit: m.Unit, Help: m.Help}
+						seriesMetadataRefs[i][j] = record.RefSeriesMetadataRef{Ref: m.Ref, MetadataRef: ref}
+					}
+				}
+
 				for i := range records {
 					// Similar order as tsdb/head_appender.go.headAppenderBase.log
 					// https://github.com/prometheus/prometheus/blob/1751685dd4f6430757ba3078a96cffeffcb2bb47/tsdb/head_append.go#L1053
 					require.NoError(t, w.Log(enc.Series(records[i].Series, nil)))
 					require.NoError(t, w.Log(enc.Metadata(records[i].Metadata, nil)))
+					require.NoError(t, w.Log(enc.MetadataDefinition(metadataDefs[i], nil)))
+					require.NoError(t, w.Log(enc.SeriesMetadataRef(seriesMetadataRefs[i], nil)))
 					require.NoError(t, w.Log(enc.Samples(records[i].Samples, nil)))
 
 					hs, cbHs := enc.HistogramSamples(records[i].Histograms, nil)
@@ -308,6 +347,8 @@ func TestWatcher_Tail(t *testing.T) {
 
 				require.Equal(t, batches, wt.seriesStores)
 				require.Equal(t, batches, wt.metadataStores)
+				require.Equal(t, batches, wt.metadataDefsStores)
+				require.Equal(t, batches, wt.seriesMetadataRefsStores)
 				require.Equal(t, batches, wt.sampleAppends)
 				require.Equal(t, 2*batches, wt.histogramAppends)
 				require.Equal(t, 2*batches, wt.floatHistogramsAppends)
@@ -318,6 +359,8 @@ func TestWatcher_Tail(t *testing.T) {
 					testutil.RequireEqual(t, records[i].Series, wt.seriesStored[i*sector:(i+1)*sector], i)
 					sector = len(records[i].Metadata)
 					require.Equal(t, records[i].Metadata, wt.metadataStored[i*sector:(i+1)*sector], i)
+					require.Equal(t, metadataDefs[i], wt.metadataDefsStored[i*sector:(i+1)*sector], i)
+					require.Equal(t, seriesMetadataRefs[i], wt.seriesMetadataRefsStored[i*sector:(i+1)*sector], i)
 					sector = len(records[i].Samples)
 					require.Equal(t, records[i].Samples, wt.samplesAppended[i*sector:(i+1)*sector], i)
 

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -552,7 +552,7 @@ func TestEndpoints(t *testing.T) {
 
 		remote := remote.NewStorage(promslog.New(&promslogConfig), prometheus.DefaultRegisterer, func() (int64, error) {
 			return 0, nil
-		}, dbDir, 1*time.Second, nil, false)
+		}, dbDir, 1*time.Second, nil, false, false)
 		t.Cleanup(func() { _ = remote.Close() })
 
 		err = remote.ApplyConfig(&config.Config{


### PR DESCRIPTION
The basic idea is to not write the metric metadata for each time series. Hope to reduce the memory overhead of using metadata in WAL feature.

Still keep metric metadata per metric family in the scrape cache and write to TSDB head if it changes to not have high load on TSDB.

Then in TSDB simply deduplicate the metric metadata when it's being updated - which means dedupe across targets and metric families (*).  Assign a unique metric metadata reference id to each new item (basically the same idea as series refs) and write into the WAL log:
- the deduplicated metric metadata with its reference
- a simple record that associates the series ref with the metric metadata ref

In the remote write queue manager: resolve the references.

One caveat:  this code does not delete metric metadata from the map. The map is cleared when the process restarts!

(*) At first I told AI to implement metric families in TSDB head for dedupe, but it pointed out that it's simpler to just do a generic dedupe.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
