### PR TITLE
tsdb: fix data race on matchers in DB.Delete

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2771,12 +2771,15 @@ func (db *DB) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Matche
 
 	for _, b := range db.blocks {
 		if b.OverlapsClosedInterval(mint, maxt) {
-			g.Go(func(b *Block) func() error {
+			// Copy the matchers as PostingsForMatchers sorts the slice in place.
+			// See https://github.com/prometheus/prometheus/issues/14723
+			g.Go(func(b *Block, ms []*labels.Matcher) func() error {
 				return func() error { return b.Delete(ctx, mint, maxt, ms...) }
-			}(b))
+			}(b, slices.Clone(ms)))
 		}
 	}
 	if db.head.OverlapsClosedInterval(mint, maxt) {
+		ms := slices.Clone(ms)
 		g.Go(func() error {
 			return db.head.Delete(ctx, mint, maxt, ms...)
 		})

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -591,6 +591,35 @@ func TestDeleteSimple(t *testing.T) {
 	}
 }
 
+// TestDBDeleteConcurrentMatchers ensures that DB.Delete does not alter the passed
+// matchers when deleting from several blocks and the head concurrently.
+// PostingsForMatchers sorts the matchers in place, so sharing the slice between
+// goroutines is a data race. See https://github.com/prometheus/prometheus/issues/14723
+func TestDBDeleteConcurrentMatchers(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	app := db.Appender(ctx)
+	_, err := app.Append(0, labels.FromStrings("__name__", "metric", "job", "a"), 0, 1)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	for range 2 {
+		createBlock(t, db.Dir(), genSeries(1, 1, 0, 10))
+	}
+	require.NoError(t, db.reloadBlocks())
+
+	// Subtracting matcher first, as the parser emits it for metric{job!="x"}.
+	originalMatchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchNotEqual, "job", "x"),
+		labels.MustNewMatcher(labels.MatchEqual, "__name__", "metric"),
+	}
+	matchers := append([]*labels.Matcher{}, originalMatchers...)
+
+	require.NoError(t, db.Delete(ctx, 0, 10, matchers...))
+	require.Equal(t, originalMatchers, matchers)
+}
+
 func TestAmendHistogramDatapointCausesError(t *testing.T) {
 	db := newTestDB(t)
 


### PR DESCRIPTION
`PostingsForMatchers` sorts the matchers slice in place (`tsdb/querier.go`, "Sort matchers to have the intersecting matchers first"). `DB.Delete` passed the same `ms` slice to a goroutine per overlapping block and to the head, so concurrent sorts raced on the shared slice. A goroutine reading the slice during another goroutine's swap could observe a matcher twice and miss another one, e.g. lose `__name__` for `metric{job!="x"}`, and write tombstones for the wrong series.

The parser appends `__name__` last, so any `delete_series` call with a subtracting matcher (`!=`, `!~`, `=~".*"`) and a range covering two or more blocks hits the sort swap in every goroutine.

This copies the slice per goroutine, the same way `storage/merge.go` already does for #14723.

The added test fails deterministically without the fix (matchers reordered) and reports a data race under `-race`.

```release-notes
[BUGFIX] TSDB: Fix data race in DB.Delete when deleting series across multiple blocks.
```
