### PR TITLE
cmd/prometheus: wire metadata-wal-records feature flag to TSDB Head o…

### DIFF
--- a/cmd/prometheus/features_test.go
+++ b/cmd/prometheus/features_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/util/testutil"
@@ -113,4 +114,19 @@ func TestFeaturesAPI(t *testing.T) {
 
 	// Compare the features data with the golden file.
 	require.Equal(t, expectedFeatures, apiResponse.Data, "Features mismatch. Run 'make update-features-testdata' to update the golden file.")
+}
+
+// TestSetFeatureListOptions_MetadataWALRecords is a regression test: enabling
+// metadata-wal-records used to only flip the scrape and web AppendMetadata
+// options, never tsdb.EnableMetadataWALRecords. AppenderV2, which the scrape
+// manager prefers whenever the storage implements it, gates on that TSDB
+// option, so metadata was silently never recorded via the default scrape
+// path regardless of the flag.
+func TestSetFeatureListOptions_MetadataWALRecords(t *testing.T) {
+	c := &flagConfig{featureList: []string{"metadata-wal-records"}}
+	require.NoError(t, c.setFeatureListOptions(promslog.NewNopLogger()))
+
+	require.True(t, c.scrape.AppendMetadata)
+	require.True(t, c.web.AppendMetadata)
+	require.True(t, c.tsdb.EnableMetadataWALRecords)
 }

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -247,6 +247,7 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 			case "metadata-wal-records":
 				c.scrape.AppendMetadata = true
 				c.web.AppendMetadata = true
+				c.tsdb.EnableMetadataWALRecords = true
 				features.Enable(features.TSDB, "metadata_wal_records")
 				logger.Info("Experimental metadata records in WAL enabled")
 			case "promql-per-step-stats":
@@ -2145,6 +2146,7 @@ type tsdbOptions struct {
 	StaleSeriesCompactionThreshold float64
 	EnableFastStartup              bool
 	FloatChunkEncoding             chunkenc.Encoding
+	EnableMetadataWALRecords       bool
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -2178,6 +2180,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		StaleSeriesCompactionThreshold: opts.StaleSeriesCompactionThreshold,
 		EnableFastStartup:              opts.EnableFastStartup,
 		FloatChunkEncoding:             opts.FloatChunkEncoding,
+		EnableMetadataWALRecords:       opts.EnableMetadataWALRecords,
 	}
 }
 


### PR DESCRIPTION
…ption

--enable-feature=metadata-wal-records set scrape.AppendMetadata and web.AppendMetadata, plus a cosmetic features.Enable() call, but never set tsdb.Options.EnableMetadataWALRecords (tsdbOptions had no such field). The classic storage.Appender.UpdateMetadata path doesn't check that option, so this went unnoticed there, but AppenderV2 does (EnableMetadataWALRecords && !opts.Metadata.IsEmpty()) and the scrape manager prefers AppenderV2 whenever the storage implements it, which tsdb.DB does. Net effect: the feature flag silently wrote no metadata records at all via the default scrape path.

Add a regression test that exercises setFeatureListOptions directly and asserts all three fields it's supposed to flip, rather than only the two that happened to already work.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] TSDB: fix no passing metadata-wal-records to TSDB from main feature flag.
```
