### PR TITLE
agent: support metadata-wal-records in agent mode

### DIFF
--- a/cmd/prometheus/features_test.go
+++ b/cmd/prometheus/features_test.go
@@ -129,4 +129,5 @@ func TestSetFeatureListOptions_MetadataWALRecords(t *testing.T) {
 	require.True(t, c.scrape.AppendMetadata)
 	require.True(t, c.web.AppendMetadata)
 	require.True(t, c.tsdb.EnableMetadataWALRecords)
+	require.True(t, c.agent.EnableMetadataWALRecords)
 }

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -248,6 +248,7 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 				c.scrape.AppendMetadata = true
 				c.web.AppendMetadata = true
 				c.tsdb.EnableMetadataWALRecords = true
+				c.agent.EnableMetadataWALRecords = true
 				features.Enable(features.TSDB, "metadata_wal_records")
 				logger.Info("Experimental metadata records in WAL enabled")
 			case "promql-per-step-stats":
@@ -1594,6 +1595,7 @@ func main() {
 					"OutOfOrderTimeWindow", cfg.agent.OutOfOrderTimeWindow,
 					"EnableSTAsZeroSample", cfg.agent.EnableSTAsZeroSample,
 					"EnableSTStorage", cfg.tsdb.EnableSTStorage,
+					"EnableMetadataWALRecords", cfg.agent.EnableMetadataWALRecords,
 				)
 
 				localStorage.Set(db, 0)
@@ -2196,6 +2198,7 @@ type agentOptions struct {
 	OutOfOrderTimeWindow         int64 // TODO(bwplotka): Unused option, fix it or remove.
 	EnableSTAsZeroSample         bool
 	EnableSTStorage              bool
+	EnableMetadataWALRecords     bool
 	CheckpointFromInMemorySeries bool
 	CheckpointBatchSize          int
 }
@@ -2215,6 +2218,7 @@ func (opts agentOptions) ToAgentOptions(outOfOrderTimeWindow int64) agent.Option
 		OutOfOrderTimeWindow:         outOfOrderTimeWindow,
 		EnableSTAsZeroSample:         opts.EnableSTAsZeroSample,
 		EnableSTStorage:              opts.EnableSTStorage,
+		EnableMetadataWALRecords:     opts.EnableMetadataWALRecords,
 		CheckpointFromInMemorySeries: opts.CheckpointFromInMemorySeries,
 		CheckpointBatchSize:          opts.CheckpointBatchSize,
 	}

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/record"
@@ -37,6 +38,15 @@ type ActiveSeries interface {
 	Ref() chunks.HeadSeriesRef
 	Labels() labels.Labels
 	LastSampleTimestamp() int64
+}
+
+// ActiveSeriesWithMetadata describes a live series that also provides metadata to be written by [Checkpoint].
+//
+// This interface is intentionally exported so downstream users of this package
+// can provide metadata without depending on Prometheus internal series types.
+type ActiveSeriesWithMetadata interface {
+	ActiveSeries
+	Metadata() *metadata.Metadata
 }
 
 // DeletedSeries describes a deleted series to be written by [Checkpoint].
@@ -67,7 +77,7 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, atIndex, batchSize int, activeS
 		return fmt.Errorf("can't find last checkpoint: %w", err)
 	}
 
-	if idx >= atIndex {
+	if err == nil && idx >= atIndex {
 		logger.Info(
 			"checkpoint already exists",
 			"dir", dir,
@@ -102,12 +112,16 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, atIndex, batchSize int, activeS
 	}()
 
 	flusher := newCheckpointFlusher(cp, batchSize)
-	if err := flusher.writeSeries(activeSeries); err != nil {
-		return err
+	if activeSeries != nil {
+		if err := flusher.writeSeries(activeSeries); err != nil {
+			return err
+		}
 	}
 
-	if err := flusher.writeDeletedRecords(deletedSeries); err != nil {
-		return err
+	if deletedSeries != nil {
+		if err := flusher.writeDeletedRecords(deletedSeries); err != nil {
+			return err
+		}
 	}
 
 	success = true
@@ -139,9 +153,11 @@ type checkpointWriter struct {
 	checkpoint  *wlog.WL
 	seriesBuff  []byte
 	samplesBuff []byte
+	metaBuff    []byte
 
 	seriesRecords []record.RefSeries
 	sampleRecords []record.RefSample
+	metaRecords   []record.RefMetadata
 	batchSize     int
 }
 
@@ -151,18 +167,28 @@ func newCheckpointFlusher(checkpoint *wlog.WL, batchSize int) *checkpointWriter 
 		checkpoint:    checkpoint,
 		seriesRecords: make([]record.RefSeries, 0, batchSize),
 		sampleRecords: make([]record.RefSample, 0, batchSize),
+		metaRecords:   make([]record.RefMetadata, 0, batchSize),
 	}
 }
 
 func (cf *checkpointWriter) flushRecords() error {
 	withSamples := len(cf.sampleRecords) > 0
+	withMeta := len(cf.metaRecords) > 0
 	cf.seriesBuff = cf.enc.Series(cf.seriesRecords, cf.seriesBuff)
 
 	var err error
-	if withSamples {
+	switch {
+	case withMeta && withSamples:
+		cf.metaBuff = cf.enc.Metadata(cf.metaRecords, cf.metaBuff)
+		cf.samplesBuff = cf.enc.Samples(cf.sampleRecords, cf.samplesBuff)
+		err = cf.checkpoint.Log(cf.seriesBuff, cf.metaBuff, cf.samplesBuff)
+	case withMeta:
+		cf.metaBuff = cf.enc.Metadata(cf.metaRecords, cf.metaBuff)
+		err = cf.checkpoint.Log(cf.seriesBuff, cf.metaBuff)
+	case withSamples:
 		cf.samplesBuff = cf.enc.Samples(cf.sampleRecords, cf.samplesBuff)
 		err = cf.checkpoint.Log(cf.seriesBuff, cf.samplesBuff)
-	} else {
+	default:
 		err = cf.checkpoint.Log(cf.seriesBuff)
 	}
 
@@ -172,8 +198,11 @@ func (cf *checkpointWriter) flushRecords() error {
 
 	cf.seriesBuff = cf.seriesBuff[:0]
 	cf.samplesBuff = cf.samplesBuff[:0]
+	cf.metaBuff = cf.metaBuff[:0]
 	cf.seriesRecords = cf.seriesRecords[:0]
 	cf.sampleRecords = cf.sampleRecords[:0]
+	clear(cf.metaRecords)
+	cf.metaRecords = cf.metaRecords[:0]
 	return nil
 }
 
@@ -191,6 +220,17 @@ func (cf *checkpointWriter) writeSeries(seriesIter iter.Seq[ActiveSeries]) error
 			Labels: series.Labels(),
 		})
 
+		if sm, ok := series.(ActiveSeriesWithMetadata); ok {
+			if m := sm.Metadata(); m != nil && !m.IsEmpty() {
+				cf.metaRecords = append(cf.metaRecords, record.RefMetadata{
+					Ref:  series.Ref(),
+					Type: record.GetMetricType(m.Type),
+					Unit: m.Unit,
+					Help: m.Help,
+				})
+			}
+		}
+
 		// Sample value is irrelevant, we only need the timestamp.
 		cf.sampleRecords = append(cf.sampleRecords, record.RefSample{
 			Ref: series.Ref(),
@@ -199,7 +239,7 @@ func (cf *checkpointWriter) writeSeries(seriesIter iter.Seq[ActiveSeries]) error
 		})
 	}
 
-	// Flush the last batch if we have one
+	// Flush the last batch if we have one.
 	if len(cf.seriesRecords) != 0 {
 		return cf.flushRecords()
 	}

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -24,12 +24,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
@@ -56,6 +58,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 		defer rs.Close()
 
 		opts := DefaultOptions()
+		opts.EnableMetadataWALRecords = true
 		opts.CheckpointFromInMemorySeries = isInMemCheckpoint
 		opts.WALSegmentSize = walSegmentSize // Set minimum size to get more segments for checkpoint.
 
@@ -93,8 +96,16 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 				sf := sample[0].F()
 
 				// replay doesn't include exemplars, thus don't include them to remove them from assertion.
-				_, err := app.Append(0, lset, st, sf)
+				ref, err := app.Append(0, lset, st, sf)
 				require.NoErrorf(t, err, "L: %v; S: %v", i, j)
+				if j == 0 && i%2 == 0 {
+					_, err = app.UpdateMetadata(ref, lset, metadata.Metadata{
+						Type: model.MetricTypeGauge,
+						Unit: "bytes",
+						Help: "test help",
+					})
+					require.NoError(t, err)
+				}
 				n++
 				maybeFlush()
 			}
@@ -189,6 +200,7 @@ func requireStripeSeriesEqual(t *testing.T, want, got *stripeSeries) {
 		require.Truef(t, labels.Equal(w.lset, g.lset),
 			"ref %d labels mismatch: wlog=%s agent=%s", ref, w.lset.String(), g.lset.String())
 		require.Equalf(t, w.lastTs, g.lastTs, "ref %d lastTs mismatch", ref)
+		require.Equalf(t, w.Metadata(), g.Metadata(), "ref %d metadata mismatch", ref)
 	}
 }
 
@@ -434,11 +446,17 @@ func createCheckpointFixtures(t testing.TB, p checkpointFixtureParams) {
 	require.NoError(t, err)
 
 	series := make([]record.RefSeries, 0, len(p.seriesLabels))
+	meta := make([]record.RefMetadata, 0, len(p.seriesLabels))
 	for i, lset := range p.seriesLabels {
-		// NOTE: don't append RefMetadata as agent.DB doesn't support it during WAL replay.
 		series = append(series, record.RefSeries{
 			Ref:    chunks.HeadSeriesRef(i),
 			Labels: labels.New(lset...),
+		})
+		meta = append(meta, record.RefMetadata{
+			Ref:  chunks.HeadSeriesRef(i),
+			Type: record.GetMetricType(model.MetricTypeGauge),
+			Unit: "bytes",
+			Help: "test help",
 		})
 	}
 
@@ -446,8 +464,10 @@ func createCheckpointFixtures(t testing.TB, p checkpointFixtureParams) {
 	samples := make([]record.RefSample, 0, len(series))
 	for i := range p.numSegments {
 		if i == 0 {
-			// Write series required for samples
+			// Write series and metadata required for samples.
 			b := enc.Series(series, nil)
+			require.NoError(t, w.Log(b))
+			b = enc.Metadata(meta, nil)
 			require.NoError(t, w.Log(b))
 		}
 

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -100,6 +100,9 @@ type Options struct {
 	// supported record types.
 	EnableSTStorage bool
 
+	// EnableMetadataWALRecords represents 'metadata-wal-records' feature flag.
+	EnableMetadataWALRecords bool
+
 	// CheckpointFromInMemorySeries changes checkpoint implementation to use only in-memory series data when building a checkpoint.
 	// This prevents re-reading the previous checkpoint and segments from disk.
 	CheckpointFromInMemorySeries bool
@@ -272,6 +275,7 @@ type DB struct {
 	walReplaySamplesPool         zeropool.Pool[[]record.RefSample]
 	walReplayHistogramsPool      zeropool.Pool[[]record.RefHistogramSample]
 	walReplayFloatHistogramsPool zeropool.Pool[[]record.RefFloatHistogramSample]
+	walReplayMetadataPool        zeropool.Pool[[]record.RefMetadata]
 
 	nextRef *atomic.Uint64
 	series  *stripeSeries
@@ -340,6 +344,8 @@ func Open(l *slog.Logger, reg prometheus.Registerer, rs *remote.Storage, dir str
 				pendingHistograms:      make([]record.RefHistogramSample, 0, 100),
 				pendingFloatHistograms: make([]record.RefFloatHistogramSample, 0, 100),
 				pendingExamplars:       make([]record.RefExemplar, 0, 10),
+				pendingMetadata:        make([]record.RefMetadata, 0, 100),
+				metadataSeries:         make([]*memSeries, 0, 100),
 			},
 		}
 	}
@@ -352,6 +358,8 @@ func Open(l *slog.Logger, reg prometheus.Registerer, rs *remote.Storage, dir str
 				pendingHistograms:      make([]record.RefHistogramSample, 0, 100),
 				pendingFloatHistograms: make([]record.RefFloatHistogramSample, 0, 100),
 				pendingExamplars:       make([]record.RefExemplar, 0, 10),
+				pendingMetadata:        make([]record.RefMetadata, 0, 100),
+				metadataSeries:         make([]*memSeries, 0, 100),
 			},
 		}
 	}
@@ -476,6 +484,7 @@ func (db *DB) resetWALReplayResources() {
 	db.walReplaySamplesPool = zeropool.Pool[[]record.RefSample]{}
 	db.walReplayHistogramsPool = zeropool.Pool[[]record.RefHistogramSample]{}
 	db.walReplayFloatHistogramsPool = zeropool.Pool[[]record.RefFloatHistogramSample]{}
+	db.walReplayMetadataPool = zeropool.Pool[[]record.RefMetadata]{}
 }
 
 func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, currentSegmentOrCheckpoint int) (err error) {
@@ -542,6 +551,18 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 					return
 				}
 				decoded <- floatHistograms
+			case record.Metadata:
+				meta := db.walReplayMetadataPool.Get()[:0]
+				meta, err = dec.Metadata(rec, meta)
+				if err != nil {
+					errCh <- &wlog.CorruptionErr{
+						Err:     fmt.Errorf("decode metadata: %w", err),
+						Segment: r.Segment(),
+						Offset:  r.Offset(),
+					}
+					return
+				}
+				decoded <- meta
 			case record.Tombstones, record.Exemplars:
 				// We don't care about tombstones or exemplars during replay.
 				// TODO: If decide to decode exemplars, we should make sure to prepopulate
@@ -667,6 +688,29 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 			}
 			clear(v) // Zero out to avoid retaining histogram data.
 			db.walReplayFloatHistogramsPool.Put(v[:0])
+		case []record.RefMetadata:
+			for _, entry := range v {
+				if ref, ok := duplicateRefToValidRef[entry.Ref]; ok {
+					if meta, ok := db.deleted[entry.Ref]; ok && meta.lastSegment <= currentSegmentOrCheckpoint {
+						meta.lastSegment = currentSegmentOrCheckpoint
+						db.deleted[entry.Ref] = meta
+					}
+					entry.Ref = ref
+				}
+				series := db.series.GetByID(entry.Ref)
+				if series == nil {
+					nonExistentSeriesRefs.Inc()
+					continue
+				}
+
+				series.meta = &metadata.Metadata{
+					Type: record.ToMetricType(entry.Type),
+					Unit: entry.Unit,
+					Help: entry.Help,
+				}
+			}
+			clear(v) // Zero out to avoid retaining metadata strings.
+			db.walReplayMetadataPool.Put(v[:0])
 		default:
 			panic(fmt.Errorf("unexpected decoded type: %T", d))
 		}
@@ -882,6 +926,7 @@ type appenderBase struct {
 	pendingHistograms      []record.RefHistogramSample
 	pendingFloatHistograms []record.RefFloatHistogramSample
 	pendingExamplars       []record.RefExemplar
+	pendingMetadata        []record.RefMetadata
 
 	// Pointers to the series referenced by each element of pendingSamples.
 	// Series lock is not held on elements.
@@ -894,6 +939,10 @@ type appenderBase struct {
 	// Pointers to the series referenced by each element of pendingFloatHistograms.
 	// Series lock is not held on elements.
 	floatHistogramSeries []*memSeries
+
+	// Pointers to the series referenced by each element of pendingMetadata.
+	// Series lock is not held on elements.
+	metadataSeries []*memSeries
 }
 
 type appender struct {
@@ -1090,9 +1139,37 @@ func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int
 	return storage.SeriesRef(series.ref), nil
 }
 
-func (*appender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
-	// TODO: Wire metadata in the Agent's appender.
-	return 0, nil
+func (a *appender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, meta metadata.Metadata) (storage.SeriesRef, error) {
+	if !a.opts.EnableMetadataWALRecords || meta.IsEmpty() {
+		return 0, nil
+	}
+
+	var series *memSeries
+	if ref != 0 {
+		series = a.series.GetByID(chunks.HeadSeriesRef(ref))
+	}
+	if series == nil {
+		series = a.series.GetByHash(l.Hash(), l)
+	}
+	if series == nil {
+		return 0, fmt.Errorf("unknown series when trying to add metadata with HeadSeriesRef: %d and labels: %s", ref, l)
+	}
+
+	series.Lock()
+	hasNewMetadata := series.meta == nil || !series.meta.Equals(meta)
+	series.Unlock()
+
+	if hasNewMetadata {
+		a.pendingMetadata = append(a.pendingMetadata, record.RefMetadata{
+			Ref:  series.ref,
+			Type: record.GetMetricType(meta.Type),
+			Unit: meta.Unit,
+			Help: meta.Help,
+		})
+		a.metadataSeries = append(a.metadataSeries, series)
+	}
+
+	return storage.SeriesRef(series.ref), nil
 }
 
 func (a *appender) AppendHistogramSTZeroSample(ref storage.SeriesRef, l labels.Labels, t, st int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
@@ -1236,6 +1313,14 @@ func (a *appenderBase) log() error {
 		buf = buf[:0]
 	}
 
+	if len(a.pendingMetadata) > 0 {
+		buf = encoder.Metadata(a.pendingMetadata, buf)
+		if err := a.wal.Log(buf); err != nil {
+			return err
+		}
+		buf = buf[:0]
+	}
+
 	if len(a.pendingSamples) > 0 {
 		buf = encoder.Samples(a.pendingSamples, buf)
 		if err := a.wal.Log(buf); err != nil {
@@ -1307,6 +1392,16 @@ func (a *appenderBase) log() error {
 			a.metrics.totalOutOfOrderSamples.Inc()
 		}
 	}
+	for i, m := range a.pendingMetadata {
+		series = a.metadataSeries[i]
+		series.Lock()
+		series.meta = &metadata.Metadata{
+			Type: record.ToMetricType(m.Type),
+			Unit: m.Unit,
+			Help: m.Help,
+		}
+		series.Unlock()
+	}
 
 	return nil
 }
@@ -1318,9 +1413,13 @@ func (a *appenderBase) clearData() {
 	a.pendingHistograms = a.pendingHistograms[:0]
 	a.pendingFloatHistograms = a.pendingFloatHistograms[:0]
 	a.pendingExamplars = a.pendingExamplars[:0]
+	clear(a.pendingMetadata)
+	a.pendingMetadata = a.pendingMetadata[:0]
 	a.sampleSeries = a.sampleSeries[:0]
 	a.histogramSeries = a.histogramSeries[:0]
 	a.floatHistogramSeries = a.floatHistogramSeries[:0]
+	clear(a.metadataSeries)
+	a.metadataSeries = a.metadataSeries[:0]
 }
 
 func (a *appenderBase) rollback() error {

--- a/tsdb/agent/db_append_v2.go
+++ b/tsdb/agent/db_append_v2.go
@@ -37,7 +37,6 @@ type appenderV2 struct {
 }
 
 // Append appends pending sample to agent's DB.
-// TODO: Wire metadata in the Agent's appender.
 func (a *appenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, opts storage.AOptions) (storage.SeriesRef, error) {
 	var (
 		// Avoid shadowing err variables for reliability.
@@ -121,6 +120,20 @@ func (a *appenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64
 	if len(opts.Exemplars) > 0 {
 		// Currently only exemplars can return partial errors.
 		partialErr = a.appendExemplars(s, opts.Exemplars)
+	}
+	if a.opts.EnableMetadataWALRecords && !opts.Metadata.IsEmpty() {
+		s.Lock()
+		metaChanged := s.meta == nil || !s.meta.Equals(opts.Metadata)
+		s.Unlock()
+		if metaChanged {
+			a.pendingMetadata = append(a.pendingMetadata, record.RefMetadata{
+				Ref:  s.ref,
+				Type: record.GetMetricType(opts.Metadata.Type),
+				Unit: opts.Metadata.Unit,
+				Help: opts.Metadata.Help,
+			})
+			a.metadataSeries = append(a.metadataSeries, s)
+		}
 	}
 	return storage.SeriesRef(s.ref), partialErr
 }

--- a/tsdb/agent/db_append_v2_test.go
+++ b/tsdb/agent/db_append_v2_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -31,6 +32,8 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb"
@@ -1248,6 +1251,289 @@ func TestDB_EnableSTZeroInjection_AppendV2(t *testing.T) {
 
 			got := readWALSamples(t, s.wal.Dir())
 			testutil.RequireEqualWithOptions(t, tc.expectedSamples, got, cmp.Options{cmp.AllowUnexported(walSample{})})
+		})
+	}
+}
+
+func TestMetadataInWAL_AppenderV2(t *testing.T) {
+	t.Run("feature disabled", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.EnableMetadataWALRecords = false
+		s := createTestAgentDB(t, nil, opts)
+		defer s.Close()
+
+		app := s.AppenderV2(t.Context())
+		lbls := labels.FromStrings("a", "b")
+		m := metadata.Metadata{Type: "gauge", Unit: "unit_1", Help: "help_1"}
+		_, err := app.Append(0, lbls, 0, 1000, 1.0, nil, nil, storage.AOptions{Metadata: m})
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		recs := readTestWAL(t, s.wal.Dir())
+		for _, rec := range recs {
+			_, ok := rec.([]record.RefMetadata)
+			require.False(t, ok, "unexpected metadata record in WAL when feature is disabled")
+		}
+	})
+
+	t.Run("stale sample skips metadata", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.EnableMetadataWALRecords = true
+		s := createTestAgentDB(t, nil, opts)
+		defer s.Close()
+
+		app := s.AppenderV2(t.Context())
+		lbls := labels.FromStrings("a", "b")
+		m := metadata.Metadata{Type: "gauge", Unit: "unit_1", Help: "help_1"}
+		_, err := app.Append(0, lbls, 0, 1000, math.Float64frombits(value.StaleNaN), nil, nil, storage.AOptions{Metadata: m})
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		recs := readTestWAL(t, s.wal.Dir())
+		for _, rec := range recs {
+			_, ok := rec.([]record.RefMetadata)
+			require.False(t, ok, "stale sample append should not write metadata to WAL")
+		}
+	})
+
+	t.Run("metadata logged and deduplicated", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.EnableMetadataWALRecords = true
+		s := createTestAgentDB(t, nil, opts)
+		defer s.Close()
+		ctx := t.Context()
+
+		// Add some series so we can attach metadata to them.
+		s1 := labels.FromStrings("a", "b")
+		s2 := labels.FromStrings("c", "d")
+		s3 := labels.FromStrings("e", "f")
+		s4 := labels.FromStrings("g", "h")
+
+		// Add a first round of metadata to the first three series.
+		m1 := metadata.Metadata{Type: "gauge", Unit: "unit_1", Help: "help_1"}
+		m2 := metadata.Metadata{Type: "gauge", Unit: "unit_2", Help: "help_2"}
+		m3 := metadata.Metadata{Type: "gauge", Unit: "unit_3", Help: "help_3"}
+
+		app := s.AppenderV2(ctx)
+		ts := int64(0)
+		_, err := app.Append(0, s1, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m1})
+		require.NoError(t, err)
+		_, err = app.Append(0, s2, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m2})
+		require.NoError(t, err)
+		_, err = app.Append(0, s3, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m3})
+		require.NoError(t, err)
+		_, err = app.Append(0, s4, 0, ts, 0, nil, nil, storage.AOptions{})
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		// Add a replicated metadata entry to the first series (deduplication check),
+		// a completely new metadata entry for the fourth series,
+		// and a changed metadata entry to the second series.
+		m4 := metadata.Metadata{Type: "counter", Unit: "unit_4", Help: "help_4"}
+		m5 := metadata.Metadata{Type: "counter", Unit: "unit_5", Help: "help_5"}
+		app = s.AppenderV2(ctx)
+		ts++
+		_, err = app.Append(0, s1, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m1})
+		require.NoError(t, err)
+		_, err = app.Append(0, s4, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m4})
+		require.NoError(t, err)
+		_, err = app.Append(0, s2, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m5})
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		// Read the WAL to see if the disk storage format is correct.
+		recs := readTestWAL(t, s.wal.Dir())
+		var gotMetadataBlocks [][]record.RefMetadata
+		for _, rec := range recs {
+			if mr, ok := rec.([]record.RefMetadata); ok {
+				gotMetadataBlocks = append(gotMetadataBlocks, mr)
+			}
+		}
+
+		expectedMetadata := []record.RefMetadata{
+			{Ref: 1, Type: record.GetMetricType(m1.Type), Unit: m1.Unit, Help: m1.Help},
+			{Ref: 2, Type: record.GetMetricType(m2.Type), Unit: m2.Unit, Help: m2.Help},
+			{Ref: 3, Type: record.GetMetricType(m3.Type), Unit: m3.Unit, Help: m3.Help},
+			{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
+			{Ref: 2, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
+		}
+		require.Len(t, gotMetadataBlocks, 2)
+		require.Equal(t, expectedMetadata[:3], gotMetadataBlocks[0])
+		require.Equal(t, expectedMetadata[3:], gotMetadataBlocks[1])
+	})
+}
+
+func TestMetadataAssertInMemoryData_AppenderV2(t *testing.T) {
+	opts := DefaultOptions()
+	opts.EnableMetadataWALRecords = true
+	s := createTestAgentDB(t, nil, opts)
+	defer s.Close()
+	ctx := t.Context()
+
+	s1 := labels.FromStrings("a", "b")
+	s2 := labels.FromStrings("c", "d")
+	s3 := labels.FromStrings("e", "f")
+	s4 := labels.FromStrings("g", "h")
+
+	m1 := metadata.Metadata{Type: "gauge", Unit: "unit_1", Help: "help_1"}
+	m2 := metadata.Metadata{Type: "gauge", Unit: "unit_2", Help: "help_2"}
+	m3 := metadata.Metadata{Type: "gauge", Unit: "unit_3", Help: "help_3"}
+
+	app := s.AppenderV2(ctx)
+	ts := int64(0)
+	_, err := app.Append(0, s1, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m1})
+	require.NoError(t, err)
+	_, err = app.Append(0, s2, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m2})
+	require.NoError(t, err)
+	_, err = app.Append(0, s3, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m3})
+	require.NoError(t, err)
+	_, err = app.Append(0, s4, 0, ts, 0, nil, nil, storage.AOptions{})
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	series1 := s.series.GetByHash(s1.Hash(), s1)
+	series2 := s.series.GetByHash(s2.Hash(), s2)
+	series3 := s.series.GetByHash(s3.Hash(), s3)
+	series4 := s.series.GetByHash(s4.Hash(), s4)
+	require.Equal(t, m1, *series1.Metadata())
+	require.Equal(t, m2, *series2.Metadata())
+	require.Equal(t, m3, *series3.Metadata())
+	require.Nil(t, series4.Metadata())
+
+	// Update metadata.
+	m4 := metadata.Metadata{Type: "counter", Unit: "unit_4", Help: "help_4"}
+	m5 := metadata.Metadata{Type: "counter", Unit: "unit_5", Help: "help_5"}
+	app = s.AppenderV2(ctx)
+	ts++
+	_, err = app.Append(0, s1, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m1})
+	require.NoError(t, err)
+	_, err = app.Append(0, s4, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m4})
+	require.NoError(t, err)
+	_, err = app.Append(0, s2, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m5})
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	require.Equal(t, m1, *series1.Metadata())
+	require.Equal(t, m5, *series2.Metadata())
+	require.Equal(t, m3, *series3.Metadata())
+	require.Equal(t, m4, *series4.Metadata())
+}
+
+func TestMetadataCheckpointing_AppenderV2(t *testing.T) {
+	for _, inMemCheckpoint := range []bool{false, true} {
+		t.Run("CheckpointFromInMemorySeries="+strconv.FormatBool(inMemCheckpoint), func(t *testing.T) {
+			ctx := t.Context()
+			opts := DefaultOptions()
+			opts.EnableMetadataWALRecords = true
+			opts.CheckpointFromInMemorySeries = inMemCheckpoint
+			opts.WALSegmentSize = walSegmentSize
+
+			s := createTestAgentDB(t, nil, opts)
+			defer s.Close()
+
+			s1 := labels.FromStrings("a", "b")
+			s2 := labels.FromStrings("c", "d")
+			s3 := labels.FromStrings("e", "f")
+			s4 := labels.FromStrings("g", "h")
+
+			m1 := metadata.Metadata{Type: "gauge", Unit: "unit_1", Help: "help_1"}
+			m2 := metadata.Metadata{Type: "gauge", Unit: "unit_2", Help: "help_2"}
+			m3 := metadata.Metadata{Type: "gauge", Unit: "unit_3", Help: "help_3"}
+			m4 := metadata.Metadata{Type: "gauge", Unit: "unit_4", Help: "help_4"}
+
+			app := s.AppenderV2(ctx)
+			ts := int64(0)
+			_, err := app.Append(0, s1, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m1})
+			require.NoError(t, err)
+			_, err = app.Append(0, s2, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m2})
+			require.NoError(t, err)
+			_, err = app.Append(0, s3, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m3})
+			require.NoError(t, err)
+			_, err = app.Append(0, s4, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m4})
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			// Update metadata for first series.
+			m5 := metadata.Metadata{Type: "counter", Unit: "unit_5", Help: "help_5"}
+			app = s.AppenderV2(ctx)
+			ts++
+			_, err = app.Append(0, s1, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m5})
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			// Switch back-and-forth metadata for second series.
+			// Since it ended on a new metadata record, we expect m6.
+			m6 := metadata.Metadata{Type: "counter", Unit: "unit_6", Help: "help_6"}
+
+			app = s.AppenderV2(ctx)
+			ts++
+			_, err = app.Append(0, s2, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m6})
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			app = s.AppenderV2(ctx)
+			ts++
+			_, err = app.Append(0, s2, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m2})
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			app = s.AppenderV2(ctx)
+			ts++
+			_, err = app.Append(0, s2, 0, ts, 0, nil, nil, storage.AOptions{Metadata: m6})
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			// Create a checkpoint directly using the configured checkpoint strategy.
+			first, last, err := wlog.Segments(s.wal.Dir())
+			require.NoError(t, err)
+
+			if inMemCheckpoint {
+				err = Checkpoint(promslog.NewNopLogger(), s.wal, last, 1000, s.series.allSeries(), nil)
+				require.NoError(t, err)
+			} else {
+				keep := func(id chunks.HeadSeriesRef) bool {
+					return id != 3 // Exclude series 3 from checkpoint.
+				}
+				_, err = wlog.Checkpoint(promslog.NewNopLogger(), s.wal, first, last, keep, 0, false)
+				require.NoError(t, err)
+			}
+
+			// Confirm checkpoint exists.
+			cdir, _, err := wlog.LastCheckpoint(s.wal.Dir())
+			require.NoError(t, err)
+
+			// Read checkpoint records.
+			recs := readTestWAL(t, cdir)
+			var gotMetadataBlocks [][]record.RefMetadata
+			for _, rec := range recs {
+				if mr, ok := rec.([]record.RefMetadata); ok {
+					gotMetadataBlocks = append(gotMetadataBlocks, mr)
+				}
+			}
+
+			require.Len(t, gotMetadataBlocks, 1)
+			gotMetadataBlock := gotMetadataBlocks[0]
+			sort.Slice(gotMetadataBlock, func(i, j int) bool { return gotMetadataBlock[i].Ref < gotMetadataBlock[j].Ref })
+
+			var wantMetadata []record.RefMetadata
+			if inMemCheckpoint {
+				// In-memory checkpoint keeps all live series including series 3.
+				wantMetadata = []record.RefMetadata{
+					{Ref: 1, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
+					{Ref: 2, Type: record.GetMetricType(m6.Type), Unit: m6.Unit, Help: m6.Help},
+					{Ref: 3, Type: record.GetMetricType(m3.Type), Unit: m3.Unit, Help: m3.Help},
+					{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
+				}
+			} else {
+				// wlog checkpoint filtered out series 3 via keep predicate.
+				wantMetadata = []record.RefMetadata{
+					{Ref: 1, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
+					{Ref: 2, Type: record.GetMetricType(m6.Type), Unit: m6.Unit, Help: m6.Help},
+					{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
+				}
+			}
+
+			require.Equal(t, wantMetadata, gotMetadataBlock)
 		})
 	}
 }

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb"
@@ -1578,4 +1579,240 @@ func BenchmarkGetOrCreate(b *testing.B) {
 			app.getOrCreate(0, lbls[i%n])
 		}
 	})
+}
+
+func readTestWAL(t testing.TB, dir string) (recs []any) {
+	sr, err := wlog.NewSegmentsReader(dir)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, sr.Close())
+	}()
+
+	dec := record.NewDecoder(labels.NewSymbolTable(), promslog.NewNopLogger())
+	r := wlog.NewReader(sr)
+
+	for r.Next() {
+		rec := r.Record()
+
+		switch dec.Type(rec) {
+		case record.Series:
+			series, err := dec.Series(rec, nil)
+			require.NoError(t, err)
+			recs = append(recs, series)
+		case record.Samples, record.SamplesV2:
+			samples, err := dec.Samples(rec, nil)
+			require.NoError(t, err)
+			recs = append(recs, samples)
+		case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
+			samples, err := dec.HistogramSamples(rec, nil)
+			require.NoError(t, err)
+			recs = append(recs, samples)
+		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
+			samples, err := dec.FloatHistogramSamples(rec, nil)
+			require.NoError(t, err)
+			recs = append(recs, samples)
+		case record.Tombstones:
+			tstones, err := dec.Tombstones(rec, nil)
+			require.NoError(t, err)
+			recs = append(recs, tstones)
+		case record.Metadata:
+			meta, err := dec.Metadata(rec, nil)
+			require.NoError(t, err)
+			recs = append(recs, meta)
+		case record.Exemplars:
+			exemplars, err := dec.Exemplars(rec, nil)
+			require.NoError(t, err)
+			recs = append(recs, exemplars)
+		default:
+			require.Fail(t, "unknown record type")
+		}
+	}
+	require.NoError(t, r.Err())
+	return recs
+}
+
+func TestUpdateMetadata(t *testing.T) {
+	t.Run("feature disabled", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.EnableMetadataWALRecords = false
+		s := createTestAgentDB(t, nil, opts)
+		defer s.Close()
+
+		app := s.Appender(t.Context())
+		lbls := labels.FromStrings("__name__", "m1")
+		ref, err := app.Append(0, lbls, 1000, 1.0)
+		require.NoError(t, err)
+
+		m := metadata.Metadata{Type: model.MetricTypeGauge, Unit: "bytes", Help: "help"}
+		_, err = app.UpdateMetadata(ref, lbls, m)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		// WAL should not contain any metadata records.
+		recs := readTestWAL(t, s.wal.Dir())
+		for _, rec := range recs {
+			_, ok := rec.([]record.RefMetadata)
+			require.False(t, ok, "unexpected metadata record in WAL when feature is disabled")
+		}
+	})
+
+	t.Run("unknown series", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.EnableMetadataWALRecords = true
+		s := createTestAgentDB(t, nil, opts)
+		defer s.Close()
+
+		app := s.Appender(t.Context())
+		m := metadata.Metadata{Type: model.MetricTypeGauge, Unit: "bytes", Help: "help"}
+		_, err := app.UpdateMetadata(0, labels.FromStrings("__name__", "unknown"), m)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown series")
+	})
+
+	t.Run("metadata logged, deduplicated, and updated", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.EnableMetadataWALRecords = true
+		s := createTestAgentDB(t, nil, opts)
+		defer s.Close()
+
+		ctx := t.Context()
+		s1 := labels.FromStrings("__name__", "m1")
+		s2 := labels.FromStrings("__name__", "m2")
+
+		m1 := metadata.Metadata{Type: model.MetricTypeGauge, Unit: "seconds", Help: "help 1"}
+		m2 := metadata.Metadata{Type: model.MetricTypeCounter, Unit: "bytes", Help: "help 2"}
+
+		// First transaction: create series and update metadata.
+		app := s.Appender(ctx)
+		ref1, err := app.Append(0, s1, 1000, 1.0)
+		require.NoError(t, err)
+		ref2, err := app.Append(0, s2, 1000, 2.0)
+		require.NoError(t, err)
+
+		_, err = app.UpdateMetadata(ref1, s1, m1)
+		require.NoError(t, err)
+		_, err = app.UpdateMetadata(ref2, s2, m2)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		// Check in-memory metadata.
+		memS1 := s.series.GetByID(chunks.HeadSeriesRef(ref1))
+		require.NotNil(t, memS1)
+		require.Equal(t, &m1, memS1.Metadata())
+
+		memS2 := s.series.GetByID(chunks.HeadSeriesRef(ref2))
+		require.NotNil(t, memS2)
+		require.Equal(t, &m2, memS2.Metadata())
+
+		// Second transaction: append same metadata (dedup) for s1, new metadata for s2.
+		m2Updated := metadata.Metadata{Type: model.MetricTypeCounter, Unit: "bytes", Help: "help 2 updated"}
+		app = s.Appender(ctx)
+		_, err = app.Append(ref1, s1, 2000, 1.5)
+		require.NoError(t, err)
+		_, err = app.UpdateMetadata(ref1, s1, m1)
+		require.NoError(t, err)
+
+		_, err = app.Append(ref2, s2, 2000, 2.5)
+		require.NoError(t, err)
+		_, err = app.UpdateMetadata(ref2, s2, m2Updated)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		// Verify in-memory updated metadata.
+		require.Equal(t, &m2Updated, memS2.Metadata())
+
+		// Verify WAL content: expected 2 metadata blocks (first has m1, m2; second has only m2Updated).
+		recs := readTestWAL(t, s.wal.Dir())
+		var gotMeta [][]record.RefMetadata
+		for _, rec := range recs {
+			if mr, ok := rec.([]record.RefMetadata); ok {
+				gotMeta = append(gotMeta, mr)
+			}
+		}
+		require.Len(t, gotMeta, 2)
+		require.Equal(t, []record.RefMetadata{
+			{Ref: chunks.HeadSeriesRef(ref1), Type: record.GetMetricType(m1.Type), Unit: m1.Unit, Help: m1.Help},
+			{Ref: chunks.HeadSeriesRef(ref2), Type: record.GetMetricType(m2.Type), Unit: m2.Unit, Help: m2.Help},
+		}, gotMeta[0])
+		require.Equal(t, []record.RefMetadata{
+			{Ref: chunks.HeadSeriesRef(ref2), Type: record.GetMetricType(m2Updated.Type), Unit: m2Updated.Unit, Help: m2Updated.Help},
+		}, gotMeta[1])
+	})
+
+	t.Run("rollback does not update metadata", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.EnableMetadataWALRecords = true
+		s := createTestAgentDB(t, nil, opts)
+		defer s.Close()
+
+		ctx := t.Context()
+		s1 := labels.FromStrings("__name__", "m1")
+		m1 := metadata.Metadata{Type: model.MetricTypeGauge, Unit: "seconds", Help: "help 1"}
+
+		app := s.Appender(ctx)
+		ref1, err := app.Append(0, s1, 1000, 1.0)
+		require.NoError(t, err)
+		_, err = app.UpdateMetadata(ref1, s1, m1)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		// Start second transaction and rollback.
+		m1New := metadata.Metadata{Type: model.MetricTypeGauge, Unit: "minutes", Help: "help 1 changed"}
+		app = s.Appender(ctx)
+		_, err = app.UpdateMetadata(ref1, s1, m1New)
+		require.NoError(t, err)
+		require.NoError(t, app.Rollback())
+
+		// Verify in-memory metadata was NOT changed.
+		memS1 := s.series.GetByID(chunks.HeadSeriesRef(ref1))
+		require.NotNil(t, memS1)
+		require.Equal(t, &m1, memS1.Metadata())
+	})
+}
+
+func TestWALReplayMetadata(t *testing.T) {
+	opts := DefaultOptions()
+	opts.EnableMetadataWALRecords = true
+	dir := t.TempDir()
+
+	l := promslog.NewNopLogger()
+	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dir, 30*time.Second, nil, false)
+	defer rs.Close()
+
+	db, err := Open(l, nil, rs, dir, opts)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	s1 := labels.FromStrings("__name__", "cpu_usage")
+	s2 := labels.FromStrings("__name__", "mem_bytes")
+
+	m1 := metadata.Metadata{Type: model.MetricTypeGauge, Unit: "percent", Help: "CPU usage percentage"}
+	m2 := metadata.Metadata{Type: model.MetricTypeGauge, Unit: "bytes", Help: "Memory used in bytes"}
+
+	app := db.Appender(ctx)
+	ref1, err := app.Append(0, s1, 1000, 50.0)
+	require.NoError(t, err)
+	ref2, err := app.Append(0, s2, 1000, 1024.0)
+	require.NoError(t, err)
+
+	_, err = app.UpdateMetadata(ref1, s1, m1)
+	require.NoError(t, err)
+	_, err = app.UpdateMetadata(ref2, s2, m2)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	require.NoError(t, db.Close())
+
+	// Reopen DB and verify metadata is restored during WAL replay.
+	db2, err := Open(l, nil, rs, dir, opts)
+	require.NoError(t, err)
+	defer db2.Close()
+
+	mem1 := db2.series.GetByID(chunks.HeadSeriesRef(ref1))
+	require.NotNil(t, mem1)
+	require.Equal(t, &m1, mem1.Metadata())
+
+	mem2 := db2.series.GetByID(chunks.HeadSeriesRef(ref2))
+	require.NotNil(t, mem2)
+	require.Equal(t, &m2, mem2.Metadata())
 }

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
@@ -32,6 +33,8 @@ type memSeries struct {
 	// Last recorded timestamp. Used by Storage.gc to determine if a series is
 	// stale.
 	lastTs int64
+
+	meta *metadata.Metadata
 }
 
 // updateTimestamp obtains the lock on s and will attempt to update lastTs.
@@ -56,6 +59,13 @@ func (m *memSeries) Labels() labels.Labels {
 
 func (m *memSeries) LastSampleTimestamp() int64 {
 	return m.lastTs
+}
+
+// Metadata returns the metadata associated with the series, or nil if none is set.
+func (m *memSeries) Metadata() *metadata.Metadata {
+	m.Lock()
+	defer m.Unlock()
+	return m.meta
 }
 
 // seriesHashmap lets agent find a memSeries by its label set, via a 64-bit hash.
@@ -325,7 +335,10 @@ func (s *stripeSeries) refLock(ref chunks.HeadSeriesRef) uint64 {
 	return uint64(ref) & uint64(s.size-1)
 }
 
-var _ ActiveSeries = (*seriesSnapshot)(nil)
+var (
+	_ ActiveSeries             = (*seriesSnapshot)(nil)
+	_ ActiveSeriesWithMetadata = (*seriesSnapshot)(nil)
+)
 
 // seriesSnapshot is a point-in-time copy of a memSeries fields.
 // It is used to avoid holding series locks during checkpoint I/O.
@@ -333,6 +346,7 @@ type seriesSnapshot struct {
 	ref    chunks.HeadSeriesRef
 	lset   labels.Labels
 	lastTs int64
+	meta   *metadata.Metadata
 }
 
 func (s *seriesSnapshot) Ref() chunks.HeadSeriesRef {
@@ -345,6 +359,10 @@ func (s *seriesSnapshot) Labels() labels.Labels {
 
 func (s *seriesSnapshot) LastSampleTimestamp() int64 {
 	return s.lastTs
+}
+
+func (s *seriesSnapshot) Metadata() *metadata.Metadata {
+	return s.meta
 }
 
 func (s *stripeSeries) allSeries() iter.Seq[ActiveSeries] {
@@ -368,6 +386,7 @@ func (s *stripeSeries) allSeries() iter.Seq[ActiveSeries] {
 					ref:    series.ref,
 					lset:   series.lset,
 					lastTs: series.lastTs,
+					meta:   series.meta,
 				}
 				series.Unlock()
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None

#### Overview / Description:

This PR adds support for the `--enable-feature=metadata-wal-records` feature flag in Prometheus Agent mode.

When enabled:
- **Ingestion**: Both `Appender.UpdateMetadata` and `AppenderV2.Append` (with metadata options) record `record.Metadata` entries to the Agent WAL and update in-memory series metadata on commit. Redundant metadata updates are deduplicated, and rollbacks discard pending metadata changes.
- **In-Memory Tracking**: `memSeries` and `seriesSnapshot` store series metadata and expose `Metadata() *metadata.Metadata`.
- **Checkpointing**: In-memory checkpointing (`agent.Checkpoint`) preserves series metadata as `record.Metadata` records in checkpoints, matching `wlog.Checkpoint`.
- **WAL Replay**: During WAL replay, `record.Metadata` records are decoded and mapped to their respective series.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[FEATURE] Agent: Support metadata-wal-records in Prometheus Agent mode.
```