### PR TITLE
api: reject unsupported values for the stats query parameter

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -102,7 +102,7 @@ URL query parameters:
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Doesn't affect scalars or strings but truncates the number of series for matrices and vectors. Optional. 0 means disabled.
 - `lookback_delta=<duration | float>`: Override the [lookback period](#staleness) just for this query in `duration` format or float number of seconds. Optional.
-- `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts). Any other non-empty value currently behaves like `true`, but is deprecated, adds a warning to the response, and will be rejected in the next major release. Optional. See [Query statistics](#query-statistics).
+- `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts). Any other value is rejected with a `bad_data` error. Optional. See [Query statistics](#query-statistics).
 
 Optional HTTP request headers:
 
@@ -180,7 +180,7 @@ URL query parameters:
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Optional. 0 means disabled.
 - `lookback_delta=<duration | float>`: Override the [lookback period](#staleness) just for this query in `duration` format or float number of seconds. Optional.
-- `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts). Any other non-empty value currently behaves like `true`, but is deprecated, adds a warning to the response, and will be rejected in the next major release. Optional. See [Query statistics](#query-statistics).
+- `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts). Any other value is rejected with a `bad_data` error. Optional. See [Query statistics](#query-statistics).
 
 Optional HTTP request headers:
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -158,10 +158,9 @@ type StatsRenderer func(context.Context, *stats.Statistics, string) stats.QueryS
 
 // DefaultStatsRenderer is the default stats renderer for the API: any
 // non-empty `stats` value includes statistics in the response. The API
-// handlers attach a deprecation warning to the response for values outside
-// the supported enum ("true", "all"); those values will be rejected in the
-// next major release. Custom StatsRenderer implementations are exempt and
-// may define their own values.
+// handlers reject unsupported values of the parameter with a bad_data error
+// before they reach the renderer. Custom StatsRenderer implementations are
+// exempt and may define their own values.
 func DefaultStatsRenderer(_ context.Context, s *stats.Statistics, param string) stats.QueryStats {
 	if param != "" {
 		return stats.NewQueryStats(s)
@@ -571,7 +570,7 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 		defer cancel()
 	}
 
-	opts, err := extractQueryOpts(r)
+	opts, err := api.extractQueryOpts(r)
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
@@ -619,9 +618,6 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 			warnings = warnings.Add(errors.New("results truncated due to limit"))
 		}
 	}
-	if warn := api.statsParamWarning(r.FormValue("stats")); warn != nil {
-		warnings = warnings.Add(warn)
-	}
 	// Optional stats field in response if parameter "stats" is not empty.
 	sr := api.statsRenderer
 	if sr == nil {
@@ -654,7 +650,11 @@ func (api *API) parseQuery(r *http.Request) apiFuncResult {
 	return apiFuncResult{data: translateAST(expr), err: nil, warnings: nil, finalizer: nil}
 }
 
-func extractQueryOpts(r *http.Request) (promql.QueryOpts, error) {
+func (api *API) extractQueryOpts(r *http.Request) (promql.QueryOpts, error) {
+	if err := api.validateStatsParam(r.FormValue("stats")); err != nil {
+		return nil, err
+	}
+
 	var duration time.Duration
 
 	if strDuration := r.FormValue("lookback_delta"); strDuration != "" {
@@ -681,21 +681,17 @@ func extractQueryOpts(r *http.Request) (promql.QueryOpts, error) {
 // when the default stats renderer is in use: statsTrue includes basic query
 // statistics in the response, statsAll additionally includes per-step
 // statistics (with --enable-feature=promql-per-step-stats). Empty disables
-// statistics.
+// statistics. Any other value is rejected with a bad_data error.
 const (
 	statsTrue = "true"
 	statsAll  = "all"
 )
 
-// statsParamWarning returns a deprecation warning for unsupported values of
-// the `stats` query parameter, to be attached to the response's warnings.
-// Historically any non-empty value silently enabled basic statistics; that
-// behaviour is kept for compatibility within the current major release, but
-// values outside the supported enum ("true", "all") are deprecated and will
-// be rejected in the next major release. Embedders that install a custom
-// StatsRenderer define their own vocabulary for the parameter, so no warning
-// is attached then.
-func (api *API) statsParamWarning(s string) error {
+// validateStatsParam checks that the `stats` query parameter is a supported
+// enum value ("true", "all", or empty). When the API uses a custom
+// StatsRenderer, the parameter vocabulary is defined by the embedder, so
+// validation is skipped.
+func (api *API) validateStatsParam(s string) error {
 	if api.customStatsRenderer {
 		return nil
 	}
@@ -703,7 +699,7 @@ func (api *API) statsParamWarning(s string) error {
 	case "", statsTrue, statsAll:
 		return nil
 	default:
-		return fmt.Errorf("value %q for parameter \"stats\" is deprecated and will be rejected in the next major release, use %q or %q", s, statsTrue, statsAll)
+		return fmt.Errorf("invalid value %q for parameter \"stats\", supported values are %q and %q", s, statsTrue, statsAll)
 	}
 }
 
@@ -752,7 +748,7 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 		defer cancel()
 	}
 
-	opts, err := extractQueryOpts(r)
+	opts, err := api.extractQueryOpts(r)
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
@@ -801,10 +797,6 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 			warnings = warnings.Add(errors.New("results truncated due to limit"))
 		}
 	}
-	if warn := api.statsParamWarning(r.FormValue("stats")); warn != nil {
-		warnings = warnings.Add(warn)
-	}
-
 	// Optional stats field in response if parameter "stats" is not empty.
 	sr := api.statsRenderer
 	if sr == nil {

--- a/web/api/v1/api_scenarios_test.go
+++ b/web/api/v1/api_scenarios_test.go
@@ -464,22 +464,19 @@ func TestAPIWithStats(t *testing.T) {
 	now := time.Now().Unix()
 
 	// Test combinations of methods, endpoints, and stats values. Values
-	// outside the supported enum ("true", "all") keep the historical
-	// behaviour (any non-empty value enables basic statistics) but attach a
-	// deprecation warning to the response; they will be rejected in the next
-	// major release.
+	// outside the supported enum ("true", "all") are rejected with a
+	// bad_data error.
 	methods := []string{"GET", "POST"}
 	statsValues := []struct {
-		value         string
-		expectStats   bool
-		expectWarning bool
+		value       string
+		expectStats bool
+		wantErr     bool
 	}{
 		{"true", true, false},
 		{"all", true, false},
-		{"1", true, true},
+		{"1", false, true},
 		{"", false, false},
 	}
-	deprecationWarning := `value "1" for parameter "stats" is deprecated and will be rejected in the next major release, use "true" or "all"`
 
 	for _, method := range methods {
 		for _, stats := range statsValues {
@@ -498,13 +495,14 @@ func TestAPIWithStats(t *testing.T) {
 					resp = testhelpers.POST(t, api, "/api/v1/query", params...)
 				}
 
-				resp.RequireSuccess().ValidateOpenAPI()
-
-				if stats.expectWarning {
-					resp.RequireArrayContains("$.warnings", deprecationWarning)
-				} else {
-					resp.RequireJSONPathNotExists("$.warnings")
+				if stats.wantErr {
+					resp.RequireStatusCode(400).
+						RequireError().
+						RequireEquals("$.errorType", "bad_data")
+					return
 				}
+
+				resp.RequireSuccess().ValidateOpenAPI()
 
 				if stats.expectStats {
 					resp.RequireJSONPathExists("$.data.stats").
@@ -541,13 +539,14 @@ func TestAPIWithStats(t *testing.T) {
 					resp = testhelpers.POST(t, api, "/api/v1/query_range", params...)
 				}
 
-				resp.RequireSuccess().ValidateOpenAPI()
-
-				if stats.expectWarning {
-					resp.RequireArrayContains("$.warnings", deprecationWarning)
-				} else {
-					resp.RequireJSONPathNotExists("$.warnings")
+				if stats.wantErr {
+					resp.RequireStatusCode(400).
+						RequireError().
+						RequireEquals("$.errorType", "bad_data")
+					return
 				}
+
+				resp.RequireSuccess().ValidateOpenAPI()
 
 				if stats.expectStats {
 					resp.RequireJSONPathExists("$.data.stats").

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1021,26 +1021,14 @@ func TestStats(t *testing.T) {
 			},
 		},
 		{
-			name:        "stats is an unsupported value",
-			param:       "foo",
-			wantWarning: true,
-			expected: func(t *testing.T, i any) {
-				// Deprecated values keep the historical behaviour for now:
-				// any non-empty value enables basic statistics.
-				require.IsType(t, &QueryData{}, i)
-				qd := i.(*QueryData)
-				require.NotNil(t, qd.Stats)
-			},
+			name:    "stats is an unsupported value",
+			param:   "foo",
+			wantErr: errorBadData,
 		},
 		{
-			name:        "stats is an unsupported truthy value",
-			param:       "1",
-			wantWarning: true,
-			expected: func(t *testing.T, i any) {
-				require.IsType(t, &QueryData{}, i)
-				qd := i.(*QueryData)
-				require.NotNil(t, qd.Stats)
-			},
+			name:    "stats is an unsupported truthy value",
+			param:   "1",
+			wantErr: errorBadData,
 		},
 		{
 			name:  "stats is true",
@@ -4974,12 +4962,20 @@ func TestExtractQueryOpts(t *testing.T) {
 			err: nil,
 		},
 		{
+			name: "with stats true",
+			form: url.Values{
+				"stats": []string{"true"},
+			},
+			expect: promql.NewPrometheusQueryOpts(false, 0, nil),
+			err:    nil,
+		},
+		{
 			name: "with stats none",
 			form: url.Values{
 				"stats": []string{"none"},
 			},
-			expect: promql.NewPrometheusQueryOpts(false, 0, nil),
-			err:    nil,
+			expect: nil,
+			err:    errors.New(`invalid value "none" for parameter "stats", supported values are "true" and "all"`),
 		},
 		{
 			name: "with lookback delta",
@@ -5024,13 +5020,14 @@ func TestExtractQueryOpts(t *testing.T) {
 		},
 	}
 
+	api := &API{}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			req := &http.Request{Form: test.form, Header: test.header}
 			if req.Header == nil {
 				req.Header = make(http.Header)
 			}
-			opts, err := extractQueryOpts(req)
+			opts, err := api.extractQueryOpts(req)
 			require.Equal(t, test.expect, opts)
 			if test.err == nil {
 				require.NoError(t, err)


### PR DESCRIPTION
Make the "stats" parameter on /api/v1/query and /api/v1/query_range a strict enum. The default renderer now accepts only "true" and "all"; any other value returns a bad_data error. Custom StatsRenderer implementations remain exempt from validation.

Fixes #10953

```release-notes
[CHANGE] API: Unsupported values for the PromQL "stats" query parameter are now rejected with a bad_data error instead of being accepted with a deprecation warning.
```
