### PR TITLE
textparse: handle zero-valued float histograms

### DIFF
--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -180,11 +180,9 @@ func (p *ProtobufParser) Series() ([]byte, *int64, float64) {
 //
 // The Compact method is called before returning the Histogram (or FloatHistogram).
 //
-// If the SampleCountFloat or the ZeroCountFloat in the proto message is > 0,
-// the histogram is parsed and returned as a FloatHistogram and nil is returned
-// as the (integer) Histogram return value. Otherwise, it is parsed and returned
-// as an (integer) Histogram and nil is returned as the FloatHistogram return
-// value.
+// A histogram with a positive SampleCountFloat or ZeroCountFloat, or any
+// PositiveCount or NegativeCount entries, is parsed and returned as a
+// FloatHistogram. Otherwise, it is parsed and returned as an integer Histogram.
 func (p *ProtobufParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
 	var (
 		ts = &p.dec.TimestampMs // To save memory allocations, never nil.
@@ -203,7 +201,7 @@ func (p *ProtobufParser) Histogram() ([]byte, *int64, *histogram.Histogram, *his
 	if p.parseClassicHistograms && len(h.GetBucket()) > 0 {
 		p.redoClassic = true
 	}
-	if h.GetSampleCountFloat() > 0 || h.GetZeroCountFloat() > 0 {
+	if isFloatHistogram(h) {
 		// It is a float histogram.
 		fh := histogram.FloatHistogram{
 			Count:         h.GetSampleCountFloat(),
@@ -734,6 +732,14 @@ func isNativeHistogram(h *dto.Histogram) bool {
 		h.GetZeroCount() > 0
 }
 
+func isFloatHistogram(h *dto.Histogram) bool {
+	// Bucket count entries identify float histograms even when all counts are zero.
+	return h.GetSampleCountFloat() > 0 ||
+		h.GetZeroCountFloat() > 0 ||
+		len(h.GetPositiveCount()) > 0 ||
+		len(h.GetNegativeCount()) > 0
+}
+
 func (p *ProtobufParser) convertToNHCB(t dto.MetricType) (*histogram.Histogram, *histogram.FloatHistogram, error) {
 	h := p.dec.GetHistogram()
 	p.tmpNHCB.Reset()
@@ -779,9 +785,8 @@ func (p *ProtobufParser) convertToNHCB(t dto.MetricType) (*histogram.Histogram, 
 // message. It catches malformed input before it reaches compactBuckets, where
 // a mismatch would cause a panic.
 func checkNativeHistogramConsistency(h *dto.Histogram) error {
-	isFloat := h.GetSampleCountFloat() > 0 || h.GetZeroCountFloat() > 0
 	var positiveBuckets, negativeBuckets int
-	if isFloat {
+	if isFloatHistogram(h) {
 		positiveBuckets = len(h.GetPositiveCount())
 		negativeBuckets = len(h.GetNegativeCount())
 	} else {

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -6016,6 +6016,45 @@ metric: <
 	}
 }
 
+func TestProtobufParseZeroFloatHistogram(t *testing.T) {
+	buf := metricFamiliesToProtobuf(t, []string{`
+name: "test_float_histogram"
+help: "Test zero float histogram with a retained bucket layout."
+type: HISTOGRAM
+metric: <
+  histogram: <
+    sample_count_float: 0
+    sample_sum: 0
+    schema: 3
+    zero_threshold: 0.001
+    zero_count_float: 0
+    positive_span: <
+      offset: -2
+      length: 5
+    >
+    positive_count: 0
+    positive_count: 0
+    positive_count: 0
+    positive_count: 0
+    positive_count: 0
+  >
+>
+	`})
+
+	p := NewProtobufParser(buf.Bytes(), false, false, false, false, labels.NewSymbolTable())
+	for _, expected := range []Entry{EntryHelp, EntryType, EntryHistogram} {
+		entry, err := p.Next()
+		require.NoError(t, err)
+		require.Equal(t, expected, entry)
+	}
+
+	_, _, h, fh := p.Histogram()
+	require.Nil(t, h)
+	require.NotNil(t, fh)
+	require.Zero(t, fh.Count)
+	require.Zero(t, fh.ZeroCount)
+}
+
 // TestProtobufParseMixedNativeAndClassicHistograms tests a metric family that
 // contains both a native histogram (with classic buckets) and a classic-only
 // histogram as separate series. With parseClassicHistograms=true and


### PR DESCRIPTION
Detect float histograms from their positive_count and negative_count fields, even when the sample and zero counts are both zero.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Scrape: fix failing scrape when float histogram is emitted over protobuf with count, zero count and buckets all zero, for example a result of recording `rate(x[1m])` over constant histogram.
```
