### PR TITLE
web: retain float histograms during federation

### DIFF
--- a/web/federate.go
+++ b/web/federate.go
@@ -132,9 +132,11 @@ Loop:
 			case chunkenc.ValFloat:
 				f = sample.F()
 			case chunkenc.ValHistogram:
+				// ToFloat(nil) returns an independent copy of the buffered histogram.
 				fh = sample.H().ToFloat(nil)
 			case chunkenc.ValFloatHistogram:
-				fh = sample.FH()
+				// The buffer is reset and reused for every series, so retain a copy.
+				fh = sample.FH().Copy()
 			default:
 				continue Loop
 			}

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -367,11 +367,31 @@ func TestFederationWithNativeHistograms(t *testing.T) {
 				F:      float64(i * 100),
 				Metric: expL,
 			})
+		case 1, 2:
+			// Use two float histograms to ensure buffer reuse does not overwrite the first.
+			hist.ZeroCount++
+			hist.Count++
+			fh := hist.ToFloat(nil)
+			_, err = app.AppendHistogram(0, l, 100*60*1000, nil, fh.Copy())
+			expVec = append(expVec, promql.Sample{
+				T:      100 * 60 * 1000,
+				H:      fh,
+				Metric: expL,
+			})
 		case 4:
 			_, err = app.AppendHistogram(0, l, 100*60*1000, histWithoutZeroBucket.Copy(), nil)
 			expVec = append(expVec, promql.Sample{
 				T:      100 * 60 * 1000,
 				H:      histWithoutZeroBucket.ToFloat(nil),
+				Metric: expL,
+			})
+		case 5:
+			hist.ZeroCount++
+			hist.Count++
+			_, err = app.AppendHistogram(0, l, 100*60*1000, hist.Copy(), nil)
+			expVec = append(expVec, promql.Sample{
+				T:      100 * 60 * 1000,
+				H:      hist.ToFloat(nil),
 				Metric: expL,
 			})
 		case 6:
@@ -422,15 +442,6 @@ func TestFederationWithNativeHistograms(t *testing.T) {
 			expVec = append(expVec, promql.Sample{
 				T:      100 * 60 * 1000,
 				F:      6,
-				Metric: expL,
-			})
-		default:
-			hist.ZeroCount++
-			hist.Count++
-			_, err = app.AppendHistogram(0, l, 100*60*1000, hist.Copy(), nil)
-			expVec = append(expVec, promql.Sample{
-				T:      100 * 60 * 1000,
-				H:      hist.ToFloat(nil),
 				Metric: expL,
 			})
 		}


### PR DESCRIPTION

#### Which issue(s) does the PR fix:

PeekBack returns buffer-owned float histograms that may be overwritten when
the buffered iterator is reset for another series. Copy the histogram before
retaining it for federation output.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Federation: fix corruption of float native histograms.
```
